### PR TITLE
#58: fix crash in target predict of targetless moves

### DIFF
--- a/source/archetypes/assassin.js
+++ b/source/archetypes/assassin.js
@@ -12,7 +12,7 @@ module.exports = new ArchetypeTemplate("Assassin",
 			const resistances = getResistances(combatant.element);
 			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)} ${getEmoji(combatant.element)}`, value: `Critical Hit: ${combatant.crit ? "💥" : "🚫"}\nWeaknesses: ${weaknesses.map(weakness => getEmoji(weakness)).join(" ")}\nResistances: ${resistances.map(resistance => getEmoji(resistance)).join(" ")}` });
 		});
-		return [false, embed]
+		return embed.setTitle(`Assassin Predictions for Round ${adventure.room.round}`);
 	},
 	(combatant) => {
 		const weaknesses = getCombatantWeaknesses(combatant);

--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -11,7 +11,7 @@ module.exports = new ArchetypeTemplate("Chemist",
 			const modifiersText = modifiersToString(combatant, false, adventure);
 			embed.addFields({ name: combatant.getName(adventure.room.enemyIdMap), value: `${generateTextBar(combatant.hp, combatant.maxHP, 16)} ${combatant.hp}/${combatant.maxHP} HP${combatant.block ? `, ${combatant.block} Block` : ""}\n${modifiersText ? `${modifiersText}` : "No modifiers"}` });
 		})
-		return [false, embed];
+		return embed.setTitle(`Chemist Predictions for Round ${adventure.room.round}`);
 	},
 	(combatant) => {
 		return `HP: ${combatant.hp}/${combatant.maxHP}`;

--- a/source/archetypes/detective.js
+++ b/source/archetypes/detective.js
@@ -12,7 +12,7 @@ module.exports = new ArchetypeTemplate("Detective",
 			const resistances = getResistances(combatant.element);
 			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)} ${getEmoji(combatant.element)}`, value: `Critical Hit: ${combatant.crit ? "💥" : "🚫"}\nWeaknesses: ${weaknesses.map(weakness => getEmoji(weakness)).join(" ")}\nResistances: ${resistances.map(resistance => getEmoji(resistance)).join(" ")}` });
 		});
-		return [false, embed]
+		return embed.setTitle(`Detective Predictions for Round ${adventure.room.round}`);
 	},
 	(combatant) => {
 		const weaknesses = getCombatantWeaknesses(combatant);

--- a/source/archetypes/hemomancer.js
+++ b/source/archetypes/hemomancer.js
@@ -17,7 +17,7 @@ module.exports = new ArchetypeTemplate("Hemomancer",
 			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)}${isStunned ? " 💫" : ""}`, value: `Stagger: ${generateTextBar(staggerCount, combatant.poise, combatant.poise)}\nSpeed: ${combatant.getTotalSpeed()}` });
 		}
 		embed.setDescription("Combatants may act out of order if they have priority or they are tied in speed.");
-		return [true, embed];
+		return embed.setTitle(`Hemomancer Predictions for Round ${adventure.room.round + 1}`);
 	},
 	(combatant) => {
 		const staggerCount = combatant.getModifierStacks("Stagger");

--- a/source/archetypes/knight.js
+++ b/source/archetypes/knight.js
@@ -9,16 +9,22 @@ module.exports = new ArchetypeTemplate("Knight",
 			if (userReference.team === "enemy") {
 				const enemy = adventure.getCombatant(userReference);
 				if (enemy.hp > 0) {
-					const targetNames = targets.map(reference => adventure.getCombatant(reference).getName(adventure.room.enemyIdMap));
+					const targetNames = [];
+					targets.forEach(reference => {
+						const combatant = adventure.getCombatant(reference);
+						if (combatant) {
+							targetNames.push(combatant.getName(adventure.room.enemyIdMap));
+						}
+					});
 					if (name !== "@{clone}") {
-						embed.addFields({ name: enemy.getName(adventure.room.enemyIdMap), value: `Round ${adventure.room.round + 1}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}(Targets: ${targetNames.length ? targetNames.join(", ") : "???"})\nRound ${adventure.room.round + 2}: ${enemy.nextAction}` });
+						embed.addFields({ name: enemy.getName(adventure.room.enemyIdMap), value: `Round ${adventure.room.round + 1}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}(Targets: ${targetNames.length ? targetNames.join(", ") : "none"})\nRound ${adventure.room.round + 2}: ${enemy.nextAction}` });
 					} else {
 						embed.addFields({ name: enemy.getName(adventure.room.enemyIdMap), value: "Mirror Clones mimic your allies!" })
 					}
 				}
 			}
 		})
-		return [true, embed];
+		return embed.setTitle(`Knight Predictions for Round ${adventure.room.round + 1}`);
 	},
 	(combatant) => {
 		if (combatant.team === "delver") {

--- a/source/archetypes/legionnaire.js
+++ b/source/archetypes/legionnaire.js
@@ -9,16 +9,22 @@ module.exports = new ArchetypeTemplate("Legionnaire",
 			if (userReference.team === "enemy") {
 				const enemy = adventure.getCombatant(userReference);
 				if (enemy.hp > 0) {
-					const targetNames = targets.map(reference => adventure.getCombatant(reference).getName(adventure.room.enemyIdMap));
+					const targetNames = [];
+					targets.forEach(reference => {
+						const combatant = adventure.getCombatant(reference);
+						if (combatant) {
+							targetNames.push(combatant.getName(adventure.room.enemyIdMap));
+						}
+					});
 					if (name !== "@{clone}") {
-						embed.addFields({ name: enemy.getName(adventure.room.enemyIdMap), value: `Round ${adventure.room.round + 1}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}(Targets: ${targetNames.length ? targetNames.join(", ") : "???"})\nRound ${adventure.room.round + 2}: ${enemy.nextAction}` });
+						embed.addFields({ name: enemy.getName(adventure.room.enemyIdMap), value: `Round ${adventure.room.round + 1}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}(Targets: ${targetNames.length ? targetNames.join(", ") : "none"})\nRound ${adventure.room.round + 2}: ${enemy.nextAction}` });
 					} else {
 						embed.addFields({ name: enemy.getName(adventure.room.enemyIdMap), value: "Mirror Clones mimic your allies!" })
 					}
 				}
 			}
 		})
-		return [true, embed];
+		return embed.setTitle(`Legionnaire Predictions for Round ${adventure.room.round + 1}`);
 	},
 	(combatant) => {
 		if (combatant.team === "delver") {

--- a/source/archetypes/martialartist.js
+++ b/source/archetypes/martialartist.js
@@ -17,7 +17,7 @@ module.exports = new ArchetypeTemplate("Martial Artist",
 			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)}${isStunned ? " 💫" : ""}`, value: `Stagger: ${generateTextBar(staggerCount, combatant.poise, combatant.poise)}\nSpeed: ${combatant.getTotalSpeed()}` });
 		}
 		embed.setDescription("Combatants may act out of order if they have priority or they are tied in speed.");
