### PR TITLE
#18: Treasure select should disable self after use

### DIFF
--- a/source/buttons/viewcollectartifact.js
+++ b/source/buttons/viewcollectartifact.js
@@ -3,6 +3,7 @@ const { ButtonWrapper } = require('../classes');
 const { getPlayer } = require('../orcustrators/playerOrcustrator');
 const { getAdventure } = require('../orcustrators/adventureOrcustrator');
 const { getArtifact } = require('../artifacts/_artifactDictionary');
+const { EMPTY_SELECT_OPTION_SET } = require('../constants');
 
 const mainId = "viewcollectartifact";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -46,10 +47,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						new StringSelectMenuBuilder()
 							.setCustomId("collectartifact")
 							.setPlaceholder("Select an artifact...")
-							.addOptions([{
-								label: "If the menu is stuck, switch channels and come back.",
-								value: "placeholder"
-							}])
+							.addOptions(EMPTY_SELECT_OPTION_SET)
 							.setDisabled(true)
 					)],
 					ephemeral: true

--- a/source/constants.js
+++ b/source/constants.js
@@ -27,4 +27,5 @@ module.exports = {
 
 	// Game Values
 	MAX_DELVER_COUNT: Math.floor(module.exports.MAX_SELECT_OPTIONS / 3),
+	EMPTY_SELECT_OPTION_SET: [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players use the same select at the same time.", value: "empty" }]
 };

--- a/source/rooms/merchant-gear.js
+++ b/source/rooms/merchant-gear.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { buildGearDescription, getGearProperty } = require("../gear/_gearDictionary");
 const { generateMerchantScoutingRow } = require("../util/messageComponentUtil");
 
@@ -14,7 +14,6 @@ module.exports = new RoomTemplate("Gear Merchant",
 		new ResourceTemplate("1", "always", "gear").setTier("Rare").setUIGroup(uiGroups[1])
 	]
 ).setBuildUI(function (adventure) {
-	const soldOutOptions = [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to buy the last item at the same time.", value: "placeholder" }];
 	const mixedGearOptions = [];
 	const rareGearOptions = [];
 
@@ -51,13 +50,13 @@ module.exports = new RoomTemplate("Gear Merchant",
 		new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[0]}`)
 				.setPlaceholder(hasMixedGearOptions ? "Check a piece of gear..." : "SOLD OUT")
-				.setOptions(hasMixedGearOptions ? mixedGearOptions : soldOutOptions)
+				.setOptions(hasMixedGearOptions ? mixedGearOptions : EMPTY_SELECT_OPTION_SET)
 				.setDisabled(!hasMixedGearOptions)
 		),
 		new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[1]}`)
 				.setPlaceholder(hasRareGearOptions ? "Check a rare piece of gear..." : "SOLD OUT")
-				.setOptions(hasRareGearOptions ? rareGearOptions : soldOutOptions)
+				.setOptions(hasRareGearOptions ? rareGearOptions : EMPTY_SELECT_OPTION_SET)
 				.setDisabled(!hasRareGearOptions)
 		),
 		generateMerchantScoutingRow(adventure)

--- a/source/rooms/merchant-item.js
+++ b/source/rooms/merchant-item.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { getGearProperty, buildGearDescription } = require("../gear/_gearDictionary");
 const { getItem } = require("../items/_itemDictionary");
 const { generateMerchantScoutingRow } = require("../util/messageComponentUtil");
@@ -15,7 +15,6 @@ module.exports = new RoomTemplate("Item Merchant",
 		new ResourceTemplate("n", "always", "item").setUIGroup(uiGroups[1])
 	]
 ).setBuildUI(function (adventure) {
-	const soldOutOptions = [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to buy the last item at the same time.", value: "placeholder" }];
 	const gearOptions = [];
 	const itemOptions = [];
 
@@ -54,13 +53,13 @@ module.exports = new RoomTemplate("Item Merchant",
 		new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[0]}`)
 				.setPlaceholder(hasGearOptions ? `Check a piece of gear...` : "SOLD OUT")
-				.setOptions(hasGearOptions ? gearOptions : soldOutOptions)
+				.setOptions(hasGearOptions ? gearOptions : EMPTY_SELECT_OPTION_SET)
 				.setDisabled(!hasGearOptions)
 		),
 		new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[1]}`)
 				.setPlaceholder(hasItemOptions ? "Check an item..." : "SOLD OUT")
-				.setOptions(hasItemOptions ? itemOptions : soldOutOptions)
+				.setOptions(hasItemOptions ? itemOptions : EMPTY_SELECT_OPTION_SET)
 				.setDisabled(!hasItemOptions)
 		),
 		generateMerchantScoutingRow(adventure)

--- a/source/rooms/merchant-overpriced.js
+++ b/source/rooms/merchant-overpriced.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { buildGearDescription, getGearProperty } = require("../gear/_gearDictionary");
 const { generateMerchantScoutingRow } = require("../util/messageComponentUtil");
 
@@ -14,7 +14,6 @@ module.exports = new RoomTemplate("Overpriced Merchant",
 		new ResourceTemplate("2", "always", "gear").setTier("Rare").setCostMultiplier(1.5).setUIGroup(uiGroups[1])
 	]
 ).setBuildUI(function (adventure) {
-	const soldOutOptions = [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to buy the last item at the same time.", value: "placeholder" }];
 	const mixedGearOptions = [];
 	const rareGearOptions = [];
 
@@ -51,13 +50,13 @@ module.exports = new RoomTemplate("Overpriced Merchant",
 		new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[0]}`)
 				.setPlaceholder(hasMixedGearOptions ? "Check a piece of gear..." : "SOLD OUT")
-				.setOptions(hasMixedGearOptions ? mixedGearOptions : soldOutOptions)
+				.setOptions(hasMixedGearOptions ? mixedGearOptions : EMPTY_SELECT_OPTION_SET)
 				.setDisabled(!hasMixedGearOptions)
 		),
 		new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[1]}`)
 				.setPlaceholder(hasRareGearOptions ? "Check a rare piece of gear..." : "SOLD OUT")
-				.setOptions(hasRareGearOptions ? rareGearOptions : soldOutOptions)
+				.setOptions(hasRareGearOptions ? rareGearOptions : EMPTY_SELECT_OPTION_SET)
 				.setDisabled(!hasRareGearOptions)
 		),
 		generateMerchantScoutingRow(adventure)

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -3,7 +3,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 const { getArtifact } = require("../artifacts/_artifactDictionary");
 const { buildGearDescription } = require("../gear/_gearDictionary");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 	"@{adventure}",
@@ -14,28 +14,38 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 		new ResourceTemplate("2", "always", "gear").setTier("?").setCostMultiplier(0)
 	]
 ).setBuildUI(function (adventure) {
-	const options = [];
-	for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
-		if (visibility === "always" && count > 0) {
-			const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
+	if (adventure.room.resources.roomAction.count > 0) {
+		const options = [];
+		for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
+			if (visibility === "always" && count > 0) {
+				const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
 
-			option.label = `${name} x ${count}`;
-			switch (resourceType) {
-				case "gear":
-					option.description = buildGearDescription(name, false);
-					break;
-				case "artifact":
-					option.description = getArtifact(name).dynamicDescription(count);
-					break;
+				option.label = `${name} x ${count}`;
+				switch (resourceType) {
+					case "gear":
+						option.description = buildGearDescription(name, false);
+						break;
+					case "artifact":
+						option.description = getArtifact(name).dynamicDescription(count);
+						break;
+				}
+				options.push(option)
 			}
-			options.push(option)
 		}
+		const hasOptions = options.length > 0;
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
+				.setOptions(hasOptions ? options : EMPTY_SELECT_OPTION_SET)
+				.setDisabled(!hasOptions)
+		)];
+	} else {
+		const pickedResource = Object.values(adventure.room.resources).find(resource => resource.count === 0 && resource.name !== "roomAction");
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(`Picked: ${pickedResource.name}`)
+				.setOptions(EMPTY_SELECT_OPTION_SET)
+				.setDisabled(true)
+		)]
 	}
