### PR TITLE
#51: scale enemy poise with party size

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Prophets of the Labyrinth Change Log
 ## Prophets of the Labyrinth Version 0.13.0:
 - Combined Barrier and Vigilance Charm
+- Some enemies's poise now scales with party size
 ## Prophets of the Labyrinth Version 0.12.0:
 - Reintroduced Light and Darkness elements
 - Reworked Martial Artist starting gear

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -2,6 +2,7 @@ const crypto = require("crypto");
 const { MAX_MESSAGE_ACTION_ROWS } = require("../constants.js");
 const { CombatantReference, Move } = require("./Move.js");
 const { Combatant, Delver } = require("./Combatant.js");
+const { parseExpression } = require("../util/textUtil.js");
 
 class Adventure {
 	/** NOTE: The setters in this class are require for a well formed entity. Currently procrastinating on refactoring /delve to fix that.
@@ -311,18 +312,21 @@ class Enemy extends Combatant {
 	 * @param {string} nameInput
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}" | "@{clone}"} elementEnum
 	 * @param {number} speedInput
-	 * @param {number} poiseInput
+	 * @param {number} poiseExpression
 	 * @param {number} critBonusInput
 	 * @param {string} firstActionName
 	 * @param {{[modifierName]: number}} startingModifiersShallowCopy
+	 * @param {number} delverCount
 	 */
-	constructor(nameInput, elementEnum, speedInput, poiseInput, critBonusInput, firstActionName, startingModifiersShallowCopy) {
+	constructor(nameInput, elementEnum, speedInput, poiseExpression, critBonusInput, firstActionName, startingModifiersShallowCopy, delverCount) {
 		super(nameInput, "enemy");
 		this.archetype = nameInput;
 		/** @type {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} */
 		this.element = elementEnum;
 		this.speed = speedInput;
-		this.poise = poiseInput;
+		if (poiseExpression && delverCount) { // allows parameterless class casting on load without crashing
+			this.poise = parseExpression(poiseExpression, delverCount);
+		}
 		this.critBonus = critBonusInput;
 		this.nextAction = firstActionName;
 		this.modifiers = startingModifiersShallowCopy;

--- a/source/classes/EnemyTemplate.js
+++ b/source/classes/EnemyTemplate.js
@@ -9,17 +9,17 @@ class EnemyTemplate {
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}" | "@{clone}"} elementEnum
 	 * @param {number} maxHPInput
 	 * @param {number} speedInput
-	 * @param {number} poiseInput number of Stagger to Stun
+	 * @param {string} poiseExpressionInput expression, where n = delver count, that parses to number of Stagger to Stun
 	 * @param {number} critBonusPercent multiplicative increase to base 1/4 crit chance
 	 * @param {string} firstActionName use "random" for random move in enemy's move pool
 	 * @param {boolean} isBoss sets enemy to not randomize HP and adds 15 critBonus
 	 */
-	constructor(nameInput, elementEnum, maxHPInput, speedInput, poiseInput, critBonusPercent, firstActionName, isBoss) {
+	constructor(nameInput, elementEnum, maxHPInput, speedInput, poiseExpressionInput, critBonusPercent, firstActionName, isBoss) {
 		if (!nameInput) throw new BuildError("Falsy nameInput");
 		if (!elementEnum) throw new BuildError("Falsy elementEnum");
 		if (!maxHPInput) throw new BuildError("Falsy maxHPInput");
 		if (!speedInput) throw new BuildError("Falsy speedInput");
-		if (!poiseInput) throw new BuildError("Falsy poiseInput");
+		if (!poiseExpressionInput) throw new BuildError("Falsy poiseExpression");
 		if (!isBoss && isBoss !== false) throw new BuildError("Nonfalse falsy isBoss");
 		const pendingCritBonus = critBonusPercent + (isBoss ? 15 : 0);
 		if (!pendingCritBonus && pendingCritBonus !== 0) throw new BuildError("Nonzero falsy critBonus");
@@ -29,7 +29,8 @@ class EnemyTemplate {
 		this.element = elementEnum;
 		this.maxHP = maxHPInput;
 		this.speed = speedInput;
-		this.poise = poiseInput;
+		/** @type {string} expression, where n = delver count */
+		this.poiseExpression = poiseExpressionInput;
 		this.critBonus = pendingCritBonus;
 		this.firstAction = firstActionName;
 		this.shouldRandomizeHP = !isBoss;

--- a/source/enemies/_enemy_blueprint.js
+++ b/source/enemies/_enemy_blueprint.js
@@ -4,7 +4,7 @@ module.exports = new EnemyTemplate("name",
 	"element",
 	300,
 	100,
-	3,
+	"3",
 	0,
 	"name",
 	false

--- a/source/enemies/bloodtailhawk.js
+++ b/source/enemies/bloodtailhawk.js
@@ -6,7 +6,7 @@ module.exports = new EnemyTemplate("Bloodtail Hawk",
 	"Wind",
 	200,
 	105,
-	1,
+	"1",
 	30,
 	"Rake",
 	false

--- a/source/enemies/clone.js
+++ b/source/enemies/clone.js
@@ -4,7 +4,7 @@ module.exports = new EnemyTemplate("@{clone}",
 	"@{clone}",
 	300,
 	100,
-	3,
+	"3",
 	0,
 	"clone", // this shouldn't get used, clones always copy delvers
 	true

--- a/source/enemies/elkemist.js
+++ b/source/enemies/elkemist.js
@@ -7,7 +7,7 @@ module.exports = new EnemyTemplate("Elkemist",
 	"Water",
 	2000,
 	100,
-	4,
+	"n*2",
 	0,
 	"random",
 	true

--- a/source/enemies/firearrowfrog.js
+++ b/source/enemies/firearrowfrog.js
@@ -15,7 +15,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 	"Fire",
 	250,
 	100,
-	2,
+	"2",
 	0,
 	"random",
 	false

--- a/source/enemies/geodetortoise.js
+++ b/source/enemies/geodetortoise.js
@@ -6,7 +6,7 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 	"Earth",
 	350,
 	85,
-	5,
+	"3+n*0.5",
 	0,
 	"random",
 	false

--- a/source/enemies/mechabee.js
+++ b/source/enemies/mechabee.js
@@ -17,7 +17,7 @@ module.exports = new EnemyTemplate("Mechabee",
 	"Darkness",
 	200,
 	100,
-	3,
+	"3",
 	0,
 	"Sting",
 	false

--- a/source/enemies/mechaqueen.js
+++ b/source/enemies/mechaqueen.js
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Mecha Queen",
 	"Darkness",
 	500,
 	100,
-	4,
+	"n+1",
 	0,
 	"a random protocol",
 	true

--- a/source/enemies/ooze.js
+++ b/source/enemies/ooze.js
@@ -6,7 +6,7 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 	"@{adventureOpposite}",
 	200,
 	90,
-	5,
+	"n+2",
 	0,
 	"Goop Spray",
 	false

--- a/source/enemies/royalslime.js
+++ b/source/enemies/royalslime.js
@@ -7,7 +7,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 	"@{adventure}",
 	600,
 	90,
-	5,
+	"n+2",
 	0,
 	"Element Shift",
 	true

--- a/source/enemies/slime.js
+++ b/source/enemies/slime.js
@@ -6,7 +6,7 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 	"@{adventure}",
 	200,
 	90,
-	5,
+	"n+2",
 	0,
 	"Tackle",
 	false

--- a/source/enemies/treasureelemental.js
+++ b/source/enemies/treasureelemental.js
@@ -17,7 +17,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 	"Earth",
 	99999,
 	100,
-	3,
+	"n*1.5",
 	0,
 	"Reinforcing Slam",
 	true

--- a/source/util/roomUtil.js
+++ b/source/util/roomUtil.js
@@ -9,7 +9,7 @@ const anyTagRegex = generateRuntimeTemplateStringRegExp(null);
  * @param {Adventure} adventure
  */
 function spawnEnemy(enemyTemplate, adventure) {
-	const enemy = new Enemy(enemyTemplate.name, enemyTemplate.element, enemyTemplate.speed, enemyTemplate.poise, enemyTemplate.critBonus, enemyTemplate.firstAction, { ...enemyTemplate.startingModifiers });
+	const enemy = new Enemy(enemyTemplate.name, enemyTemplate.element, enemyTemplate.speed, enemyTemplate.poiseExpression, enemyTemplate.critBonus, enemyTemplate.firstAction, { ...enemyTemplate.startingModifiers }, adventure.delvers.length);
 	let hpPercent = 85 + 15 * adventure.delvers.length;
 	if (enemyTemplate.shouldRandomizeHP) {
 		hpPercent += 10 * (2 - adventure.generateRandomNumber(5, "battle"));


### PR DESCRIPTION
Summary
-------
- enemy poise can now scale with party size

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] constant poise expression evaluates without crashing enemy spawning
- [x] enemy poise value loads from file without issue
- [x] non-constant poise expression evaluates without crashing enemy spawning

Issue
-----
Closes #51 