-		return [true, embed];
+		return embed.setTitle(`Martial Artist Predictions for Round ${adventure.room.round + 1}`);
 	},
 	(combatant) => {
 		const staggerCount = combatant.getModifierStacks("Stagger");

--- a/source/archetypes/ritualist.js
+++ b/source/archetypes/ritualist.js
@@ -12,7 +12,7 @@ module.exports = new ArchetypeTemplate("Ritualist",
 			const modifiersText = modifiersToString(combatant, false, adventure);
 			embed.addFields({ name: combatant.getName(adventure.room.enemyIdMap), value: `${generateTextBar(combatant.hp, combatant.maxHP, 16)} ${combatant.hp}/${combatant.maxHP} HP${combatant.block ? `, ${combatant.block} Block` : ""}\n${modifiersText ? `${modifiersText}` : "No modifiers"}` });
 		})
-		return [false, embed];
+		return embed.setTitle(`Ritualist Predictions for Round ${adventure.room.round}`);
 	},
 	(combatant) => {
 		return `Has Debuffs: ${Object.keys(combatant.modifiers).some(modifier => isDebuff(modifier)) ? "✅" : "🚫"}`;

--- a/source/buttons/predict.js
+++ b/source/buttons/predict.js
@@ -29,15 +29,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}
 		}
 		const predictFunction = getArchetype(delver.archetype).predict;
-		const [infoForNextRound, embed] = predictFunction(new EmbedBuilder().setAuthor({ name: `Room #${adventure.depth} - Round ${adventure.room.round}` }).setColor(getColor(adventure.room.element)).setFooter(randomFooterTip()), adventure);
-		let title;
-		if (infoForNextRound) {
-			title = `Predictions for Round ${adventure.room.round + 1}`;
-		} else {
-			title = `State of Round ${adventure.room.round}`;
-		}
-		embed.setTitle(title);
-		interaction.reply({ embeds: [embed], ephemeral: true })
-			.catch(console.error);
+		interaction.reply({
+			embeds: [
+				predictFunction(new EmbedBuilder().setAuthor({ name: `Room #${adventure.depth} - Round ${adventure.room.round}` }).setColor(getColor(adventure.room.element)).setFooter(randomFooterTip()), adventure)
+			],
+			ephemeral: true
+		}).catch(console.error);
 	}
 );

--- a/source/classes/ArchetypeTemplate.js
+++ b/source/classes/ArchetypeTemplate.js
@@ -8,7 +8,7 @@ class ArchetypeTemplate {
 	 * @param {string} descriptionInput
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} elementLabel
 	 * @param {string[]} startingGearNames
-	 * @param {(embed: EmbedBuilder, adventure: Adventure ) => [isInfoForNextRound: boolean, embed: EmbedBuilder]} predictFunction
+	 * @param {(embed: EmbedBuilder, adventure: Adventure ) => EmbedBuilder} predictFunction
 	 * @param {(combatant) => string} miniPredictFunction
 	 */
 	constructor(nameInput, descriptionInput, elementLabel, startingGearNames, predictFunction, miniPredictFunction) {


### PR DESCRIPTION
Summary
-------
- fix crash in target predict of targetless moves
- improve predict titles

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Knight can predict Treasure Elemental using Escape without crash

Issue
-----
Closes #58