-	const hasOptions = options.length > 0;
-	return [new ActionRowBuilder().addComponents(
-		new StringSelectMenuBuilder().setCustomId("treasure")
-			.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
-			.setOptions(hasOptions ? options : [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to take the last thing at the same time.", value: "placeholder" }])
-			.setDisabled(!hasOptions)
-	)];
 });

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { buildGearDescription } = require("../gear/_gearDictionary");
 const { getItem } = require("../items/_itemDictionary");
@@ -15,28 +15,38 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 		new ResourceTemplate("2", "always", "item").setCostMultiplier(0)
 	]
 ).setBuildUI(function (adventure) {
-	const options = [];
-	for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
-		if (visibility === "always" && count > 0) {
-			const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
+	if (adventure.room.resources.roomAction.count > 0) {
+		const options = [];
+		for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
+			if (visibility === "always" && count > 0) {
+				const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
 
-			option.label = `${name} x ${count}`;
-			switch (resourceType) {
-				case "gear":
-					option.description = buildGearDescription(name, false);
-					break;
-				case "item":
-					option.description = getItem(name).description;
-					break;
+				option.label = `${name} x ${count}`;
+				switch (resourceType) {
+					case "gear":
+						option.description = buildGearDescription(name, false);
+						break;
+					case "item":
+						option.description = getItem(name).description;
+						break;
+				}
+				options.push(option)
 			}
-			options.push(option)
 		}
+		const hasOptions = options.length > 0;
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
+				.setOptions(hasOptions ? options : EMPTY_SELECT_OPTION_SET)
+				.setDisabled(!hasOptions)
+		)];
+	} else {
+		const pickedResource = Object.values(adventure.room.resources).find(resource => resource.count === 0 && resource.name !== "roomAction");
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(`Picked: ${pickedResource.name}`)
+				.setOptions(EMPTY_SELECT_OPTION_SET)
+				.setDisabled(true)
+		)]
 	}
