### PR TITLE
#54: fix crash in replacegear from merchant

### DIFF
--- a/source/buttons/replacegear.js
+++ b/source/buttons/replacegear.js
@@ -16,7 +16,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			interaction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
 				adventure.room.resources[name].count--;
 				adventure.gold -= cost;
-				if (Boolean(atTreasure)) {
+				if (atTreasure === "true") {
 					adventure.room.resources.roomAction.count--;
 				}
 				return roomMessage.edit(renderRoom(adventure, interaction.channel));


### PR DESCRIPTION
Summary
-------
- fix crash in replacegear from merchant

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] replacegear allows a delver to replace gear in their inventory

Issue
-----
Closes #54 