### PR TITLE
#13: allow Event rooms to roll other room categories

### DIFF
--- a/source/classes/LabyrinthTemplate.js
+++ b/source/classes/LabyrinthTemplate.js
@@ -8,7 +8,7 @@ class LabyrinthTemplate {
 	 * @param {number[]} bossRoomDepthsInput
 	 * @param {Record<"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped", string[]} itemMap
 	 * @param {Record<"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped", Record<"Cursed" | "Common" | "Rare", string[]>>} gearMap
-	 * @param {Record<"Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Forge" | "Artifact Guardian" | "Treasure" | "Empty", (string | "Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Forge" | "Artifact Guardian" | "Treasure" | "Empty")[]>} roomMap if a room category is rolled, it rolls again on that category
+	 * @param {Record<"Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Forge" | "Artifact Guardian" | "Treasure" | "Empty", string[]>} roomMap if a room category is rolled, it rolls again on that category
 	 */
 	constructor(nameInput, elementInput, maxDepthInput, bossRoomDepthsInput, itemMap, gearMap, roomMap) {
 		if (!nameInput) throw new BuildError("Falsy nameInput");

--- a/source/classes/LabyrinthTemplate.js
+++ b/source/classes/LabyrinthTemplate.js
@@ -8,7 +8,7 @@ class LabyrinthTemplate {
 	 * @param {number[]} bossRoomDepthsInput
 	 * @param {Record<"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped", string[]} itemMap
 	 * @param {Record<"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped", Record<"Cursed" | "Common" | "Rare", string[]>>} gearMap
-	 * @param {Record<"Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Forge" | "Artifact Guardian" | "Treasure" | "Empty" |, string[]>} roomMap
+	 * @param {Record<"Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Forge" | "Artifact Guardian" | "Treasure" | "Empty", (string | "Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Forge" | "Artifact Guardian" | "Treasure" | "Empty")[]>} roomMap if a room category is rolled, it rolls again on that category
 	 */
 	constructor(nameInput, elementInput, maxDepthInput, bossRoomDepthsInput, itemMap, gearMap, roomMap) {
 		if (!nameInput) throw new BuildError("Falsy nameInput");

--- a/source/labyrinths/_labyrinthDictionary.js
+++ b/source/labyrinths/_labyrinthDictionary.js
@@ -1,7 +1,7 @@
 const { Adventure, LabyrinthTemplate, RoomTemplate } = require("../classes");
 const { gearExists } = require("../gear/_gearDictionary.js");
 const { itemExists } = require("../items/_itemDictionary.js");
-const { getRoom } = require("../rooms/_roomDictionary");
+const { getRoom, ROOM_CATEGORIES } = require("../rooms/_roomDictionary");
 
 /** @type {Record<string, LabyrinthTemplate>} */
 const LABYRINTHS = {};
@@ -31,7 +31,7 @@ for (const file of [
 
 	for (const tag in labyrinth.availableRooms) {
 		for (const roomTitle of labyrinth.availableRooms[tag]) {
-			if (!getRoom(roomTitle)) {
+			if (!(ROOM_CATEGORIES.includes(roomTitle) || getRoom(roomTitle))) {
 				console.error(`Unregistered room title in ${labyrinth.name}: ${roomTitle}`);
 			}
 		}
@@ -117,7 +117,12 @@ function rollRoom(type, adventure) {
 		return LABYRINTHS["Debug Dungeon"].availableRooms["Empty"][0];
 	}
 	const roomPool = LABYRINTHS[adventure.labyrinth].availableRooms[type];
-	return getRoom(roomPool[adventure.generateRandomNumber(roomPool.length, "general")]);
+	const roomName = roomPool[adventure.generateRandomNumber(roomPool.length, "general")];
+	if (ROOM_CATEGORIES.includes(roomName)) {
+		return rollRoom(roomName, adventure);
+	} else {
+		return getRoom(roomName);
+	}
 }
 
 module.exports = {

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -191,10 +191,10 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 		}
 	},
 	{
-		"Event": ["Twin Pedestals", "Elemental Research", "Free Gold?", "Health Redistribution", "The Score Beggar", "Repair Kit, just hanging out", "Abandoned Forge", "Gear Merchant", "Item Merchant", "Overpriced Merchant", "Rest Site", "Treasure! Artifact or Gear?"],
+		"Event": ["Twin Pedestals", "Elemental Research", "Free Gold?", "Health Redistribution", "The Score Beggar", "Repair Kit, just hanging out", "Forge", "Merchant", "Rest Site", "Treasure"],
 		"Battle": ["Hawk Fight", "Frog Fight", "Mechabee Fight", "Slime Fight", "Tortoise Fight"],
 		"Merchant": ["Gear Merchant", "Item Merchant", "Overpriced Merchant"],
-		"Rest Site": ["Rest Site"],
+		"Rest Site": ["Rest Site: Mysterious Challenger"],
 		"Final Battle": ["A Northern Laboratory", "Hall of Mirrors", "The Hexagon"],
 		"Forge": ["Abandoned Forge"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],

--- a/source/rooms/_roomDictionary.js
+++ b/source/rooms/_roomDictionary.js
@@ -46,5 +46,6 @@ function getRoom(roomTitle) {
 }
 
 module.exports = {
-	getRoom
+	getRoom,
+	ROOM_CATEGORIES: ["Event", "Battle", "Merchant", "Rest Site", "Final Battle", "Forge", "Artifact Guardian", "Treasure", "Empty"]
 };

--- a/source/rooms/restsite-basic.js
+++ b/source/rooms/restsite-basic.js
@@ -2,9 +2,9 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
 
-module.exports = new RoomTemplate("Rest Site",
+module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 	"@{adventure}",
-	"The room contains a rest site... and a mysterious challenger hanging out in the corner.",
+	"The room contains a campfire... and a mysterious challenger hanging out in the corner.",
 	[
 		new ResourceTemplate("n", "internal", "roomAction"),
 		new ResourceTemplate("2", "internal", "challenge")


### PR DESCRIPTION
Summary
-------
- allow categories within room maps (which are then rolled) to reduce design complexity in room maps

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] room category successfully parses to a room

Issue
-----
Closes #13