-	const hasOptions = options.length > 0;
-	return [new ActionRowBuilder().addComponents(
-		new StringSelectMenuBuilder().setCustomId("treasure")
-			.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
-			.setOptions(hasOptions ? options : [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to take the last thing at the same time.", value: "placeholder" }])
-			.setDisabled(!hasOptions)
-	)];
 });

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { buildGearDescription } = require("../gear/_gearDictionary");
 
@@ -14,28 +14,38 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 		new ResourceTemplate("2", "always", "gear").setTier("?").setCostMultiplier(0)
 	]
 ).setBuildUI(function (adventure) {
-	const options = [];
-	for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
-		if (visibility === "always" && count > 0) {
-			const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
+	if (adventure.room.resources.roomAction.count > 0) {
+		const options = [];
+		for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
+			if (visibility === "always" && count > 0) {
+				const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
 
-			if (name === "gold") {
-				option.label = `${count} Gold`;
-			} else {
-				option.label = `${name} x ${count}`;
-			}
+				if (name === "gold") {
+					option.label = `${count} Gold`;
+				} else {
+					option.label = `${name} x ${count}`;
+				}
 
-			if (resourceType === "gear") {
-				option.description = buildGearDescription(name, false);
+				if (resourceType === "gear") {
+					option.description = buildGearDescription(name, false);
+				}
+				options.push(option)
 			}
-			options.push(option)
 		}
+		const hasOptions = options.length > 0;
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
+				.setOptions(hasOptions ? options : EMPTY_SELECT_OPTION_SET)
+				.setDisabled(!hasOptions)
+		)];
+	} else {
+		const pickedResource = Object.values(adventure.room.resources).find(resource => resource.count === 0 && resource.name !== "roomAction");
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(`Picked: ${pickedResource.name}`)
+				.setOptions(EMPTY_SELECT_OPTION_SET)
+				.setDisabled(true)
+		)]
 	}
-	const hasOptions = options.length > 0;
-	return [new ActionRowBuilder().addComponents(
-		new StringSelectMenuBuilder().setCustomId("treasure")
-			.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
-			.setOptions(hasOptions ? options : [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to take the last thing at the same time.", value: "placeholder" }])
-			.setDisabled(!hasOptions)
-	)];
 });

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { getItem } = require("../items/_itemDictionary");
 
