### PR TITLE
#52: merchant bugfixes

### DIFF
--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -34,7 +34,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				}
 			})
 
-			interaction.reply({ content: `The adventure has begun (and closed to new delvers joining)! You can use \`/delver-stats\`, or \`/party-stats\` to check adventure status.`, fetchReply: true }).then(message => {
+			interaction.reply({ content: `The adventure has begun (and closed to new delvers joining)! You can use the \`/adventure\` commands to check adventure status.`, fetchReply: true }).then(message => {
 				message.pin();
 				adventure.state = "ongoing";
 				adventure.messageIds.utility = message.id;

--- a/source/classes/RoomTemplate.js
+++ b/source/classes/RoomTemplate.js
@@ -55,9 +55,9 @@ class ResourceTemplate {
 		this.count = countExpression;
 		this.visibility = visibilityInput;
 		if (visibilityInput === "loot") {
-			this.costMultiplier = 0;
+			this.costExpression = "0";
 		} else {
-			this.costMultiplier = 1;
+			this.costExpression = "n";
 		}
 		this.resourceType = resourceTypeInput;
 	}
@@ -72,9 +72,9 @@ class ResourceTemplate {
 		return this;
 	}
 
-	/** @param {number} costMultiplierInput */
-	setCostMultiplier(costMultiplierInput) {
-		this.costMultiplier = costMultiplierInput;
+	/** @param {string} costExpressionInput */
+	setCostExpression(costExpressionInput) {
+		this.costExpression = costExpressionInput;
 		return this;
 	}
 

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -172,7 +172,7 @@ function nextRoom(roomType, thread) {
 	}
 
 	// Initialize Resources
-	for (const { resourceType, count: unparsedCount, tier: unparsedTier, visibility, cost: unparsedCost, uiGroup } of roomTemplate.resourceList) {
+	for (const { resourceType, count: unparsedCount, tier: unparsedTier, visibility, costExpression: unparsedCostExpression, uiGroup } of roomTemplate.resourceList) {
 		const count = Math.ceil(parseExpression(unparsedCount, adventure.delvers.length));
 		switch (resourceType) {
 			case "challenge":
@@ -187,7 +187,7 @@ function nextRoom(roomType, thread) {
 						tier = rollGearTier(adventure);
 					}
 					const gearName = rollGear(tier, adventure);
-					adventure.addResource(gearName, resourceType, visibility, 1, uiGroup, Math.ceil(parseExpression(unparsedCost ?? "0", getGearProperty(gearName, "cost", resourceType))));
+					adventure.addResource(gearName, resourceType, visibility, 1, uiGroup, Math.ceil(parseExpression(unparsedCostExpression ?? "0", getGearProperty(gearName, "cost", resourceType))));
 				}
 				break;
 			case "artifact":
@@ -196,7 +196,7 @@ function nextRoom(roomType, thread) {
 				break;
 			case "item":
 				const item = rollItem(adventure);
-				adventure.addResource(item, resourceType, visibility, count, uiGroup, Math.ceil(parseExpression(unparsedCost, getItem(item).cost)));
+				adventure.addResource(item, resourceType, visibility, count, uiGroup, Math.ceil(parseExpression(unparsedCostExpression, getItem(item).cost)));
 				break;
 			case "gold":
 				// Randomize loot gold

--- a/source/rooms/event-freerepairkit.js
+++ b/source/rooms/event-freerepairkit.js
@@ -5,7 +5,7 @@ module.exports = new RoomTemplate("Repair Kit, just hanging out",
 	"Earth",
 	"There's a Repair Kit hanging in the middle of the room tied to the ceiling by a rope.",
 	[
-		new ResourceTemplate("1", "internal", "Repair Kit").setCostMultiplier(0)
+		new ResourceTemplate("1", "internal", "Repair Kit").setCostExpression("0")
 	]
 ).setBuildUI(
 	function (adventure) {

--- a/source/rooms/merchant-item.js
+++ b/source/rooms/merchant-item.js
@@ -22,25 +22,25 @@ module.exports = new RoomTemplate("Item Merchant",
 		if (adventure.room.resources[name].count > 0) {
 			switch (uiGroup) {
 				case uiGroups[0]: // gear
-					const cost = adventure.room.resources[gearName].cost;
+					const cost = adventure.room.resources[name].cost;
 					/** @type {number} */
-					const maxDurability = getGearProperty(gearName, "maxDurability");
-					let description = buildGearDescription(gearName, false);
+					const maxDurability = getGearProperty(name, "maxDurability");
+					let description = buildGearDescription(name, false);
 					if (description.length > 100) {
 						description = description.slice(0, 99) + "…"; // Single character elipsis
 					}
 					gearOptions.push({
-						label: `${cost}g: ${gearName} (${maxDurability} uses)`,
+						label: `${cost}g: ${name} (${maxDurability} uses)`,
 						description,
-						value: `${gearName}${SAFE_DELIMITER}${i}`
+						value: `${name}${SAFE_DELIMITER}${i}`
 					});
 					break;
 				case uiGroups[1]: // items
-					const item = getItem(itemName);
+					const item = getItem(name);
 					itemOptions.push({
-						label: `${item.cost}g: ${itemName}`,
+						label: `${item.cost}g: ${name}`,
 						description: item.description,
-						value: `${itemName}${SAFE_DELIMITER}${i}`
+						value: `${name}${SAFE_DELIMITER}${i}`
 					})
 					break;
 			}

--- a/source/rooms/merchant-overpriced.js
+++ b/source/rooms/merchant-overpriced.js
@@ -10,8 +10,8 @@ module.exports = new RoomTemplate("Overpriced Merchant",
 	"@{adventure}",
 	"A masked figure sits in front of a packed rack of weapons and other gear. \"Best selction around! Looking for something particular?\"",
 	[
-		new ResourceTemplate("2*n", "always", "gear").setTier("?").setCostMultiplier(1.5).setUIGroup(uiGroups[0]),
-		new ResourceTemplate("2", "always", "gear").setTier("Rare").setCostMultiplier(1.5).setUIGroup(uiGroups[1])
+		new ResourceTemplate("2*n", "always", "gear").setTier("?").setCostExpression("1.5*n").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("2", "always", "gear").setTier("Rare").setCostExpression("1.5*n").setUIGroup(uiGroups[1])
 	]
 ).setBuildUI(function (adventure) {
 	const mixedGearOptions = [];

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -10,8 +10,8 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("1", "always", "artifact").setCostMultiplier(0),
-		new ResourceTemplate("2", "always", "gear").setTier("?").setCostMultiplier(0)
+		new ResourceTemplate("1", "always", "artifact").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "gear").setTier("?").setCostExpression("0")
 	]
 ).setBuildUI(function (adventure) {
 	if (adventure.room.resources.roomAction.count > 0) {

--- a/source/rooms/treasure-artifactvsgold.js
+++ b/source/rooms/treasure-artifactvsgold.js
@@ -10,8 +10,8 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gold' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("1", "always", "artifact").setCostMultiplier(0),
-		new ResourceTemplate("250*n", "always", "gold").setCostMultiplier(0)
+		new ResourceTemplate("1", "always", "artifact").setCostExpression("0"),
+		new ResourceTemplate("250*n", "always", "gold").setCostExpression("0")
 	]
 ).setBuildUI(function (adventure) {
 	if (adventure.room.resources.roomAction.count > 0) {

--- a/source/rooms/treasure-artifactvsitems.js
+++ b/source/rooms/treasure-artifactvsitems.js
@@ -11,8 +11,8 @@ module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("1", "always", "artifact").setCostMultiplier(0),
-		new ResourceTemplate("2", "always", "item").setCostMultiplier(0)
+		new ResourceTemplate("1", "always", "artifact").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "item").setCostExpression("0")
 	]
 ).setBuildUI(function (adventure) {
 	if (adventure.room.resources.roomAction.count > 0) {

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -11,8 +11,8 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gear' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("2", "always", "gear").setTier("?").setCostMultiplier(0),
-		new ResourceTemplate("2", "always", "item").setCostMultiplier(0)
+		new ResourceTemplate("2", "always", "gear").setTier("?").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "item").setCostExpression("0")
 	]
 ).setBuildUI(function (adventure) {
 	if (adventure.room.resources.roomAction.count > 0) {

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -10,8 +10,8 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("250*n", "always", "gold").setCostMultiplier(0),
-		new ResourceTemplate("2", "always", "gear").setTier("?").setCostMultiplier(0)
+		new ResourceTemplate("250*n", "always", "gold").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "gear").setTier("?").setCostExpression("0")
 	]
 ).setBuildUI(function (adventure) {
 	if (adventure.room.resources.roomAction.count > 0) {

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -10,8 +10,8 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("250*n", "always", "gold").setCostMultiplier(0),
-		new ResourceTemplate("2", "always", "item").setCostMultiplier(0)
+		new ResourceTemplate("250*n", "always", "gold").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "item").setCostExpression("0")
 	]
 ).setBuildUI(function (adventure) {
 	if (adventure.room.resources.roomAction.count > 0) {

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -80,9 +80,8 @@ function renderRoom(adventure, thread, descriptionOverride) {
 	if (adventure.depth <= getLabyrinthProperty(adventure.labyrinth, "maxDepth")) {
 		if (!Adventure.endStates.includes(adventure.state)) {
 			// Continue
-			const roomActionCount = adventure.room.resources.roomAction?.count;
 			if ("roomAction" in adventure.room.resources) {
-				roomEmbed.addFields({ name: "Room Actions", value: roomActionCount.toString() });
+				roomEmbed.addFields({ name: "Room Actions", value: adventure.room.resources.roomAction.count.toString() });
 			}
 
 			if (roomTemplate?.buildUI) {


### PR DESCRIPTION
Summary
-------
- fix merchant prices set to 0 by reverting change of costExpression to costMultiplier
- fix crashes in item merchant's buildUI
- update ready message from old command names
- simplify renderRoom

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] tested each merchant (item, gear, overpriced) directly

Issue
-----
Closes #52 