@@ -14,28 +14,38 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 		new ResourceTemplate("2", "always", "item").setCostMultiplier(0)
 	]
 ).setBuildUI(function (adventure) {
-	const options = [];
-	for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
-		if (visibility === "always" && count > 0) {
-			const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
+	if (adventure.room.resources.roomAction.count > 0) {
+		const options = [];
+		for (const { name, resourceType, count, visibility } of Object.values(adventure.room.resources)) {
+			if (visibility === "always" && count > 0) {
+				const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
 
-			if (name === "gold") {
-				option.label = `${count} Gold`;
-			} else {
-				option.label = `${name} x ${count}`;
-			}
+				if (name === "gold") {
+					option.label = `${count} Gold`;
+				} else {
+					option.label = `${name} x ${count}`;
+				}
 
-			if (resourceType === "item") {
-				option.description = getItem(name).description;
+				if (resourceType === "item") {
+					option.description = getItem(name).description;
+				}
+				options.push(option)
 			}
-			options.push(option)
 		}
+		const hasOptions = options.length > 0;
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
+				.setOptions(hasOptions ? options : EMPTY_SELECT_OPTION_SET)
+				.setDisabled(!hasOptions)
+		)];
+	} else {
+		const pickedResource = Object.values(adventure.room.resources).find(resource => resource.count === 0 && resource.name !== "roomAction");
+		return [new ActionRowBuilder().addComponents(
+			new StringSelectMenuBuilder().setCustomId("treasure")
+				.setPlaceholder(`Picked: ${pickedResource.name}`)
+				.setOptions(EMPTY_SELECT_OPTION_SET)
+				.setDisabled(true)
+		)]
 	}
-	const hasOptions = options.length > 0;
-	return [new ActionRowBuilder().addComponents(
-		new StringSelectMenuBuilder().setCustomId("treasure")
-			.setPlaceholder(hasOptions ? "Pick 1 treasure to take..." : "No treasure")
-			.setOptions(hasOptions ? options : [{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to take the last thing at the same time.", value: "placeholder" }])
-			.setDisabled(!hasOptions)
-	)];
 });

--- a/source/selects/artifactdupe.js
+++ b/source/selects/artifactdupe.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
 const { SelectWrapper } = require('../classes');
-const { ZERO_WIDTH_WHITESPACE } = require('../constants');
+const { ZERO_WIDTH_WHITESPACE, EMPTY_SELECT_OPTION_SET } = require('../constants');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { updateRoomHeader } = require('../util/embedUtil');
 const { consumeRoomActions } = require('../util/messageComponentUtil');
@@ -25,7 +25,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 				new StringSelectMenuBuilder().setCustomId("artifactdupe")
 					.setPlaceholder(`✔️ Duplicated ${artifactName}`)
 					.setDisabled(true)
-					.setOptions([{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to duplicate an artifact at the same time.", value: "placeholder" }])
+					.setOptions(EMPTY_SELECT_OPTION_SET)
 			))
 			interaction.update({ embeds, components });
 			setAdventure(adventure);

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -36,7 +36,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					break;
 				case "artifact":
 					adventure.gainArtifact(name, count);
-					adventure.room.resources[name] = 0;
+					adventure.room.resources[name].count = 0;
 					result = {
 						content: `The party acquires ${name} x ${count}.`
 					}

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, EmbedBuilder, StringSelectMenuBuilder } = require("discord.js");
 
 const { Adventure } = require("../classes");
-const { SAFE_DELIMITER } = require("../constants");
+const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { getArtifact } = require("../artifacts/_artifactDictionary");
 const { buildGearDescription } = require("../gear/_gearDictionary");
@@ -105,7 +105,7 @@ function generateLootRow(adventure) {
 		return new ActionRowBuilder().addComponents(
 			new StringSelectMenuBuilder().setCustomId("loot")
 				.setPlaceholder("No loot")
-				.setOptions([{ label: "If the menu is stuck, switch channels and come back.", description: "This usually happens when two players try to take the last thing at the same time.", value: "placeholder" }])
+				.setOptions(EMPTY_SELECT_OPTION_SET)
 				.setDisabled(true)
 		)
 	}


### PR DESCRIPTION
Summary
-------
- treasure select disables self after use and records pick
- fixed bug where taking a treasure artifact was overwriting the artifact resource
- created constant for empty select option set

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested treasure select in treasure room

Issue
-----
Closes #18