### PR TITLE
#17: rework Stagger

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 # Prophets of the Labyrinth Change Log
 ## Prophets of the Labyrinth Version 0.13.0:
 - Combined Barrier and Vigilance Charm
+- Doubled poise and added stagger, left per round fall-off and matching element stagger cure at 1
+- Combatant stagger can no longer be modified while the combatant is stunned
+- New Debuff: Frail - Deals damage when the bearer is Stunned
+- Iron Fist Stance crits now apply Frail to all enemies instead of granting the user Power Up
 - Some enemies's poise now scales with party size
 - Tweaked room rarities, largely to make Battles and Events more common
 ## Prophets of the Labyrinth Version 0.12.0:

--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -8,7 +8,7 @@ module.exports = new ArchetypeTemplate("Chemist",
 	["Sickle", "Potion Kit"],
 	(embed, adventure) => {
 		adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0).forEach(combatant => {
-			const modifiersText = modifiersToString(combatant, false, adventure);
+			const modifiersText = modifiersToString(combatant, adventure);
 			embed.addFields({ name: combatant.getName(adventure.room.enemyIdMap), value: `${generateTextBar(combatant.hp, combatant.maxHP, 16)} ${combatant.hp}/${combatant.maxHP} HP${combatant.block ? `, ${combatant.block} Block` : ""}\n${modifiersText ? `${modifiersText}` : "No modifiers"}` });
 		})
 		return embed.setTitle(`Chemist Predictions for Round ${adventure.room.round}`);

--- a/source/archetypes/hemomancer.js
+++ b/source/archetypes/hemomancer.js
@@ -12,15 +12,12 @@ module.exports = new ArchetypeTemplate("Hemomancer",
 				return second.getTotalSpeed() - first.getTotalSpeed();
 			});
 		for (const combatant of activeCombatants) {
-			const staggerCount = combatant.getModifierStacks("Stagger");
-			const isStunned = combatant.getModifierStacks("Stun") > 0;
-			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)}${isStunned ? " 💫" : ""}`, value: `Stagger: ${generateTextBar(staggerCount, combatant.poise, combatant.poise)}\nSpeed: ${combatant.getTotalSpeed()}` });
+			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)}${combatant.isStunned ? " 💫" : ""}`, value: `Stagger: ${generateTextBar(combatant.stagger, combatant.poise, combatant.poise)}\nSpeed: ${combatant.getTotalSpeed()}` });
 		}
 		embed.setDescription("Combatants may act out of order if they have priority or they are tied in speed.");
 		return embed.setTitle(`Hemomancer Predictions for Round ${adventure.room.round + 1}`);
 	},
 	(combatant) => {
-		const staggerCount = combatant.getModifierStacks("Stagger");
-		return `Stagger: ${generateTextBar(staggerCount, combatant.poise, combatant.poise)}`;
+		return `Stagger: ${generateTextBar(combatant.stagger, combatant.poise, combatant.poise)}`;
 	}
 );

--- a/source/archetypes/martialartist.js
+++ b/source/archetypes/martialartist.js
@@ -12,15 +12,12 @@ module.exports = new ArchetypeTemplate("Martial Artist",
 				return second.getTotalSpeed() - first.getTotalSpeed();
 			});
 		for (const combatant of activeCombatants) {
-			const staggerCount = combatant.getModifierStacks("Stagger");
-			const isStunned = combatant.getModifierStacks("Stun") > 0;
-			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)}${isStunned ? " 💫" : ""}`, value: `Stagger: ${generateTextBar(staggerCount, combatant.poise, combatant.poise)}\nSpeed: ${combatant.getTotalSpeed()}` });
+			embed.addFields({ name: `${combatant.getName(adventure.room.enemyIdMap)}${combatant.isStunned ? " 💫" : ""}`, value: `Stagger: ${generateTextBar(combatant.stagger, combatant.poise, combatant.poise)}\nSpeed: ${combatant.getTotalSpeed()}` });
 		}
 		embed.setDescription("Combatants may act out of order if they have priority or they are tied in speed.");
 		return embed.setTitle(`Martial Artist Predictions for Round ${adventure.room.round + 1}`);
 	},
 	(combatant) => {
-		const staggerCount = combatant.getModifierStacks("Stagger");
-		return `Stagger: ${generateTextBar(staggerCount, combatant.poise, combatant.poise)}`;
+		return `Stagger: ${generateTextBar(combatant.stagger, combatant.poise, combatant.poise)}`;
 	}
 );

--- a/source/archetypes/ritualist.js
+++ b/source/archetypes/ritualist.js
@@ -9,7 +9,7 @@ module.exports = new ArchetypeTemplate("Ritualist",
 	["Censer", "Corrosion"],
 	(embed, adventure) => {
 		adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0).forEach(combatant => {
-			const modifiersText = modifiersToString(combatant, false, adventure);
+			const modifiersText = modifiersToString(combatant, adventure);
 			embed.addFields({ name: combatant.getName(adventure.room.enemyIdMap), value: `${generateTextBar(combatant.hp, combatant.maxHP, 16)} ${combatant.hp}/${combatant.maxHP} HP${combatant.block ? `, ${combatant.block} Block` : ""}\n${modifiersText ? `${modifiersText}` : "No modifiers"}` });
 		})
 		return embed.setTitle(`Ritualist Predictions for Round ${adventure.room.round}`);

--- a/source/buttons/modifier.js
+++ b/source/buttons/modifier.js
@@ -42,7 +42,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					new EmbedBuilder().setColor(Colors.LightGrey)
 						.setAuthor(randomAuthorTip())
 						.setTitle("All Modifiers")
-						.setDescription(modifiersToString(delver, true, adventure))
+						.setDescription(modifiersToString(delver, adventure))
 				],
 				ephemeral: true
 			});

--- a/source/buttons/readyitem.js
+++ b/source/buttons/readyitem.js
@@ -16,7 +16,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			interaction.reply({ content: "This adventure isn't active or you aren't participating in it.", ephemeral: true });
 			return;
 		}
-		if (delver.getModifierStacks("Stun") > 0) { // Early out if stunned
+		if (delver.isStunned) {
 			interaction.reply({ content: "You cannot pick a move because you are stunned this round.", ephemeral: true });
 			return;
 		}

--- a/source/buttons/readymove.js
+++ b/source/buttons/readymove.js
@@ -17,7 +17,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			interaction.reply({ content: "This adventure isn't active or you aren't participating in it.", ephemeral: true });
 			return;
 		}
-		if (delver.getModifierStacks("Stun") > 0) { // Early out if stunned
+		if (delver.isStunned) {
 			interaction.reply({ content: "You cannot pick a move because you are stunned this round.", ephemeral: true });
 			return;
 		}

--- a/source/classes/ArchetypeTemplate.js
+++ b/source/classes/ArchetypeTemplate.js
@@ -10,7 +10,7 @@ class ArchetypeTemplate {
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} elementLabel
 	 * @param {string[]} startingGearNames
 	 * @param {(embed: EmbedBuilder, adventure: Adventure ) => EmbedBuilder} predictFunction
-	 * @param {(combatant:Combatant) => string} miniPredictFunction
+	 * @param {(combatant: Combatant) => string} miniPredictFunction
 	 */
 	constructor(nameInput, descriptionInput, elementLabel, startingGearNames, predictFunction, miniPredictFunction) {
 		if (!nameInput) throw new BuildError("Falsy nameInput");

--- a/source/classes/Combatant.js
+++ b/source/classes/Combatant.js
@@ -16,10 +16,12 @@ class Combatant {
 	maxHP = 300;
 	speed = 100;
 	critBonus = 0;
-	poise = 3;
+	poise = 6;
 
 	hp = 300;
 	block = 0;
+	stagger = 0;
+	isStunned = false;
 	crit = false;
 	roundSpeed = 0;
 	/** @type {{[modifierName: string]: number}} */
@@ -47,6 +49,21 @@ class Combatant {
 			totalSpeed += quickenStacks * 5;
 		}
 		return Math.ceil(totalSpeed);
+	}
+
+	/** add Stagger, negative values allowed
+	 * @param {number | "elementMatchAlly" | "elementMatchFoe"} value
+	 */
+	addStagger(value) {
+		if (!this.isStunned) {
+			let pendingStagger = value;
+			if (value === "elementMatchAlly") {
+				pendingStagger = -1;
+			} else if (value === "elementMatchFoe") {
+				pendingStagger = 2;
+			}
+			this.stagger = Math.min(Math.max(this.stagger + pendingStagger, 0), this.poise);
+		}
 	}
 }
 

--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -49,6 +49,8 @@ class GearTemplate {
 	healing;
 	/** @type {number} */
 	priority;
+	/** @type {number} */
+	stagger;
 	/** @type {{name: string, stacks: number}[]} */
 	modifiers;
 	/** @type {import("discord.js").EmbedField} */
@@ -121,6 +123,12 @@ class GearTemplate {
 	/** @param {number} integer */
 	setPriority(integer) {
 		this.priority = integer;
+		return this;
+	}
+
+	/** @param {number} integer */
+	setStagger(integer) {
+		this.stagger = integer;
 		return this;
 	}
 

--- a/source/commands/manual.js
+++ b/source/commands/manual.js
@@ -67,6 +67,9 @@ const subcommands = [
 		]
 	}
 ];
+
+const matchingElementStaggerField = { name: "Matching Element Stagger", value: "When a combatant makes a move that matches their element, their target gets a bonus effect. If the target is an ally, they are relieved of 1 Stagger. If the target is an enemy, they suffer 2 additional Stagger. Check the page on Stagger to learn more about Stagger and Stun." };
+
 module.exports = new CommandWrapper(mainId, "Get information about how to play or game entities", null, false, true, 3000, options, subcommands,
 	(interaction) => {
 		switch (interaction.options.getSubcommand()) {
@@ -97,7 +100,7 @@ module.exports = new CommandWrapper(mainId, "Get information about how to play o
 											const weaknesses = getWeaknesses(element);
 											const resistances = getResistances(element);
 											return { name: `${getEmoji(element)} ${element}`, value: `Opposite: ${getEmoji(getOpposite(element))}\nWeaknesses: ${weaknesses.length > 0 ? weaknesses.map(weakness => getEmoji(weakness)).join(" ") : "(none)"}\nResistances: ${resistances.length > 0 ? resistances.map(resistance => getEmoji(resistance)).join(" ") : "(none)"}` }
-										}).concat({ name: "Matching Element Stagger", value: "When a combatant makes a move that matches their element, their target gets a bonus effect. If the target is an ally, they are relieved of 1 Stagger. If the target is an enemy, they suffer 1 additional Stagger. Check the page on Stagger to learn more about Stagger and Stun." })
+										}).concat(matchingElementStaggerField)
 									)
 							],
 							ephemeral: true
@@ -107,8 +110,8 @@ module.exports = new CommandWrapper(mainId, "Get information about how to play o
 						interaction.reply({
 							embeds: [
 								embedTemplate().setTitle("Stagger")
-									.setDescription("Stagger is a modifier (that is neither a buff nor debuff) that stacks up on a combatant eventually leading to the combatant getting Stunned (also not a buff or debuff). A stunned combatant misses their next turn, even if they had readied a move for that turn. Stagger promotes to Stun when a combatant's number of stacks exceeds their poise (default 3 for delvers, varies for enemies).")
-									.addFields({ name: "Matching Element Stagger", value: "When a combatant makes a move that matches their element, their target gets a bonus effect. If the target is an ally, they are relieved of 1 Stagger. If the target is an enemy, they suffer 1 additional Stagger. Check the page on Elements to learn more about move and combatant elements." })
+									.setDescription("Stagger stacks up on combatants when moves are used against them, leading to the combatant getting Stunned. Stagger promotes to Stun between rounds when a combatant's Stagger reaches their Poise (default 6 for delvers, varies for enemies). A stunned combatant misses their turn next round.")
+									.addFields(matchingElementStaggerField)
 							],
 							ephemeral: true
 						});

--- a/source/enemies/bloodtailhawk.js
+++ b/source/enemies/bloodtailhawk.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectRandomFoe, nextRepeat } = require("../shared/actionComponents");
-const { dealDamage, addModifier } = require("../util/combatantUtil");
+const { dealDamage } = require("../util/combatantUtil");
 
 module.exports = new EnemyTemplate("Bloodtail Hawk",
 	"Wind",
@@ -19,7 +19,7 @@ module.exports = new EnemyTemplate("Bloodtail Hawk",
 		if (isCrit) {
 			damage *= 2;
 		}
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		return dealDamage([target], user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,

--- a/source/enemies/clone.js
+++ b/source/enemies/clone.js
@@ -4,7 +4,7 @@ module.exports = new EnemyTemplate("@{clone}",
 	"@{clone}",
 	300,
 	100,
-	"3",
+	"6",
 	0,
 	"clone", // this shouldn't get used, clones always copy delvers
 	true

--- a/source/enemies/elkemist.js
+++ b/source/enemies/elkemist.js
@@ -1,13 +1,13 @@
 const { EnemyTemplate } = require("../classes");
 const { isBuff } = require("../modifiers/_modifierDictionary.js");
-const { addBlock, dealDamage, addModifier, removeModifier } = require("../util/combatantUtil");
+const { addBlock, dealDamage, addModifier } = require("../util/combatantUtil");
 const { selectSelf, nextRandom, selectRandomFoe, selectAllFoes } = require("../shared/actionComponents.js");
 
 module.exports = new EnemyTemplate("Elkemist",
 	"Water",
 	2000,
 	100,
-	"n*2",
+	"n*4",
 	0,
 	"random",
 	true
@@ -17,7 +17,7 @@ module.exports = new EnemyTemplate("Elkemist",
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
 		// Gain block and medium progress
-		removeModifier(user, { name: "Stagger", stacks: 1 });
+		user.addStagger("elementMatchAlly");
 		if (isCrit) {
 			addModifier(user, { name: "Progress", stacks: 60 + adventure.generateRandomNumber(46, "battle") });
 		} else {
@@ -39,7 +39,7 @@ module.exports = new EnemyTemplate("Elkemist",
 			damage *= 2;
 		}
 		addModifier(user, { name: "Progress", stacks: 15 + adventure.generateRandomNumber(16, "battle") });
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		return `An obstacle to potion progress is identified and mitigated; ${dealDamage([target], user, damage, false, user.element, adventure)}`;
 	},
 	selector: selectRandomFoe,

--- a/source/enemies/firearrowfrog.js
+++ b/source/enemies/firearrowfrog.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectRandomFoe, selectSelf } = require("../shared/actionComponents.js");
-const { addModifier, removeModifier, dealDamage } = require("../util/combatantUtil");
+const { addModifier, dealDamage } = require("../util/combatantUtil");
 
 const PATTERN = {
 	"Venom Cannon": "random",
@@ -15,7 +15,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 	"Fire",
 	250,
 	100,
-	"2",
+	"4",
 	0,
 	"random",
 	false
@@ -44,7 +44,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 			stacks *= 3;
 		}
 		addModifier(user, { name: "Evade", stacks });
-		removeModifier(user, { name: "Stagger", stacks: 1 });
+		user.addStagger("elementMatchAlly");
 		return "It's prepared to Evade.";
 	},
 	selector: selectSelf,
@@ -56,7 +56,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 	effect: ([target], user, isCrit, adventure) => {
 		if (isCrit) {
 			addModifier(target, { name: "Slow", stacks: 3 });
-			addModifier(target, { name: "Stagger", stacks: 1 });
+			target.addStagger("elementMatchFoe");
 		} else {
 			addModifier(target, { name: "Slow", stacks: 2 });
 		}

--- a/source/enemies/geodetortoise.js
+++ b/source/enemies/geodetortoise.js
@@ -1,12 +1,12 @@
 const { EnemyTemplate } = require("../classes");
-const { addBlock, addModifier, removeModifier, dealDamage } = require("../util/combatantUtil");
+const { addBlock, addModifier, dealDamage } = require("../util/combatantUtil");
 const { selectRandomFoe, selectSelf, nextRandom } = require("../shared/actionComponents.js");
 
 module.exports = new EnemyTemplate("Geode Tortoise",
 	"Earth",
 	350,
 	85,
-	"3+n*0.5",
+	"6+n",
 	0,
 	"random",
 	false
@@ -19,7 +19,7 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 		if (isCrit) {
 			damage *= 2;
 		}
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		return dealDamage([target], user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,
@@ -32,7 +32,7 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 		addBlock(user, 150);
 		if (isCrit) {
 			addModifier(user, { name: "Power Up", stacks: 50 });
-			removeModifier(user, { name: "Stagger", stacks: 1 });
+			user.addStagger("elementMatchAlly");
 		} else {
 			addModifier(user, { name: "Power Up", stacks: 25 });
 		}

--- a/source/enemies/mechabee.js
+++ b/source/enemies/mechabee.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes");
-const { dealDamage, addModifier, removeModifier } = require("../util/combatantUtil");
+const { dealDamage, addModifier } = require("../util/combatantUtil");
 const { selectRandomFoe, selectSelf, selectNone, selectAllFoes } = require("../shared/actionComponents.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 
@@ -17,7 +17,7 @@ module.exports = new EnemyTemplate("Mechabee",
 	"Darkness",
 	200,
 	100,
-	"3",
+	"6",
 	0,
 	"Sting",
 	false
@@ -26,7 +26,7 @@ module.exports = new EnemyTemplate("Mechabee",
 	element: "Darkness",
 	priority: 0,
 	effect: ([target], user, isCrit, adventure) => {
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		if (isCrit) {
 			addModifier(target, { name: "Poison", stacks: 4 });
 		} else {
@@ -46,7 +46,7 @@ module.exports = new EnemyTemplate("Mechabee",
 			stacks *= 3;
 		}
 		addModifier(user, { name: "Evade", stacks });
-		removeModifier(user, { name: "Stagger", stacks: 1 });
+		user.addStagger("elementMatchAlly");
 		return "It's prepared to Evade.";
 	},
 	selector: selectSelf,
@@ -72,7 +72,7 @@ module.exports = new EnemyTemplate("Mechabee",
 		}
 		user.hp = 0;
 		targets.map(target => {
-			addModifier(target, { name: "Stagger", stacks: 1 });
+			target.addStagger("elementMatchFoe");
 		})
 
 		return dealDamage(targets, user, damage, false, user.element, adventure);

--- a/source/enemies/mechaqueen.js
+++ b/source/enemies/mechaqueen.js
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Mecha Queen",
 	"Darkness",
 	500,
 	100,
-	"n+1",
+	"n*2+2",
 	0,
 	"a random protocol",
 	true
@@ -90,7 +90,7 @@ module.exports = new EnemyTemplate("Mecha Queen",
 	element: "Darkness",
 	priority: 0,
 	effect: ([target], user, isCrit, adventure) => {
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		if (isCrit) {
 			addModifier(target, { name: "Poison", stacks: 5 });
 		} else {

--- a/source/enemies/ooze.js
+++ b/source/enemies/ooze.js
@@ -6,7 +6,7 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 	"@{adventureOpposite}",
 	200,
 	90,
-	"n+2",
+	"n*2+4",
 	0,
 	"Goop Spray",
 	false
@@ -17,7 +17,7 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 	effect: ([target], user, isCrit, adventure) => {
 		if (isCrit) {
 			addModifier(target, { name: "Slow", stacks: 3 });
-			addModifier(target, { name: "Stagger", stacks: 1 });
+			target.addStagger("elementMatchFoe");
 		} else {
 			addModifier(target, { name: "Slow", stacks: 2 });
 		}
@@ -34,7 +34,7 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 		if (isCrit) {
 			damage *= 2;
 		}
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		return dealDamage([target], user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,

--- a/source/enemies/royalslime.js
+++ b/source/enemies/royalslime.js
@@ -1,13 +1,13 @@
 const { EnemyTemplate } = require("../classes");
 const { nextRandom, selectSelf, selectAllFoes } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, removeModifier } = require("../util/combatantUtil");
+const { addModifier, dealDamage } = require("../util/combatantUtil");
 const { elementsList } = require("../util/elementUtil");
 
 module.exports = new EnemyTemplate("Royal Slime",
 	"@{adventure}",
 	600,
 	90,
-	"n+2",
+	"n*2+4",
 	0,
 	"Element Shift",
 	true
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 		user.element = elementPool[adventure.generateRandomNumber(elementPool.length, "battle")];
 		if (isCrit) {
 			addModifier(user, { name: `${user.element} Absorb`, stacks: 5 });
-			removeModifier(user, { name: "Stagger", stacks: 1 });
+			user.addStagger("elementMatchAlly");
 		} else {
 			addModifier(user, { name: `${user.element} Absorb`, stacks: 3 });
 		}
@@ -38,7 +38,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 			damage *= 2;
 		}
 		targets.map(target => {
-			addModifier(target, { name: "Stagger", stacks: 1 });
+			target.addStagger("elementMatchFoe");
 		})
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
@@ -54,7 +54,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 			damage *= 2;
 		}
 		targets.map(target => {
-			addModifier(target, { name: "Stagger", stacks: 1 });
+			target.addStagger("elementMatchFoe");
 		})
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
@@ -68,7 +68,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 		targets.forEach(target => {
 			if (isCrit) {
 				addModifier(target, { name: "Slow", stacks: 3 });
-				addModifier(target, { name: "Stagger", stacks: 1 });
+				target.addStagger("elementMatchFoe");
 			} else {
 				addModifier(target, { name: "Slow", stacks: 2 });
 			}

--- a/source/enemies/slime.js
+++ b/source/enemies/slime.js
@@ -6,7 +6,7 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 	"@{adventure}",
 	200,
 	90,
-	"n+2",
+	"n*2+4",
 	0,
 	"Tackle",
 	false
@@ -19,7 +19,7 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 		if (isCrit) {
 			damage *= 2;
 		}
-		addModifier(target, { name: "Stagger", stacks: 1 });
+		target.addStagger("elementMatchFoe");
 		return dealDamage([target], user, damage, false, adventure.element, adventure);
 	},
 	selector: selectRandomFoe,
@@ -31,7 +31,7 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 	effect: ([target], user, isCrit, adventure) => {
 		if (isCrit) {
 			addModifier(target, { name: "Slow", stacks: 3 });
-			addModifier(target, { name: "Stagger", stacks: 1 });
+			target.addStagger("elementMatchFoe");
 		} else {
 			addModifier(target, { name: "Slow", stacks: 2 });
 		}

--- a/source/enemies/treasureelemental.js
+++ b/source/enemies/treasureelemental.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectSelf, selectNone, selectAllFoes, selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, addBlock, removeModifier, dealDamage } = require("../util/combatantUtil");
+const { addModifier, addBlock, dealDamage } = require("../util/combatantUtil");
 
 const PATTERN = {
 	"Reinforcing Slam": "Burrow",
@@ -17,7 +17,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 	"Earth",
 	99999,
 	100,
-	"n*1.5",
+	"n*3",
 	0,
 	"Reinforcing Slam",
 	true
@@ -32,7 +32,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 				block *= 2;
 			}
 			addBlock(user, block);
-			removeModifier(user, { name: "Stagger", stacks: 1 });
+			user.addStagger("elementMatchAlly");
 			return `It prepares to Block and ${dealDamage([target], user, 100, false, user.element, adventure)}`;
 		},
 		selector: selectRandomFoe,
@@ -47,7 +47,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 				stacks *= 3;
 			}
 			addModifier(user, { name: "Evade", stacks });
-			removeModifier(user, { name: "Stagger", stacks: 1 });
+			user.addStagger("elementMatchAlly");
 			return "It scatters among the other treasure in the room to Evade.";
 		},
 		selector: selectSelf,
@@ -65,7 +65,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			addModifier(user, { name: "Curse of Midas", stacks: 1 });
 			targets.forEach(target => {
 				addModifier(target, { name: "Power Down", stacks });
-				addModifier(target, { name: "Stagger", stacks: 1 });
+				target.addStagger("elementMatchFoe");
 			});
 			return "Everyone is Powered Down, due to being distracted by a treasure that catches their eyes.";
 		},

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -162,7 +162,8 @@ function buildGearDescription(gearName, buildFullDescription) {
 			.replace(/@{bonus}/g, getGearProperty(gearName, "bonus"))
 			.replace(/@{block}/g, getGearProperty(gearName, "block"))
 			.replace(/@{hpCost}/g, getGearProperty(gearName, "hpCost"))
-			.replace(/@{healing}/g, getGearProperty(gearName, "healing"));
+			.replace(/@{healing}/g, getGearProperty(gearName, "healing"))
+			.replace(/@{stagger}/g, `${getGearProperty(gearName, "stagger")} Stagger`);
 		getGearProperty(gearName, "modifiers")?.forEach((modifier, index) => {
 			description = description.replace(new RegExp(`@{mod${index}}`, "g"), modifier.name)
 				.replace(new RegExp(`@{mod${index}Stacks}`, "g"), modifier.stacks);

--- a/source/gear/_gear_blueprint.js
+++ b/source/gear/_gear_blueprint.js
@@ -7,7 +7,7 @@ module.exports = new GearTemplate("name",
 	"element",
 	200,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger] } = module.exports;
+		let { element } = module.exports;
 		if (user.element === element) {
 
 		}
@@ -17,5 +17,4 @@ module.exports = new GearTemplate("name",
 		return ""; // see style guide for conventions on result texts
 	}
 ).setTargetingTags({ target: "", team: "" })
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability();

--- a/source/gear/_punch.js
+++ b/source/gear/_punch.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Punch",
 	"Strike a foe for @{damage} @{element} damage",
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Punch",
 			pendingDamage *= critBonus;
 		}
 		if (totalStagger > 0) {
-			addModifier(target, { name: "Stagger", stacks: totalStagger });
+			target.addStagger(totalStagger);
 		}
 		return dealDamage([target], user, pendingDamage, false, pendingElement, adventure);
 	})

--- a/source/gear/barrier-base.js
+++ b/source/gear/barrier-base.js
@@ -1,16 +1,16 @@
 const { GearTemplate } = require('../classes');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil.js');
+const { addBlock, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Barrier",
-	"Gain @{block} block and @{mod1Stacks} @{mod1}",
-	"@{mod1} x@{critBonus}",
+	"Gain @{block} block and @{mod0Stacks} @{mod0}",
+	"@{mod0} x@{critBonus}",
 	"Spell",
 	"Earth",
 	200,
 	([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, vigilance, critVigilance], block } = module.exports;
+		let { element, modifiers: [vigilance, critVigilance], block } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			addModifier(user, vigilance);
@@ -22,6 +22,6 @@ module.exports = new GearTemplate("Barrier",
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setUpgrades("Cleansing Barrier", "Devoted Barrier", "Long Barrier")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 1 }, { name: "Vigilance", stacks: 2 })
+	.setModifiers({ name: "Vigilance", stacks: 1 }, { name: "Vigilance", stacks: 2 })
 	.setDurability(5)
 	.setBlock(999);

--- a/source/gear/barrier-cleansing.js
+++ b/source/gear/barrier-cleansing.js
@@ -3,15 +3,15 @@ const { isDebuff } = require('../modifiers/_modifierDictionary');
 const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Cleansing Barrier",
-	"Gain @{block} block and @{mod1Stacks} @{mod1} and cure a random debuff",
-	"@{mod1} x@{critBonus}",
+	"Gain @{block} block and @{mod0Stacks} @{mod0} and cure a random debuff",
+	"@{mod0} x@{critBonus}",
 	"Spell",
 	"Earth",
 	350,
 	([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, vigilance, critVigilance], block } = module.exports;
+		let { element, modifiers: [vigilance, critVigilance], block } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			addModifier(user, vigilance);
@@ -30,6 +30,6 @@ module.exports = new GearTemplate("Cleansing Barrier",
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setSidegrades("Devoted Barrier", "Long Barrier")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 1 }, { name: "Vigilance", stacks: 2 })
+	.setModifiers({ name: "Vigilance", stacks: 1 }, { name: "Vigilance", stacks: 2 })
 	.setDurability(5)
 	.setBlock(999);

--- a/source/gear/barrier-devoted.js
+++ b/source/gear/barrier-devoted.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil.js');
+const { addBlock, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Devoted Barrier",
-	"Grant an ally @{block} block and @{mod1Stacks} @{mod1}",
-	"@{mod1} x@{critBonus}",
+	"Grant an ally @{block} block and @{mod0Stacks} @{mod0}",
+	"@{mod0} x@{critBonus}",
 	"Spell",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, vigilance, critVigilance], block } = module.exports;
+		let { element, modifiers: [vigilance, critVigilance], block } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			addModifier(target, vigilance);
@@ -23,6 +23,6 @@ module.exports = new GearTemplate("Devoted Barrier",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Cleansing Barrier", "Long Barrier")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 1 }, { name: "Vigilance", stacks: 2 })
+	.setModifiers({ name: "Vigilance", stacks: 1 }, { name: "Vigilance", stacks: 2 })
 	.setDurability(5)
 	.setBlock(999);

--- a/source/gear/barrier-long.js
+++ b/source/gear/barrier-long.js
@@ -1,16 +1,16 @@
 const { GearTemplate } = require('../classes');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil.js');
+const { addBlock, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Long Barrier",
-	"Gain @{block} block and @{mod1Stacks} @{mod1}",
-	"@{mod1} x@{critBonus}",
+	"Gain @{block} block and @{mod0Stacks} @{mod0}",
+	"@{mod0} x@{critBonus}",
 	"Spell",
 	"Earth",
 	350,
 	([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, vigilance, critVigilance], block } = module.exports;
+		let { element, modifiers: [vigilance, critVigilance], block } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			addModifier(user, vigilance);
@@ -22,6 +22,6 @@ module.exports = new GearTemplate("Long Barrier",
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setSidegrades("Cleansing Barrier", "Devoted Barrier")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 2 }, { name: "Vigilance", stacks: 4 })
+	.setModifiers({ name: "Vigilance", stacks: 2 }, { name: "Vigilance", stacks: 4 })
 	.setDurability(5)
 	.setBlock(999);

--- a/source/gear/battleaxe-base.js
+++ b/source/gear/battleaxe-base.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { addModifier, dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Battleaxe",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed], damage, critBonus } = module.exports;
+		let { element, modifiers: [exposed], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Battleaxe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Prideful Battleaxe", "Thick Battleaxe", "Thirsting Battleaxe")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 })
+	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)
 	.setDamage(125);

--- a/source/gear/battleaxe-prideful.js
+++ b/source/gear/battleaxe-prideful.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { addModifier, dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Prideful Battleaxe",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Untyped",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed], damage, critBonus } = module.exports;
+		let { element, modifiers: [exposed], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Prideful Battleaxe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Thick Battleaxe", "Thirsting Battleaxe")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 })
+	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)
 	.setDamage(175);

--- a/source/gear/battleaxe-thick.js
+++ b/source/gear/battleaxe-thick.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { addModifier, dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Thick Battleaxe",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed], damage, critBonus } = module.exports;
+		let { element, modifiers: [exposed], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Thick Battleaxe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Prideful Battleaxe", "Thirsting Battleaxe")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 })
+	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(30)
 	.setDamage(125);

--- a/source/gear/battleaxe-thirsting.js
+++ b/source/gear/battleaxe-thirsting.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { addModifier, dealDamage, gainHealth } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Thirsting Battleaxe",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1}; heal @{healing} hp on kill",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0}; heal @{healing} hp on kill",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed], damage, critBonus, healing } = module.exports;
+		let { element, modifiers: [exposed], damage, critBonus, healing } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Thirsting Battleaxe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Prideful Battleaxe", "Thick Battleaxe")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 })
+	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)
 	.setDamage(125)
 	.setHealing(60);

--- a/source/gear/bloodaegis-base.js
+++ b/source/gear/bloodaegis-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { removeModifier, addBlock, payHP } = require('../util/combatantUtil.js');
+const { addBlock, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Blood Aegis",
 	"Pay @{hpCost} hp; gain @{block} block and intercept a later single target move",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Blood Aegis",
 	"Darkness",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, critBonus, hpCost } = module.exports;
+		let { element, block, critBonus, hpCost } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -30,7 +30,6 @@ module.exports = new GearTemplate("Blood Aegis",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Charging Blood Aegis", "Reinforced Blood Aegis", "Sweeping Blood Aegis")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setHPCost(25)
 	.setBlock(125);

--- a/source/gear/bloodaegis-charging.js
+++ b/source/gear/bloodaegis-charging.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { removeModifier, addBlock, addModifier, payHP } = require('../util/combatantUtil.js');
+const { addBlock, addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Charging Blood Aegis",
-	"Pay @{hpCost} hp; gain @{block} block, @{mod1Stacks} @{mod1}, intercept a later single target move",
+	"Pay @{hpCost} hp; gain @{block} block, @{mod0Stacks} @{mod0}, intercept a later single target move",
 	"Block x@{critBonus}",
 	"Pact",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], block, critBonus, hpCost } = module.exports;
+		let { element, modifiers: [powerUp], block, critBonus, hpCost } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -31,7 +31,7 @@ module.exports = new GearTemplate("Charging Blood Aegis",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Reinforced Blood Aegis", "Sweeping Blood Aegis")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setHPCost(25)
 	.setBlock(125);

--- a/source/gear/bloodaegis-reinforced.js
+++ b/source/gear/bloodaegis-reinforced.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { removeModifier, addBlock, payHP } = require('../util/combatantUtil.js');
+const { addBlock, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reinforced Blood Aegis",
 	"Pay @{hpCost} hp; gain @{block} block and intercept a later single target move",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Reinforced Blood Aegis",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, critBonus, hpCost } = module.exports;
+		let { element, block, critBonus, hpCost } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -30,7 +30,6 @@ module.exports = new GearTemplate("Reinforced Blood Aegis",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Charging Blood Aegis", "Sweeping Blood Aegis")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setHPCost(25)
 	.setBlock(250);

--- a/source/gear/bloodaegis-sweeping.js
+++ b/source/gear/bloodaegis-sweeping.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { removeModifier, addBlock, payHP } = require('../util/combatantUtil.js');
+const { addBlock, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sweeping Blood Aegis",
 	"Pay @{hpCost} hp; gain @{block} block and intercept all later single target moves",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Sweeping Blood Aegis",
 	"Darkness",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, critBonus, hpCost } = module.exports;
+		let { element, block, critBonus, hpCost } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -37,7 +37,6 @@ module.exports = new GearTemplate("Sweeping Blood Aegis",
 	})
 ).setTargetingTags({ target: "all", team: "enemy" })
 	.setSidegrades("Charging Blood Aegis", "Reinforced Blood Aegis")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setHPCost(25)
 	.setBlock(100);

--- a/source/gear/bow-base.js
+++ b/source/gear/bow-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Bow",
 	"Strike a foe for @{damage} @{element} damage with priority",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Bow",
 	"Wind",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Bow",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Evasive Bow", "Hunter's Bow", "Mercurial Bow")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setPriority(1);

--- a/source/gear/bow-evasive.js
+++ b/source/gear/bow-evasive.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Evasive Bow",
-	"Strike a foe for @{damage} @{element} damage and gain @{mod1Stacks} @{mod1} with priority",
+	"Strike a foe for @{damage} @{element} damage and gain @{mod0Stacks} @{mod0} with priority",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, evade], damage, critBonus } = module.exports;
+		let { element, modifiers: [evade], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Evasive Bow",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Hunter's Bow", "Mercurial Bow")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 })
+	.setModifiers({ name: "Evade", stacks: 2 })
 	.setDurability(15)
 	.setDamage(75)
 	.setPriority(1);

--- a/source/gear/bow-hunters.js
+++ b/source/gear/bow-hunters.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Hunter's Bow",
 	"Strike a foe for @{damage} @{element} damage with priority, gain @{bonus}g on kill",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Hunter's Bow",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus: bonusBounty, critBonus } = module.exports;
+		let { element, damage, bonus: bonusBounty, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -25,7 +25,6 @@ module.exports = new GearTemplate("Hunter's Bow",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Evasive Bow", "Mercurial Bow")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(15) // gold

--- a/source/gear/bow-mercurial.js
+++ b/source/gear/bow-mercurial.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Mercurial Bow",
 	"Strike a foe for @{damage} damage matching the user's element with priority",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Mercurial Bow",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Mercurial Bow",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Evasive Bow", "Hunter's Bow")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setPriority(1);

--- a/source/gear/buckler-base.js
+++ b/source/gear/buckler-base.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil');
+const { addBlock, addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Buckler",
-	"Grant an ally @{block} block and gain @{mod1Stacks} @{mod1}",
+	"Grant an ally @{block} block and gain @{mod0Stacks} @{mod0}",
 	"Block x@{critBonus}",
 	"Armor",
 	"Earth",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], block, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -22,6 +22,6 @@ module.exports = new GearTemplate("Buckler",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setUpgrades("Devoted Buckler", "Guarding Buckler", "Reinforced Buckler")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setBlock(75);

--- a/source/gear/buckler-devoted.js
+++ b/source/gear/buckler-devoted.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil');
+const { addBlock, addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Devoted Buckler",
-	"Grant an ally @{block} block and @{mod1Stacks} @{mod1}",
+	"Grant an ally @{block} block and @{mod0Stacks} @{mod0}",
 	"Block x@{critBonus}",
 	"Armor",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], block, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -23,6 +23,6 @@ module.exports = new GearTemplate("Devoted Buckler",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Guarding Buckler", "Reinforced Buckler")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setBlock(75);

--- a/source/gear/buckler-guarding.js
+++ b/source/gear/buckler-guarding.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil');
+const { addBlock, addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Guarding Buckler",
-	"Grant an ally @{block} block and gain @{mod1Stacks} @{mod1}",
+	"Grant an ally @{block} block and gain @{mod0Stacks} @{mod0}",
 	"Block x@{critBonus}",
 	"Armor",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], block, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -22,6 +22,6 @@ module.exports = new GearTemplate("Guarding Buckler",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Devoted Buckler", "Reinforced Buckler")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setBlock(125);

--- a/source/gear/buckler-reinforced.js
+++ b/source/gear/buckler-reinforced.js
@@ -1,18 +1,18 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier, addModifier } = require('../util/combatantUtil');
+const { addBlock, addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Reinforced Buckler",
-	"Grant @{block} block to an ally and yourself and gain @{mod1Stacks} @{mod1}",
+	"Grant @{block} block to an ally and yourself and gain @{mod0Stacks} @{mod0}",
 	"Block x@{critBonus}",
 	"Armor",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], block, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
-			removeModifier(target, elementStagger);
+			user.addStagger("elementMatchAlly");
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -25,6 +25,6 @@ module.exports = new GearTemplate("Reinforced Buckler",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Devoted Buckler", "Guarding Buckler")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setBlock(75);

--- a/source/gear/censer-base.js
+++ b/source/gear/censer-base.js
@@ -5,14 +5,14 @@ const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Censer",
 	"Burn a foe for @{damage} (+@{bonus} if target has any debuffs) @{element} damage",
-	"Also apply @{mod1Stacks} @{mod1}",
+	"Also apply @{mod0Stacks} @{mod0}",
 	"Trinket",
 	"Fire",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, slow], damage, bonus } = module.exports;
+		let { element, modifiers: [slow], damage, bonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 			damage += bonus;
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Censer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Fate-Sealing Censer", "Thick Censer", "Tormenting Censor")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(50)
 	.setBonus(75) // damage
 	.setDurability(15);

--- a/source/gear/censer-fatesealing.js
+++ b/source/gear/censer-fatesealing.js
@@ -5,14 +5,14 @@ const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Fate-Sealing Censer",
 	"Burn a foe for @{damage} (+@{bonus} if target has any debuffs) @{element} damage",
-	"Also apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}",
+	"Also apply @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1}",
 	"Trinket",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, slow, stasis], damage, bonus } = module.exports;
+		let { element, modifiers: [slow, stasis], damage, bonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 			damage += bonus;
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Fate-Sealing Censer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Thick Censer", "Tormenting Censor")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 }, { name: "Stasis", stacks: 1 })
+	.setModifiers({ name: "Slow", stacks: 2 }, { name: "Stasis", stacks: 1 })
 	.setDamage(50)
 	.setBonus(75) // damage
 	.setDurability(15);

--- a/source/gear/censer-thick.js
+++ b/source/gear/censer-thick.js
@@ -5,14 +5,14 @@ const { dealDamage, addModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Thick Censer",
 	"Burn a foe for @{damage} (+@{bonus} if target has any debuffs) @{element} damage",
-	"Also apply @{mod1Stacks} @{mod1}",
+	"Also apply @{mod0Stacks} @{mod0}",
 	"Trinket",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, slow], damage, bonus } = module.exports;
+		let { element, modifiers: [slow], damage, bonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 			damage += bonus;
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Thick Censer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Fate-Sealing Censer", "Tormenting Censor")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(50)
 	.setBonus(75) // damage
 	.setDurability(30);

--- a/source/gear/censer-tormenting.js
+++ b/source/gear/censer-tormenting.js
@@ -4,19 +4,19 @@ const { dealDamage, addModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Tormenting Censer",
 	"Burn a foe for @{damage} (+@{bonus} if target has debuffs) @{element} damage, duplicate its debuffs",
-	"Also apply @{mod1Stacks} @{mod1}",
+	"Also apply @{mod0Stacks} @{mod0}",
 	"Trinket",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, slow], damage, bonus } = module.exports;
+		let { element, modifiers: [slow], damage, bonus } = module.exports;
 		for (const modifier in target.modifiers) {
 			if (isDebuff(modifier)) {
 				addModifier(target, { name: modifier, stacks: 1 });
 			}
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (Object.keys(target.modifiers).some(modifier => isDebuff(modifier))) {
 			damage += bonus;
@@ -31,7 +31,7 @@ module.exports = new GearTemplate("Tormenting Censer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Fate-Sealing Censer", "Thick Censer")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(50)
 	.setBonus(75) // damage
 	.setDurability(15);

--- a/source/gear/certainvictory-base.js
+++ b/source/gear/certainvictory-base.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Certain Victory",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1}; pay HP for your @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0}; pay HP for your @{mod0}",
 	"Damage x@{critBonus}",
 	"Pact",
 	"Earth",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], damage, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Certain Victory",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Hunter's Certain Victory", "Lethal Certain Victory", "Reckless Certain Victory")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/certainvictory-hunters.js
+++ b/source/gear/certainvictory-hunters.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Hunter's Certain Victory",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1} (@{bonus}g on kill); pay HP for your @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0} (@{bonus}g on kill); pay HP for your @{mod0}",
 	"Damage x@{critBonus}",
 	"Pact",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], damage, bonus: bounty, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], damage, bonus: bounty, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Hunter's Certain Victory",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Lethal Certain Victory", "Reckless Certain Victory")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(15);

--- a/source/gear/certainvictory-lethal.js
+++ b/source/gear/certainvictory-lethal.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Lethal Certain Victory",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1}; pay HP for your @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0}; pay HP for your @{mod0}",
 	"Damage x@{critBonus}",
 	"Pact",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], damage, critBonus } = module.exports;
+		let { element, modifiers: [powerUp], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Lethal Certain Victory",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Hunter's Certain Victory", "Reckless Certain Victory")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)
 	.setDamage(75)
 	.setCritBonus(3);

--- a/source/gear/certainvictory-reckless.js
+++ b/source/gear/certainvictory-reckless.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reckless Certain Victory",
-	"Strike a foe for @{damage} @{element} damage, gain @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}; pay HP for your @{mod1}",
+	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1}; pay HP for your @{mod0}",
 	"Damage x@{critBonus}",
 	"Pact",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp, exposed], damage, critBonus } = module.exports;
+		let { element, modifiers: [powerUp, exposed], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -22,6 +22,6 @@ module.exports = new GearTemplate("Reckless Certain Victory",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Hunter's Certain Victory", "Lethal Certain Victory")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Exposed", stacks: 1 })
+	.setModifiers({ name: "Power Up", stacks: 25 }, { name: "Exposed", stacks: 1 })
 	.setDurability(15)
 	.setDamage(125);

--- a/source/gear/cloak-accelerating.js
+++ b/source/gear/cloak-accelerating.js
@@ -1,18 +1,18 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accelerating Cloak",
-	"Gain @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2}",
-	"@{mod1} +@{bonus} and @{mod2} +@{bonus}",
+	"Gain @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1}",
+	"@{mod0} +@{bonus} and @{mod1} +@{bonus}",
 	"Armor",
 	"Wind",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, evade, quicken], bonus } = module.exports;
+		let { element, modifiers: [evade, quicken], bonus } = module.exports;
 		const pendingEvade = { ...evade, stacks: evade.stacks + (isCrit ? bonus : 0) };
 		const pendingQuicken = { ...quicken, stacks: quicken.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		addModifier(user, pendingEvade);
 		addModifier(user, pendingQuicken);
@@ -20,6 +20,6 @@ module.exports = new GearTemplate("Accelerating Cloak",
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setSidegrades("Long Cloak", "Thick Cloak")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Quicken", stacks: 1 })
+	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Quicken", stacks: 1 })
 	.setBonus(1) // Evade stacks
 	.setDurability(15);

--- a/source/gear/cloak-base.js
+++ b/source/gear/cloak-base.js
@@ -1,23 +1,23 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Cloak",
-	"Gain @{mod1Stacks} @{mod1}",
-	"@{mod1} +@{bonus}",
+	"Gain @{mod0Stacks} @{mod0}",
+	"@{mod0} +@{bonus}",
 	"Armor",
 	"Wind",
 	200,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, evade], bonus } = module.exports;
+		let { element, modifiers: [evade], bonus } = module.exports;
 		const pendingEvade = { ...evade, stacks: evade.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		addModifier(user, pendingEvade);
 		return `${user.getName(adventure.room.enemyIdMap)} is prepared to Evade.`;
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setUpgrades("Accelerating Cloak", "Long Cloak", "Thick Cloak")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 })
+	.setModifiers({ name: "Evade", stacks: 2 })
 	.setBonus(1) // Evade stacks
 	.setDurability(15);

--- a/source/gear/cloak-long.js
+++ b/source/gear/cloak-long.js
@@ -1,23 +1,23 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Long Cloak",
-	"Gain @{mod1Stacks} @{mod1}",
-	"@{mod1} +@{bonus}",
+	"Gain @{mod0Stacks} @{mod0}",
+	"@{mod0} +@{bonus}",
 	"Armor",
 	"Wind",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, evade], bonus } = module.exports;
+		let { element, modifiers: [evade], bonus } = module.exports;
 		const pendingEvade = { ...evade, stacks: evade.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		addModifier(user, pendingEvade);
 		return `${user.getName(adventure.room.enemyIdMap)} is prepared to Evade.`;
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setSidegrades("Accelerating Cloak", "Thick Cloak")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 3 })
+	.setModifiers({ name: "Evade", stacks: 3 })
 	.setBonus(1) // Evade stacks
 	.setDurability(15);

--- a/source/gear/cloak-thick.js
+++ b/source/gear/cloak-thick.js
@@ -1,23 +1,23 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Thick Cloak",
-	"Gain @{mod1Stacks} @{mod1}",
-	"@{mod1} +@{bonus}",
+	"Gain @{mod0Stacks} @{mod0}",
+	"@{mod0} +@{bonus}",
 	"Armor",
 	"Wind",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, evade], bonus } = module.exports;
+		let { element, modifiers: [evade], bonus } = module.exports;
 		const pendingEvade = { ...evade, stacks: evade.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		addModifier(user, pendingEvade);
 		return `${user.getName(adventure.room.enemyIdMap)} is prepared to Evade.`;
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setSidegrades("Accelerating Cloak", "Long Cloak")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 })
+	.setModifiers({ name: "Evade", stacks: 2 })
 	.setBonus(1) // Evade stacks
 	.setDurability(30);

--- a/source/gear/corrosion-base.js
+++ b/source/gear/corrosion-base.js
@@ -3,23 +3,24 @@ const { needsLivingTargets } = require("../shared/actionComponents");
 const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Corrosion",
-	"Inflict @{mod1Stacks} @{mod1} on a foe",
-	"Also inflict @{mod2Stacks} @{mod2}",
+	"Inflict @{mod0Stacks} @{mod0} on a foe",
+	"Also inflict @{stagger}",
 	"Spell",
 	"Fire",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerDown, critStagger] } = module.exports;
+		let { element, modifiers: [powerDown], stagger } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
-			addModifier(target, critStagger);
+			target.addStagger(stagger);
 		}
 		addModifier(target, powerDown);
 		return `${target.getName(adventure.room.enemyIdMap)} is Powered Down.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Flanking Corrosion")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Down", stacks: 40 }, { name: "Stagger", stacks: 1 })
+	.setModifiers({ name: "Power Down", stacks: 40 })
+	.setStagger(2)
 	.setDurability(15);

--- a/source/gear/corrosion-flanking.js
+++ b/source/gear/corrosion-flanking.js
@@ -3,23 +3,24 @@ const { needsLivingTargets } = require("../shared/actionComponents");
 const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Flanking Corrosion",
-	"Inflict @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} on a foe",
-	"Also inflict @{mod3Stacks} @{mod3}",
+	"Inflict @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} on a foe",
+	"Also inflict @{stagger}",
 	"Spell",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerDown, exposed, critStagger] } = module.exports;
+		let { element, modifiers: [powerDown, exposed], stagger } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
-			addModifier(target, critStagger);
+			target.addStagger(stagger);
 		}
 		addModifier(target, powerDown);
 		addModifier(target, exposed);
 		return `${target.getName(adventure.room.enemyIdMap)} is Powered Down and Exposed.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Down", stacks: 40 }, { name: "Exposed", stacks: 2 }, { name: "Stagger", stacks: 1 })
+	.setModifiers({ name: "Power Down", stacks: 40 }, { name: "Exposed", stacks: 2 })
+	.setStagger(2)
 	.setDurability(15);

--- a/source/gear/daggers-base.js
+++ b/source/gear/daggers-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier } = require('../util/combatantUtil');
+const { dealDamage } = require('../util/combatantUtil');
 const { needsLivingTargets } = require('../shared/actionComponents');
 
 module.exports = new GearTemplate("Daggers",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Daggers",
 	"Wind",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Daggers",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Sharpened Daggers", "Sweeping Daggers", "Slowing Daggers")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setCritBonus(3);

--- a/source/gear/daggers-sharpened.js
+++ b/source/gear/daggers-sharpened.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sharpened Daggers",
 	"Strike a foe for @{damage} @{element} damage",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Sharpened Daggers",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Sharpened Daggers",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Sweeping Daggers", "Slowing Daggers")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setCritBonus(3)
 	.setDamage(100);

--- a/source/gear/daggers-slowing.js
+++ b/source/gear/daggers-slowing.js
@@ -3,14 +3,14 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Slowing Daggers",
-	"Strike a foe for @{damage} @{element} damage and inflict @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} @{element} damage and inflict @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Wind",
 	350, needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, slow], damage, critBonus } = module.exports;
+		let { element, modifiers: [slow], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Slowing Daggers",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Sharpened Daggers", "Sweeping Daggers")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 1 })
+	.setModifiers({ name: "Slow", stacks: 1 })
 	.setDurability(15)
 	.setCritBonus(3)
 	.setDamage(75);

--- a/source/gear/daggers-sweeping.js
+++ b/source/gear/daggers-sweeping.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sweeping Daggers",
 	"Strike all foes for @{damage} @{element} damage",
@@ -9,10 +9,10 @@ module.exports = new GearTemplate("Sweeping Daggers",
 	"Wind",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		targets.map(target => {
 			if (user.element === element) {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 			if (isCrit) {
 				damage *= critBonus;
@@ -22,7 +22,6 @@ module.exports = new GearTemplate("Sweeping Daggers",
 	})
 ).setTargetingTags({ target: "all", team: "enemy" })
 	.setSidegrades("Sharpened Daggers", "Slowing Daggers")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setCritBonus(3)
 	.setDamage(50);

--- a/source/gear/firecracker-base.js
+++ b/source/gear/firecracker-base.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants.js');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Firecracker",
 	"Strike 3 random foes for @{damage} @{element} damage",
@@ -10,21 +10,20 @@ module.exports = new GearTemplate("Firecracker",
 	"Fire",
 	200,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		let pendingDamage = damage;
 		if (isCrit) {
 			pendingDamage *= critBonus;
 		}
 		targets.map(target => {
 			if (user.element === element) {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		})
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	})
 ).setTargetingTags({ target: `random${SAFE_DELIMITER}3`, team: "enemy" })
 	.setUpgrades("Double Firecracker", "Mercurial Firecracker", "Toxic Firecracker")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setCritBonus(2)
 	.setDamage(50);

--- a/source/gear/firecracker-double.js
+++ b/source/gear/firecracker-double.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants.js');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Double Firecracker",
 	"Strike 6 random foes for @{damage} @{element} damage",
@@ -10,21 +10,20 @@ module.exports = new GearTemplate("Double Firecracker",
 	"Fire",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		let pendingDamage = damage;
 		if (isCrit) {
 			pendingDamage *= critBonus;
 		}
 		targets.map(target => {
 			if (user.element === element) {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		})
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	})
 ).setTargetingTags({ target: `random${SAFE_DELIMITER}6`, team: "enemy" })
 	.setSidegrades("Mercurial Firecracker", "Toxic Firecracker")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setCritBonus(2)
 	.setDamage(50);

--- a/source/gear/firecracker-mercurial.js
+++ b/source/gear/firecracker-mercurial.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants.js');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Mercurial Firecracker",
 	"Strike 3 random foes for @{damage} damage matching the user's element",
@@ -10,21 +10,20 @@ module.exports = new GearTemplate("Mercurial Firecracker",
 	"Fire",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		let pendingDamage = damage;
 		if (isCrit) {
 			pendingDamage *= critBonus;
 		}
 		targets.map(target => {
 			if (user.element === element) {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		})
 		return dealDamage(targets, user, pendingDamage, false, user.element, adventure);
 	})
 ).setTargetingTags({ target: `random${SAFE_DELIMITER}3`, team: "enemy" })
 	.setSidegrades("Double Firecracker", "Toxic Firecracker")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setCritBonus(2)
 	.setDamage(50);

--- a/source/gear/firecracker-toxic.js
+++ b/source/gear/firecracker-toxic.js
@@ -4,28 +4,28 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Firecracker",
-	"Strike 3 random foes applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage",
+	"Strike 3 random foes applying @{mod0Stacks} @{mod0} and @{damage} @{element} damage",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, poison], damage, critBonus } = module.exports;
+		let { element, modifiers: [poison], damage, critBonus } = module.exports;
 		let pendingDamage = damage;
 		if (isCrit) {
 			pendingDamage *= critBonus;
 		}
 		targets.map(target => {
 			if (user.element === element) {
-				addModifier(target, elementStagger);
-				addModifier(target, poison);
+				target.addStagger("elementMatchFoe");
 			}
+			addModifier(target, poison);
 		})
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	})
 ).setTargetingTags({ target: `random${SAFE_DELIMITER}3`, team: "enemy" })
 	.setSidegrades("Double Firecracker", "Mercurial Firecracker")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 3 })
+	.setModifiers({ name: "Poison", stacks: 3 })
 	.setDurability(15)
 	.setCritBonus(2)
 	.setDamage(50);

--- a/source/gear/floatingmiststance-base.js
+++ b/source/gear/floatingmiststance-base.js
@@ -2,15 +2,15 @@ const { GearTemplate } = require("../classes");
 const { addModifier, removeModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Floating Mist Stance",
-	"Enter a stance that increases Punch stagger by @{bonus} and grants @{mod1Stacks} @{mod1} each round (exit other stances)",
-	"Gain @{mod1Stacks} @{mod1} now",
+	"Enter a stance that increases Punch stagger by @{bonus} and grants @{mod0Stacks} @{mod0} each round (exit other stances)",
+	"Gain @{mod0Stacks} @{mod0} now",
 	"Technique",
 	"Light",
 	200,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, displayEvade, floatingMistStance] } = module.exports;
+		let { element, modifiers: [displayEvade, floatingMistStance] } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			addModifier(user, displayEvade);
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Floating Mist Stance",
 	}
 ).setUpgrades("Soothing Floating Mist Stance")
 	.setTargetingTags({ target: "self", team: "any" })
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Floating Mist Stance", stacks: 1 })
+	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Floating Mist Stance", stacks: 1 })
 	.setBonus(2) // Punch stagger boost
 	.setDurability(10);

--- a/source/gear/floatingmiststance-soothing.js
+++ b/source/gear/floatingmiststance-soothing.js
@@ -2,15 +2,15 @@ const { GearTemplate } = require("../classes");
 const { addModifier, removeModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Soothing Floating Mist Stance",
-	"Enter a stance that increases Punch stagger by @{bonus} and grants @{mod1Stacks} @{mod1} each round (exit other stances), gain @{mod2Stacks} @{mod2} now",
-	"Gain @{mod1Stacks} @{mod1} now",
+	"Enter a stance that increases Punch stagger by @{bonus} and grants @{mod0Stacks} @{mod0} each round (exit other stances), gain @{mod1Stacks} @{mod1} now",
+	"Gain @{mod0Stacks} @{mod0} now",
 	"Technique",
 	"Light",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, displayEvade, floatingMistStance, regen] } = module.exports;
+		let { element, modifiers: [displayEvade, floatingMistStance, regen] } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			addModifier(user, displayEvade);
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Soothing Floating Mist Stance",
 		return `${user.getName(adventure.room.enemyIdMap)} enters Floating Mist Stance${isCrit ? " and prepares to Evade" : ""}.`;
 	}
 ).setTargetingTags({ target: "self", team: "any" })
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Floating Mist Stance", stacks: 1 }, { name: "Regen", stacks: 2 })
+	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Floating Mist Stance", stacks: 1 }, { name: "Regen", stacks: 2 })
 	.setBonus(2) // Punch stagger boost
 	.setDurability(10);

--- a/source/gear/infiniteregeneration-base.js
+++ b/source/gear/infiniteregeneration-base.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { removeModifier, addModifier, payHP } = require('../util/combatantUtil.js');
+const { addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Infinite Regeneration",
-	"Pay @{hpCost} hp to grant an ally @{mod1Stacks} @{mod1}",
+	"Pay @{hpCost} hp to grant an ally @{mod0Stacks} @{mod0}",
 	"HP Cost / @{critBonus}",
 	"Pact",
 	"Light",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, regen], hpCost, critBonus } = module.exports;
+		let { element, modifiers: [regen], hpCost, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			hpCost /= critBonus;
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Infinite Regeneration",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setUpgrades("Discounted Infinite Regeneration", "Fate-Sealing Infinite Regeneration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Regen", stacks: 3 })
+	.setModifiers({ name: "Regen", stacks: 3 })
 	.setHPCost(50)
 	.setDurability(10);

--- a/source/gear/infiniteregeneration-discounted.js
+++ b/source/gear/infiniteregeneration-discounted.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { removeModifier, addModifier, payHP } = require('../util/combatantUtil.js');
+const { addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Discounted Infinite Regeneration",
-	"Pay @{hpCost} hp to grant an ally @{mod1Stacks} @{mod1}",
+	"Pay @{hpCost} hp to grant an ally @{mod0Stacks} @{mod0}",
 	"HP Cost / @{critBonus}",
 	"Pact",
 	"Light",
 	100,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, regen], hpCost, critBonus } = module.exports;
+		let { element, modifiers: [regen], hpCost, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			hpCost /= critBonus;
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Discounted Infinite Regeneration",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Fate-Sealing Infinite Regeneration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Regen", stacks: 3 })
+	.setModifiers({ name: "Regen", stacks: 3 })
 	.setHPCost(50)
 	.setDurability(10);

--- a/source/gear/infiniteregeneration-fatesealing.js
+++ b/source/gear/infiniteregeneration-fatesealing.js
@@ -1,17 +1,17 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { removeModifier, addModifier, payHP } = require('../util/combatantUtil.js');
+const { addModifier, payHP } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Fate-Sealing Infinite Regeneration",
-	"Pay @{hpCost} hp to grant an ally @{mod1Stacks} @{mod1}",
-	"HP Cost / @{critBonus} and grant @{mod2Stacks} @{mod2}",
+	"Pay @{hpCost} hp to grant an ally @{mod0Stacks} @{mod0}",
+	"HP Cost / @{critBonus} and grant @{mod1Stacks} @{mod1}",
 	"Pact",
 	"Light",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, regen, stasis], hpCost, critBonus } = module.exports;
+		let { element, modifiers: [regen, stasis], hpCost, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			hpCost /= critBonus;
@@ -22,6 +22,6 @@ module.exports = new GearTemplate("Fate-Sealing Infinite Regeneration",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Discounted Infinite Regeneration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Regen", stacks: 3 }, { name: "Stasis", stacks: 1 })
+	.setModifiers({ name: "Regen", stacks: 3 }, { name: "Stasis", stacks: 1 })
 	.setHPCost(50)
 	.setDurability(10);

--- a/source/gear/inspiration-base.js
+++ b/source/gear/inspiration-base.js
@@ -1,24 +1,24 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Inspiration",
-	"Apply @{mod1Stacks} @{mod1} to an ally",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} to an ally",
+	"@{mod0} +@{bonus}",
 	"Spell",
 	"Wind",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], bonus } = module.exports;
+		let { element, modifiers: [powerUp], bonus } = module.exports;
 		const pendingPowerUp = { ...powerUp, stacks: powerUp.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		addModifier(target, pendingPowerUp);
 		return `${target.getName(adventure.room.enemyIdMap)} is Powered Up.`;
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setUpgrades("Guarding Inspiration", "Soothing Inspiration", "Sweeping Inspiration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setBonus(25) // Power Up stacks
 	.setDurability(10);

--- a/source/gear/inspiration-guarding.js
+++ b/source/gear/inspiration-guarding.js
@@ -1,18 +1,18 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier, addBlock } = require('../util/combatantUtil.js');
+const { addModifier, addBlock } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Guarding Inspiration",
-	"Apply @{mod1Stacks} @{mod1} and @{block} block to an ally",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} and @{block} block to an ally",
+	"@{mod0} +@{bonus}",
 	"Spell",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], bonus, block } = module.exports;
+		let { element, modifiers: [powerUp], bonus, block } = module.exports;
 		const pendingPowerUp = { ...powerUp, stacks: powerUp.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		addModifier(target, pendingPowerUp);
 		addBlock(target, block);
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Guarding Inspiration",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Soothing Inspiration", "Sweeping Inspiration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setBonus(25) // Power Up stacks
 	.setBlock(25)
 	.setDurability(10);

--- a/source/gear/inspiration-soothing.js
+++ b/source/gear/inspiration-soothing.js
@@ -1,18 +1,18 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Soothing Inspiration",
-	"Apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to an ally",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to an ally",
+	"@{mod0} +@{bonus}",
 	"Spell",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp, regen], bonus } = module.exports;
+		let { element, modifiers: [powerUp, regen], bonus } = module.exports;
 		const pendingPowerUp = { ...powerUp, stacks: powerUp.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
+			target.addStagger("elementMatchAlly");
 		}
 		addModifier(target, pendingPowerUp);
 		addModifier(target, regen);
@@ -20,6 +20,6 @@ module.exports = new GearTemplate("Soothing Inspiration",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Guarding Inspiration", "Sweeping Inspiration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 }, { name: "Regen", stacks: 2 })
+	.setModifiers({ name: "Power Up", stacks: 25 }, { name: "Regen", stacks: 2 })
 	.setBonus(25) // Power Up stacks
 	.setDurability(10);

--- a/source/gear/inspiration-sweeping.js
+++ b/source/gear/inspiration-sweeping.js
@@ -1,19 +1,19 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sweeping Inspiration",
-	"Apply @{mod1Stacks} @{mod1} to all allies",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} to all allies",
+	"@{mod0} +@{bonus}",
 	"Spell",
 	"Wind",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, powerUp], bonus } = module.exports;
+		let { element, modifiers: [powerUp], bonus } = module.exports;
 		const pendingPowerUp = { ...powerUp, stacks: powerUp.stacks + (isCrit ? bonus : 0) };
 		targets.forEach(target => {
 			if (user.element === element) {
-				removeModifier(target, elementStagger);
+				target.addStagger("elementMatchAlly");
 			}
 			addModifier(target, pendingPowerUp);
 		})
@@ -21,6 +21,6 @@ module.exports = new GearTemplate("Sweeping Inspiration",
 	})
 ).setTargetingTags({ target: "all", team: "delver" })
 	.setSidegrades("Guarding Inspiration", "Soothing Inspiration")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setBonus(25) // Power Up stacks
 	.setDurability(10);

--- a/source/gear/ironfiststance-base.js
+++ b/source/gear/ironfiststance-base.js
@@ -3,24 +3,28 @@ const { addModifier, removeModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Iron Fist Stance",
 	"Increase Punch damage by @{bonus} and change its type to yours (exit other stances)",
-	"Gain @{mod2Stacks} @{mod2}",
+	"Inflict @{mod1Stacks} @{mod1} on all enemies",
 	"Technique",
 	"Light",
 	200,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, ironFistStance, powerUp] } = module.exports;
+		let { element, modifiers: [ironFistStance, frail] } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
-			addModifier(user, powerUp);
+			adventure.room.enemies.forEach(enemy => {
+				if (enemy.hp > 0) {
+					addModifier(enemy, frail);
+				}
+			})
 		}
 		removeModifier(user, { name: "Floating Mist Stance", stacks: "all", force: true });
 		addModifier(user, ironFistStance);
-		return `${user.getName(adventure.room.enemyIdMap)} enters Iron Fist Stance${isCrit ? " and is Powered Up" : ""}.`;
+		return `${user.getName(adventure.room.enemyIdMap)} enters Iron Fist Stance${isCrit ? " and enemies become Frail" : ""}.`;
 	}
 ).setTargetingTags({ target: "self", team: "any" })
 	.setUpgrades("Organic Iron Fist Stance")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Iron Fist Stance", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Iron Fist Stance", stacks: 1 }, { name: "Frail", stacks: 4 })
 	.setBonus(45) // Punch damage boost
 	.setDurability(10);

--- a/source/gear/ironfiststance-organic.js
+++ b/source/gear/ironfiststance-organic.js
@@ -3,23 +3,27 @@ const { addModifier, removeModifier } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Organic Iron Fist Stance",
 	"Increase Punch damage by @{bonus} and change its type to yours (exit other stances), regain 1 durability each room",
-	"Gain @{mod2Stacks} @{mod2}",
+	"Inflict @{mod1Stacks} @{mod1} on all enemies",
 	"Technique",
 	"Light",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, ironFistStance, powerUp] } = module.exports;
+		let { element, modifiers: [ironFistStance, frail] } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
-			addModifier(user, powerUp);
+			adventure.room.enemies.forEach(enemy => {
+				if (enemy.hp > 0) {
+					addModifier(enemy, frail);
+				}
+			})
 		}
 		removeModifier(user, { name: "Floating Mist Stance", stacks: "all", force: true });
 		addModifier(user, ironFistStance);
-		return `${user.getName(adventure.room.enemyIdMap)} enters Iron Fist Stance${isCrit ? " and is Powered Up" : ""}.`;
+		return `${user.getName(adventure.room.enemyIdMap)} enters Iron Fist Stance${isCrit ? " and enemies become Frail" : ""}.`;
 	}
 ).setTargetingTags({ target: "self", team: "any" })
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Iron Fist Stance", stacks: 1 }, { name: "Power Up", stacks: 25 })
+	.setModifiers({ name: "Iron Fist Stance", stacks: 1 }, { name: "Frail", stacks: 4 })
 	.setBonus(45) // Punch damage boost
 	.setDurability(10);

--- a/source/gear/lance-accelerating.js
+++ b/source/gear/lance-accelerating.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Accelerating Lance",
-	"Strike a foe for @{damage} @{element} damage (double increase from Power Up), then gain @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} @{element} damage (double increase from Power Up), then gain @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, quicken], damage, critBonus } = module.exports;
+		let { element, modifiers: [quicken], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		const powerUpStacks = user.getModifierStacks("Power Up");
 		damage += powerUpStacks;
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Accelerating Lance",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Piercing Lance", "Vigilant Lance")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Quicken", stacks: 1 })
+	.setModifiers({ name: "Quicken", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/lance-base.js
+++ b/source/gear/lance-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil');
+const { dealDamage } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Lance",
 	"Strike a foe for @{damage} @{element} damage (double increase from Power Up)",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Lance",
 	"Earth",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		const powerUpStacks = user.getModifierStacks("Power Up");
 		damage += powerUpStacks;
@@ -23,6 +23,5 @@ module.exports = new GearTemplate("Lance",
 	})
 ).setUpgrades("Accelerating Lance", "Piercing Lance", "Vigilant Lance")
 	.setTargetingTags({ target: "single", team: "enemy" })
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/lance-piercing.js
+++ b/source/gear/lance-piercing.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil');
+const { dealDamage } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Piercing Lance",
 	"Strike a foe for @{damage} @{element} unblockable damage (double increase from Power Up)",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Piercing Lance",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		const powerUpStacks = user.getModifierStacks("Power Up");
 		damage += powerUpStacks;
@@ -23,6 +23,5 @@ module.exports = new GearTemplate("Piercing Lance",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Accelerating Lance", "Vigilant Lance")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/lance-vigilant.js
+++ b/source/gear/lance-vigilant.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Vigilant Lance",
-	"Strike a foe for @{damage} @{element} damage (double increase from Power Up), then gain @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} @{element} damage (double increase from Power Up), then gain @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, vigilance], damage, critBonus } = module.exports;
+		let { element, modifiers: [vigilance], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		const powerUpStacks = user.getModifierStacks("Power Up");
 		damage += powerUpStacks;
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Vigilant Lance",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Accelerating Lance", "Piercing Lance")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 2 })
+	.setModifiers({ name: "Vigilance", stacks: 2 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/lifedrain-base.js
+++ b/source/gear/lifedrain-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage, gainHealth } = require('../util/combatantUtil.js');
+const { dealDamage, gainHealth } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Life Drain",
 	"Strike a foe for @{damage} @{element} damage, then gain @{healing} hp",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Life Drain",
 	"Darkness",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, healing, critBonus } = module.exports;
+		let { element, damage, healing, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			healing *= critBonus;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Life Drain",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Flanking Life Drain", "Reactive Life Drain", "Urgent Life Drain")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setHealing(25);

--- a/source/gear/lifedrain-flanking.js
+++ b/source/gear/lifedrain-flanking.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { addModifier, dealDamage, gainHealth } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Flanking Life Drain",
-	"Strike a foe for @{damage} @{element} damage and inflict @{mod1Stacks} @{mod1}, then gain @{healing} hp",
+	"Strike a foe for @{damage} @{element} damage and inflict @{mod0Stacks} @{mod0}, then gain @{healing} hp",
 	"Healing x@{critBonus}",
 	"Spell",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed], damage, healing, critBonus } = module.exports;
+		let { element, modifiers: [exposed], damage, healing, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			healing *= critBonus;
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Flanking Life Drain",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Reactive Life Drain", "Urgent Life Drain")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 2 })
+	.setModifiers({ name: "Exposed", stacks: 2 })
 	.setDurability(15)
 	.setDamage(75)
 	.setHealing(25);

--- a/source/gear/lifedrain-reactive.js
+++ b/source/gear/lifedrain-reactive.js
@@ -1,6 +1,6 @@
 const { GearTemplate, Move } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, dealDamage, gainHealth } = require('../util/combatantUtil.js');
+const { dealDamage, gainHealth } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reactive Life Drain",
 	"Strike a foe for @{damage} (+@{bonus} if after foe) @{element} damage, then gain @{healing} hp",
@@ -9,7 +9,7 @@ module.exports = new GearTemplate("Reactive Life Drain",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus, healing, critBonus } = module.exports;
+		let { element, damage, bonus, healing, critBonus } = module.exports;
 		const userMove = adventure.room.moves.find(move => move.userReference.team === user.team && move.userReference.index === adventure.getCombatantIndex(user));
 		const targetMove = adventure.room.moves.find(move => move.userReference.team === target.team && move.userReference.index === adventure.getCombatantIndex(target));
 
@@ -17,7 +17,7 @@ module.exports = new GearTemplate("Reactive Life Drain",
 			damage += bonus;
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			healing *= critBonus;
@@ -27,7 +27,6 @@ module.exports = new GearTemplate("Reactive Life Drain",
 	)
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Flanking Life Drain", "Urgent Life Drain")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setHealing(25)

--- a/source/gear/lifedrain-urgent.js
+++ b/source/gear/lifedrain-urgent.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage, gainHealth } = require('../util/combatantUtil.js');
+const { dealDamage, gainHealth } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Urgent Life Drain",
 	"Strike a foe for @{damage} @{element} damage, then gain @{healing} hp with priority",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Urgent Life Drain",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, healing, critBonus } = module.exports;
+		let { element, damage, healing, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			healing *= critBonus;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Urgent Life Drain",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Flanking Life Drain", "Reactive Life Drain")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setHealing(25)

--- a/source/gear/midasstaff-accelerating.js
+++ b/source/gear/midasstaff-accelerating.js
@@ -1,21 +1,21 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accelerating Midas Staff",
-	"Apply @{mod1Stacks} @{mod1} to a combatant, then gain @{mod2Stacks} @{mod2}",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} to a combatant, then gain @{mod1Stacks} @{mod1}",
+	"@{mod0} +@{bonus}",
 	"Trinket",
 	"Water",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, curse, quicken], bonus } = module.exports;
+		let { element, modifiers: [curse, quicken], bonus } = module.exports;
 		const pendingCurse = { ...curse, stacks: curse.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
 			if (target.team === user.team) {
-				removeModifier(target, elementStagger);
+				target.addStagger("elementMatchAlly");
 			} else {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		}
 		addModifier(target, pendingCurse);
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Accelerating Midas Staff",
 	})
 ).setTargetingTags({ target: "single", team: "any" })
 	.setSidegrades("Discounted Midas Staff", "Soothing Midas Staff")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 }, { name: "Quicken", stacks: 1 })
+	.setModifiers({ name: "Curse of Midas", stacks: 1 }, { name: "Quicken", stacks: 1 })
 	.setBonus(1) // Curse of Midas stacks
 	.setDurability(10);

--- a/source/gear/midasstaff-base.js
+++ b/source/gear/midasstaff-base.js
@@ -1,21 +1,21 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Midas Staff",
-	"Apply @{mod1Stacks} @{mod1} to a combatant",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} to a combatant",
+	"@{mod0} +@{bonus}",
 	"Trinket",
 	"Water",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, curse], bonus } = module.exports;
+		let { element, modifiers: [curse], bonus } = module.exports;
 		const pendingCurse = { ...curse, stacks: curse.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
 			if (target.team === user.team) {
-				removeModifier(target, elementStagger);
+				target.addStagger("elementMatchAlly");
 			} else {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		}
 		addModifier(target, pendingCurse);
@@ -23,6 +23,6 @@ module.exports = new GearTemplate("Midas Staff",
 	})
 ).setTargetingTags({ target: "single", team: "any" })
 	.setUpgrades("Accelerating Midas Staff", "Discounted Midas Staff", "Soothing Midas Staff")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 })
+	.setModifiers({ name: "Curse of Midas", stacks: 1 })
 	.setBonus(1) // Curse of Midas stacks
 	.setDurability(10);

--- a/source/gear/midasstaff-discounted.js
+++ b/source/gear/midasstaff-discounted.js
@@ -1,21 +1,21 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Discounted Midas Staff",
-	"Apply @{mod1Stacks} @{mod1} to a combatant",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} to a combatant",
+	"@{mod0} +@{bonus}",
 	"Trinket",
 	"Water",
 	100,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, curse], bonus } = module.exports;
+		let { element, modifiers: [curse], bonus } = module.exports;
 		const pendingCurse = { ...curse, stacks: curse.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
 			if (target.team === user.team) {
-				removeModifier(target, elementStagger);
+				target.addStagger("elementMatchAlly");
 			} else {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		}
 		addModifier(target, pendingCurse);
@@ -23,6 +23,6 @@ module.exports = new GearTemplate("Discounted Midas Staff",
 	})
 ).setTargetingTags({ target: "single", team: "any" })
 	.setSidegrades("Accelerating Midas Staff", "Soothing Midas Staff")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 })
+	.setModifiers({ name: "Curse of Midas", stacks: 1 })
 	.setBonus(1) // Curse of Midas stacks
 	.setDurability(10);

--- a/source/gear/midasstaff-soothing.js
+++ b/source/gear/midasstaff-soothing.js
@@ -1,21 +1,21 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, removeModifier } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Soothing Midas Staff",
-	"Apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to a combatant",
-	"@{mod1} +@{bonus}",
+	"Apply @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to a combatant",
+	"@{mod0} +@{bonus}",
 	"Trinket",
 	"Water",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, curse, regen], bonus } = module.exports;
+		let { element, modifiers: [curse, regen], bonus } = module.exports;
 		const pendingCurse = { ...curse, stacks: curse.stacks + (isCrit ? bonus : 0) };
 		if (user.element === element) {
 			if (target.team === user.team) {
-				removeModifier(target, elementStagger);
+				target.addStagger("elementMatchAlly");
 			} else {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		}
 		addModifier(target, pendingCurse);
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Soothing Midas Staff",
 	})
 ).setTargetingTags({ target: "single", team: "any" })
 	.setSidegrades("Accelerating Midas Staff", "Discounted Midas Staff")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Curse of Midas", stacks: 1 }, { name: "Regen", stacks: 2 })
+	.setModifiers({ name: "Curse of Midas", stacks: 1 }, { name: "Regen", stacks: 2 })
 	.setBonus(1) // Curse of Midas stacks
 	.setDurability(10);

--- a/source/gear/morningstar-base.js
+++ b/source/gear/morningstar-base.js
@@ -1,26 +1,26 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, dealDamage } = require('../util/combatantUtil');
+const { dealDamage } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Morning Star",
-	"Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage",
+	"Strike a foe applying @{stagger} and @{damage} @{element} damage",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Light",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, stagger], damage, critBonus } = module.exports;
+		let { element, stagger, damage, critBonus } = module.exports;
 		let pendingDamage = damage;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			pendingDamage *= critBonus;
 		}
-		addModifier(target, stagger);
+		target.addStagger(stagger);
 		return `${dealDamage([target], user, pendingDamage, false, element, adventure)} ${target.getName(adventure.room.enemyIdMap)} is Staggered.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
+	.setStagger(2)
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/pistol-base.js
+++ b/source/gear/pistol-base.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier, getCombatantWeaknesses } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Pistol",
-	"Strike a foe for @{damage} @{element} damage, give a random ally @{mod1Stacks} @{mod1} if the foe is weak to @{element}",
+	"Strike a foe for @{damage} @{element} damage, give a random ally @{mod0Stacks} @{mod0} if the foe is weak to @{element}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Earth",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { damage, critBonus, element, modifiers: [elementStagger, powerUp] } = module.exports;
+		let { damage, critBonus, element, modifiers: [powerUp] } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (getCombatantWeaknesses(target).includes(element)) {
 			const damageText = dealDamage([target], user, damage * (isCrit ? critBonus : 1), false, element, adventure);
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Pistol",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Double Pistol", "Duelist's Pistol")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 30 })
+	.setModifiers({ name: "Power Up", stacks: 30 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/pistol-double.js
+++ b/source/gear/pistol-double.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier, getCombatantWeaknesses } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Double Pistol",
-	"Strike a foe for @{damage} @{element} damage, give 2 random allies @{mod1Stacks} @{mod1} if the foe is weak to @{element}",
+	"Strike a foe for @{damage} @{element} damage, give 2 random allies @{mod0Stacks} @{mod0} if the foe is weak to @{element}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { damage, critBonus, element, modifiers: [elementStagger, powerUp] } = module.exports;
+		let { damage, critBonus, element, modifiers: [powerUp] } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (getCombatantWeaknesses(target).includes(element)) {
 			const damageText = dealDamage([target], user, damage * (isCrit ? critBonus : 1), false, element, adventure);
@@ -26,6 +26,6 @@ module.exports = new GearTemplate("Double Pistol",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Duelist's Pistol")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 30 })
+	.setModifiers({ name: "Power Up", stacks: 30 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/pistol-duelists.js
+++ b/source/gear/pistol-duelists.js
@@ -2,19 +2,19 @@ const { GearTemplate } = require("../classes");
 const { needsLivingTargets } = require("../shared/actionComponents");
 const { dealDamage, addModifier, getCombatantWeaknesses } = require("../util/combatantUtil");
 module.exports = new GearTemplate("Duelist's Pistol",
-	"Strike a foe for @{damage} (+@{bonus} if only attacker) @{element} damage, give a random ally @{mod1Stacks} @{mod1} if the foe is weak to @{element}",
+	"Strike a foe for @{damage} (+@{bonus} if only attacker) @{element} damage, give a random ally @{mod0Stacks} @{mod0} if the foe is weak to @{element}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { damage, bonus, critBonus, element, modifiers: [elementStagger, powerUp] } = module.exports;
+		let { damage, bonus, critBonus, element, modifiers: [powerUp] } = module.exports;
 		const targetIndex = adventure.getCombatantIndex(target);
 		const userIndex = adventure.getCombatantIndex(user);
 		const isLoneAttacker = !adventure.room.moves.some(move => !(move.userReference.team === user.team && move.userReference.index === userIndex) && move.targets.some(moveTarget => moveTarget.team === target.team && moveTarget.index === targetIndex));
 		let pendingDamage = damage + (isLoneAttacker ? bonus : 0);
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (getCombatantWeaknesses(target).includes(element)) {
 			const damageText = dealDamage([target], user, pendingDamage * (isCrit ? critBonus : 1), false, element, adventure);
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Duelist's Pistol",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Double Pistol")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 30 })
+	.setModifiers({ name: "Power Up", stacks: 30 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(75);

--- a/source/gear/poisontorrent-base.js
+++ b/source/gear/poisontorrent-base.js
@@ -2,21 +2,21 @@ const { GearTemplate } = require('../classes');
 const { addModifier } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Poison Torrent",
-	"Inflict @{mod1Stacks} @{mod1} on all foes",
-	"@{mod1} x@{critBonus}",
+	"Inflict @{mod0Stacks} @{mod0} on all foes",
+	"@{mod0} x@{critBonus}",
 	"Spell",
 	"Water",
 	200,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, poison], critBonus } = module.exports;
+		let { element, modifiers: [poison], critBonus } = module.exports;
 		targets.forEach(target => {
 			addModifier(target, { name: "Poison", stacks: poison.stacks * (isCrit ? critBonus : 1) })
 			if (user.element === element) {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 		})
 		return `${targets.map(target => target.getName(adventure.room.enemyIdMap)).join(", ")} was Poisoned.`;
 	}
 ).setTargetingTags({ target: "all", team: "enemy" })
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 2 })
+	.setModifiers({ name: "Poison", stacks: 2 })
 	.setDurability(15);

--- a/source/gear/potionkit-base.js
+++ b/source/gear/potionkit-base.js
@@ -1,5 +1,4 @@
 const { GearTemplate } = require('../classes');
-const { removeModifier } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Block Potion",
@@ -21,9 +20,9 @@ module.exports = new GearTemplate("Potion Kit",
 	"Water",
 	200,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], critBonus } = module.exports;
+		let { element, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		const randomPotion = rollablePotions[adventure.generateRandomNumber(rollablePotions.length, "battle")];
 		if (isCrit) {
@@ -36,6 +35,5 @@ module.exports = new GearTemplate("Potion Kit",
 	}
 ).setTargetingTags({ target: "none", team: "none" })
 	.setUpgrades("Organic Potion Kit", "Reinforced Potion Kit", "Urgent Potion Kit")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setFlavorText({ name: "Possible Potions", value: rollablePotions.join(", ") });

--- a/source/gear/potionkit-organic.js
+++ b/source/gear/potionkit-organic.js
@@ -1,5 +1,4 @@
 const { GearTemplate } = require('../classes');
-const { removeModifier } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Block Potion",
@@ -22,9 +21,9 @@ module.exports = new GearTemplate("Organic Potion Kit",
 	"Water",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], critBonus } = module.exports;
+		let { element, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		const randomPotion = rollablePotions[adventure.generateRandomNumber(rollablePotions.length, "battle")];
 		if (isCrit) {
@@ -37,6 +36,5 @@ module.exports = new GearTemplate("Organic Potion Kit",
 	}
 ).setTargetingTags({ target: "none", team: "none" })
 	.setSidegrades("Reinforced Potion Kit", "Urgent Potion Kit")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setFlavorText({ name: "Possible Potions", value: rollablePotions.join(", ") });

--- a/source/gear/potionkit-reinforced.js
+++ b/source/gear/potionkit-reinforced.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { removeModifier, addBlock } = require('../util/combatantUtil');
+const { addBlock } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Block Potion",
@@ -22,9 +22,9 @@ module.exports = new GearTemplate("Reinforced Potion Kit",
 	"Water",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, critBonus } = module.exports;
+		let { element, block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		const randomPotion = rollablePotions[adventure.generateRandomNumber(rollablePotions.length, "battle")];
 		addBlock(user, block);
@@ -38,7 +38,6 @@ module.exports = new GearTemplate("Reinforced Potion Kit",
 	}
 ).setTargetingTags({ target: "none", team: "none" })
 	.setSidegrades("Organic Potion Kit", "Urgent Potion Kit")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setBlock(75)
 	.setFlavorText({ name: "Possible Potions", value: rollablePotions.join(", ") });

--- a/source/gear/potionkit-urgent.js
+++ b/source/gear/potionkit-urgent.js
@@ -1,5 +1,4 @@
 const { GearTemplate } = require('../classes');
-const { removeModifier } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Block Potion",
@@ -21,9 +20,9 @@ module.exports = new GearTemplate("Urgent Potion Kit",
 	"Water",
 	350,
 	(targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], critBonus } = module.exports;
+		let { element, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		const randomPotion = rollablePotions[adventure.generateRandomNumber(rollablePotions.length, "battle")];
 		if (isCrit) {
@@ -36,7 +35,6 @@ module.exports = new GearTemplate("Urgent Potion Kit",
 	}
 ).setTargetingTags({ target: "none", team: "none" })
 	.setSidegrades("Organic Potion Kit", "Reinforced Potion Kit")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setPriority(1)
 	.setFlavorText({ name: "Possible Potions", value: rollablePotions.join(", ") });

--- a/source/gear/powerfromwrath-base.js
+++ b/source/gear/powerfromwrath-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, payHP, dealDamage } = require('../util/combatantUtil');
+const { payHP, dealDamage } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Power from Wrath",
 	"Pay @{hpCost} to strike a foe for @{damage} @{element} damage (greatly increases with your missing hp)",
@@ -8,11 +8,11 @@ module.exports = new GearTemplate("Power from Wrath",
 	"Darkness",
 	200,
 	([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, hpCost } = module.exports;
+		let { element, damage, hpCost } = module.exports;
 		const furiousness = (user.maxHP - user.hp) / user.maxHP + 1;
 		let pendingDamage = damage * furiousness;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			pendingDamage *= 2;
@@ -20,7 +20,6 @@ module.exports = new GearTemplate("Power from Wrath",
 		return `${payHP(user, hpCost, adventure)}${dealDamage([target], user, pendingDamage, false, element, adventure)}`;
 	}
 ).setTargetingTags({ target: "single", team: "enemy" })
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setHPCost(40)
 	.setDamage(75);

--- a/source/gear/sabotagekit-base.js
+++ b/source/gear/sabotagekit-base.js
@@ -10,12 +10,12 @@ module.exports = new GearTemplate("Sabotage Kit",
 	"Earth",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [slow, elementStagger, critSlow] } = module.exports;
+		let { element, modifiers: [slow, critSlow] } = module.exports;
 		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
 		const weaknessPool = elementsList(ineligibleWeaknesses);
 		const rolledWeakness = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			addModifier(target, critSlow);
@@ -32,6 +32,6 @@ module.exports = new GearTemplate("Sabotage Kit",
 	})
 ).setUpgrades("Long Sabotage Kit")
 	.setTargetingTags({ target: "single", team: "enemy" })
-	.setModifiers({ name: "Slow", stacks: 2 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 4 })
+	.setModifiers({ name: "Slow", stacks: 2 }, { name: "Slow", stacks: 4 })
 	.setDurability(15)
 	.setFlavorText({ name: "Eligible Weaknesses", value: "The rolled weakness won't be one of the target's resistances or existing weaknesses" });

--- a/source/gear/sabotagekit-long.js
+++ b/source/gear/sabotagekit-long.js
@@ -10,12 +10,12 @@ module.exports = new GearTemplate("Long Sabotage Kit",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [slow, elementStagger, critSlow] } = module.exports;
+		let { element, modifiers: [slow, critSlow] } = module.exports;
 		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
 		const weaknessPool = elementsList(ineligibleWeaknesses);
 		const rolledWeakness = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			addModifier(target, critSlow);
@@ -31,6 +31,6 @@ module.exports = new GearTemplate("Long Sabotage Kit",
 		return `${target.getName(adventure.room.enemyIdMap)} is Slowed${weaknessPool.length > 0 ? `, and gains ${rolledWeakness}` : ""}.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
-	.setModifiers({ name: "Slow", stacks: 3 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 5 })
+	.setModifiers({ name: "Slow", stacks: 3 }, { name: "Slow", stacks: 5 })
 	.setDurability(15)
 	.setFlavorText({ name: "Eligible Weaknesses", value: "The rolled weakness won't be one of the target's resistances or existing weaknesses" });

--- a/source/gear/scutum-base.js
+++ b/source/gear/scutum-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier } = require('../util/combatantUtil.js');
+const { addBlock } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Scutum",
 	"Grant @{block} block to an ally and yourself",
@@ -9,10 +9,10 @@ module.exports = new GearTemplate("Scutum",
 	"Fire",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, critBonus } = module.exports;
+		let { element, block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
-			removeModifier(user, elementStagger);
+			target.addStagger("elementMatchAlly");
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -23,6 +23,5 @@ module.exports = new GearTemplate("Scutum",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setUpgrades("Guarding Scutum", "Sweeping Scutum", "Vigilant Scutum")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setBlock(75);

--- a/source/gear/scutum-guarding.js
+++ b/source/gear/scutum-guarding.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addBlock, removeModifier } = require('../util/combatantUtil.js');
+const { addBlock } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Guarding Scutum",
 	"Grant @{block} block to an ally and @{bonus} block to yourself",
@@ -9,12 +9,12 @@ module.exports = new GearTemplate("Guarding Scutum",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, bonus, critBonus } = module.exports;
+		let { element, block, bonus, critBonus } = module.exports;
 		let selfBlock = bonus;
 		let targetBlock = block;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
-			removeModifier(user, elementStagger);
+			target.addStagger("elementMatchAlly");
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			selfBlock *= critBonus;
@@ -26,7 +26,6 @@ module.exports = new GearTemplate("Guarding Scutum",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Sweeping Scutum", "Vigilant Scutum")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setBlock(100)
 	.setBonus(75);

--- a/source/gear/scutum-sweeping.js
+++ b/source/gear/scutum-sweeping.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier } = require('../util/combatantUtil.js');
+const { addBlock } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sweeping Scutum",
 	"Grant @{block} block to all allies (including yourself)",
@@ -9,17 +9,17 @@ module.exports = new GearTemplate("Sweeping Scutum",
 	"Fire",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], block, critBonus } = module.exports;
+		let { element, block, critBonus } = module.exports;
 		if (isCrit) {
 			block *= critBonus;
 		}
 		addBlock(user, block);
 		if (user.element === element) {
-			removeModifier(user, elementStagger);
+			user.addStagger("elementMatchAlly");
 		}
 		targets.forEach(target => {
 			if (user.element === element) {
-				removeModifier(target, elementStagger);
+				target.addStagger("elementMatchAlly");
 			}
 			addBlock(target, block);
 		})
@@ -27,6 +27,5 @@ module.exports = new GearTemplate("Sweeping Scutum",
 	})
 ).setTargetingTags({ target: "all", team: "delver" })
 	.setSidegrades("Guarding Scutum", "Vigilant Scutum")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setBlock(75);

--- a/source/gear/scutum-vigilant.js
+++ b/source/gear/scutum-vigilant.js
@@ -1,18 +1,18 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addBlock, removeModifier } = require('../util/combatantUtil.js');
+const { addBlock } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Vigilant Scutum",
-	"Grant @{block} block to an ally and yourself and gain @{mod1Stacks} @{mod1}",
+	"Grant @{block} block to an ally and yourself and gain @{mod0Stacks} @{mod0}",
 	"Block x@{critBonus}",
 	"Armor",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, vigilance], block, critBonus } = module.exports;
+		let { element, modifiers: [vigilance], block, critBonus } = module.exports;
 		if (user.element === element) {
-			removeModifier(target, elementStagger);
-			removeModifier(user, elementStagger);
+			target.addStagger("elementMatchAlly");
+			user.addStagger("elementMatchAlly");
 		}
 		if (isCrit) {
 			block *= critBonus;
@@ -25,6 +25,6 @@ module.exports = new GearTemplate("Vigilant Scutum",
 	})
 ).setTargetingTags({ target: "single", team: "delver" })
 	.setSidegrades("Guarding Scutum", "Sweeping Scutum")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Vigilance", stacks: 1 })
+	.setModifiers({ name: "Vigilance", stacks: 1 })
 	.setDurability(15)
 	.setBlock(75);

--- a/source/gear/scythe-base.js
+++ b/source/gear/scythe-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Scythe",
 	"Strike a foe for @{damage} @{element} damage; instant death if foe is at or below @{bonus} hp",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Scythe",
 	"Darkness",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus: hpThreshold, critBonus } = module.exports;
+		let { element, damage, bonus: hpThreshold, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			hpThreshold *= critBonus;
@@ -25,7 +25,6 @@ module.exports = new GearTemplate("Scythe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Lethal Scythe", "Piercing Scythe", "Toxic Scythe")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(99); // execute threshold

--- a/source/gear/scythe-lethal.js
+++ b/source/gear/scythe-lethal.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Lethal Scythe",
 	"Strike a foe for @{damage} @{element} damage; instant death if foe is at or below @{bonus} hp",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Lethal Scythe",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus: hpThreshold, critBonus } = module.exports;
+		let { element, damage, bonus: hpThreshold, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			hpThreshold *= critBonus;
@@ -25,7 +25,6 @@ module.exports = new GearTemplate("Lethal Scythe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Piercing Scythe", "Toxic Scythe")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(99) // execute threshold

--- a/source/gear/scythe-piercing.js
+++ b/source/gear/scythe-piercing.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Piercing Scythe",
 	"Strike a foe for @{damage} @{element} unblockable damage; instant death if foe is at or below @{bonus} hp",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Piercing Scythe",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus: hpThreshold, critBonus } = module.exports;
+		let { element, damage, bonus: hpThreshold, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			hpThreshold *= critBonus;
@@ -25,7 +25,6 @@ module.exports = new GearTemplate("Piercing Scythe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Lethal Scythe", "Toxic Scythe")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(99); // execute threshold

--- a/source/gear/scythe-toxic.js
+++ b/source/gear/scythe-toxic.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { addModifier, dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Scythe",
-	"Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} @{element} damage; instant death if foe is at or below @{bonus} hp",
+	"Strike a foe applying @{mod0Stacks} @{mod0} and @{damage} @{element} damage; instant death if foe is at or below @{bonus} hp",
 	"Instant death threshold x@{critBonus}",
 	"Weapon",
 	"Darkness",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, poison], damage, bonus: hpThreshold, critBonus } = module.exports;
+		let { element, modifiers: [poison], damage, bonus: hpThreshold, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			hpThreshold *= critBonus;
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Toxic Scythe",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Lethal Scythe", "Piercing Scythe")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 3 })
+	.setModifiers({ name: "Poison", stacks: 3 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(99); // execute threshold

--- a/source/gear/shortsword-accelerating.js
+++ b/source/gear/shortsword-accelerating.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accelerating Shortsword",
-	"Strike a foe for @{damage} @{element} damage, then apply @{mod1Stacks} @{mod1} to the foe and @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to yourself",
+	"Strike a foe for @{damage} @{element} damage, then apply @{mod0Stacks} @{mod0} to the foe and @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to yourself",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed, quicken], damage, critBonus } = module.exports;
+		let { element, modifiers: [exposed, quicken], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Accelerating Shortsword",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Toxic Shortsword")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 }, { name: "Quicken", stacks: 1 })
+	.setModifiers({ name: "Exposed", stacks: 1 }, { name: "Quicken", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/shortsword-base.js
+++ b/source/gear/shortsword-base.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Shortsword",
-	"Strike a foe for @{damage} @{element} damage, then apply @{mod1Stacks} @{mod1} to both the foe and yourself",
+	"Strike a foe for @{damage} @{element} damage, then apply @{mod0Stacks} @{mod0} to both the foe and yourself",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed], damage, critBonus } = module.exports;
+		let { element, modifiers: [exposed], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -23,6 +23,6 @@ module.exports = new GearTemplate("Shortsword",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Accelerating Shortsword", "Toxic Shortsword")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 })
+	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/shortsword-toxic.js
+++ b/source/gear/shortsword-toxic.js
@@ -3,15 +3,15 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Shortsword",
-	"Strike a foe for @{damage} @{element} damage, then apply @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} to the foe and @{mod1Stacks} @{mod1} to yourself",
+	"Strike a foe for @{damage} @{element} damage, then apply @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to the foe and @{mod0Stacks} @{mod0} to yourself",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Fire",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, exposed, poison], damage, critBonus } = module.exports;
+		let { element, modifiers: [exposed, poison], damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -24,6 +24,6 @@ module.exports = new GearTemplate("Toxic Shortsword",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Accelerating Shortsword")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Exposed", stacks: 1 }, { name: "Poison", stacks: 3 })
+	.setModifiers({ name: "Exposed", stacks: 1 }, { name: "Poison", stacks: 3 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/sickle-base.js
+++ b/source/gear/sickle-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sickle",
 	"Strike a foe for @{damage} (+5% foe max hp) @{element} damage",
@@ -9,10 +9,10 @@ module.exports = new GearTemplate("Sickle",
 	"Water",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		damage += (0.05 * target.maxHP);
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,6 +21,5 @@ module.exports = new GearTemplate("Sickle",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Hunter's Sickle", "Sharpened Sickle", "Toxic Sickle")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/sickle-hunters.js
+++ b/source/gear/sickle-hunters.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Hunter's Sickle",
 	"Strike a foe for @{damage} (+5% foe max hp) @{element} damage, gain @{bonus}g on kill",
@@ -9,10 +9,10 @@ module.exports = new GearTemplate("Hunter's Sickle",
 	"Water",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus, bonus: bonusBounty } = module.exports;
+		let { element, damage, critBonus, bonus: bonusBounty } = module.exports;
 		damage += (0.05 * target.maxHP);
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -26,7 +26,6 @@ module.exports = new GearTemplate("Hunter's Sickle",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Sharpened Sickle", "Toxic Sickle")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(15); // gold

--- a/source/gear/sickle-sharpened.js
+++ b/source/gear/sickle-sharpened.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents.js');
-const { addModifier, dealDamage } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sharpened Sickle",
 	"Strike a foe for @{damage} (+5% foe max hp) @{element} damage",
@@ -9,10 +9,10 @@ module.exports = new GearTemplate("Sharpened Sickle",
 	"Water",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, critBonus } = module.exports;
+		let { element, damage, critBonus } = module.exports;
 		damage += (0.05 * target.maxHP);
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -21,6 +21,5 @@ module.exports = new GearTemplate("Sharpened Sickle",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Hunter's Sickle", "Toxic Sickle")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(125);

--- a/source/gear/sickle-toxic.js
+++ b/source/gear/sickle-toxic.js
@@ -3,16 +3,16 @@ const { needsLivingTargets } = require('../shared/actionComponents.js');
 const { addModifier, dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Sickle",
-	"Strike a foe applying @{mod1Stacks} @{mod1} and @{damage} (+5% foe max hp) @{element} damage",
+	"Strike a foe applying @{mod0Stacks} @{mod0} and @{damage} (+5% foe max hp) @{element} damage",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Water",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, poison], damage, critBonus } = module.exports;
+		let { element, modifiers: [poison], damage, critBonus } = module.exports;
 		damage += (0.05 * target.maxHP);
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -27,6 +27,6 @@ module.exports = new GearTemplate("Toxic Sickle",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Hunter's Sickle", "Sharpened Sickle")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Poison", stacks: 3 })
+	.setModifiers({ name: "Poison", stacks: 3 })
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/spear-base.js
+++ b/source/gear/spear-base.js
@@ -1,25 +1,25 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Spear",
 	"Strike a foe for @{damage} @{element} damage",
-	"Also inflict @{mod1Stacks} @{mod1}",
+	"Also inflict @{stagger}",
 	"Weapon",
 	"Wind",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, critStagger], damage } = module.exports;
+		let { element, stagger, damage } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
-			addModifier(target, critStagger);
+			target.addStagger(stagger);
 		}
 		return dealDamage([target], user, damage, false, element, adventure);
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Lethal Spear", "Reactive Spear", "Sweeping Spear")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
+	.setStagger(2)
 	.setDurability(15)
 	.setDamage(100);

--- a/source/gear/spear-lethal.js
+++ b/source/gear/spear-lethal.js
@@ -1,26 +1,26 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Lethal Spear",
 	"Strike a foe for @{damage} @{element} damage",
-	"Damage x@{critBonus}, also inflict @{mod1Stacks} @{mod1}",
+	"Damage x@{critBonus}, also inflict @{stagger}",
 	"Weapon",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, critStagger], damage, critBonus } = module.exports;
+		let { element, stagger, damage, critBonus } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
-			addModifier(target, critStagger);
+			target.addStagger(stagger);
 		}
 		return dealDamage([target], user, damage, false, element, adventure);
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Reactive Spear", "Sweeping Spear")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
+	.setStagger(2)
 	.setDurability(15)
 	.setDamage(100);

--- a/source/gear/spear-reactive.js
+++ b/source/gear/spear-reactive.js
@@ -1,15 +1,15 @@
 const { GearTemplate, Move } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reactive Spear",
 	"Strike a foe for @{damage} (+@{bonus} if after foe) @{element} damage",
-	"Also inflict @{mod1Stacks} @{mod1}",
+	"Also inflict @{stagger}",
 	"Weapon",
 	"Wind",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, critStagger], damage, bonus } = module.exports;
+		let { element, stagger, damage, bonus } = module.exports;
 		const userMove = adventure.room.moves.find(move => move.userReference.team === user.team && move.userReference.index === adventure.getCombatantIndex(user));
 		const targetMove = adventure.room.moves.find(move => move.userReference.team === target.team && move.userReference.index === adventure.getCombatantIndex(target));
 
@@ -17,16 +17,16 @@ module.exports = new GearTemplate("Reactive Spear",
 			damage += bonus;
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
-			addModifier(target, critStagger);
+			target.addStagger(stagger);
 		}
 		return dealDamage([target], user, damage, false, element, adventure);
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Lethal Spear", "Sweeping Spear")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
+	.setStagger(2)
 	.setDurability(15)
 	.setDamage(100)
 	.setBonus(75); // damage

--- a/source/gear/spear-sweeping.js
+++ b/source/gear/spear-sweeping.js
@@ -1,27 +1,27 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sweeping Spear",
 	"Strike all foes for @{damage} @{element} damage",
-	"Also inflict @{mod1Stacks} @{mod1}",
+	"Also inflict @{stagger}",
 	"Weapon",
 	"Wind",
 	350,
 	needsLivingTargets((targets, user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, critStagger], damage } = module.exports;
+		let { element, stagger, damage } = module.exports;
 		targets.map(target => {
 			if (user.element === element) {
-				addModifier(target, elementStagger);
+				target.addStagger("elementMatchFoe");
 			}
 			if (isCrit) {
-				addModifier(target, critStagger);
+				target.addStagger(stagger);
 			}
 		})
 		return dealDamage(targets, user, damage, false, element, adventure);
 	})
 ).setTargetingTags({ target: "all", team: "enemy" })
 	.setSidegrades("Lethal Spear", "Reactive Spear")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
+	.setStagger(2)
 	.setDurability(15)
 	.setDamage(75);

--- a/source/gear/sunflare-accelerating.js
+++ b/source/gear/sunflare-accelerating.js
@@ -3,25 +3,26 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accelerating Sun Flare",
-	"Inflict @{mod1Stacks} @{mod1} on a foe, then gain @{mod2Stacks} @{mod2} with priority",
-	"Also inflict @{mod3Stacks} @{mod3}",
+	"Inflict @{stagger} on a foe, then gain @{mod0Stacks} @{mod0} with priority",
+	"Also inflict @{mod1Stacks} @{mod1}",
 	"Technique",
 	"Light",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, stagger, quicken, slow] } = module.exports;
+		let { element, modifiers: [quicken, slow], stagger } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			addModifier(target, slow);
 		}
-		addModifier(target, stagger);
+		target.addStagger(stagger);
 		addModifier(user, quicken);
 		return `${user.getName(adventure.room.enemyIdMap)} is Quickened. ${target.getName(adventure.room.enemyIdMap)} is Staggered${isCrit ? ` and Slowed` : ""}.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Evasive Sun Flare", "Tormenting Sun Flare")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Quicken", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Quicken", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setStagger(2)
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/sunflare-base.js
+++ b/source/gear/sunflare-base.js
@@ -3,24 +3,25 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sun Flare",
-	"Inflict @{mod1Stacks} @{mod1} on a foe with priority",
-	"Also inflict @{mod2Stacks} @{mod2}",
+	"Inflict @{stagger} on a foe with priority",
+	"Also inflict @{mod0Stacks} @{mod0}",
 	"Technique",
 	"Light",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, stagger, slow] } = module.exports;
+		let { element, modifiers: [slow], stagger } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			addModifier(target, slow);
 		}
-		addModifier(target, stagger);
+		target.addStagger(stagger)
 		return `${target.getName(adventure.room.enemyIdMap)} is Staggered${isCrit ? " and Slowed" : ""}.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Accelerating Sun Flare", "Evasive Sun Flare", "Tormenting Sun Flare")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Slow", stacks: 2 })
+	.setStagger(2)
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/sunflare-evasive.js
+++ b/source/gear/sunflare-evasive.js
@@ -3,25 +3,26 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Evasive Sun Flare",
-	"Inflict @{mod1Stacks} @{mod1} on a foe and gain @{mod2Stacks} @{mod2} with priority",
-	"Also inflict @{mod3Stacks} @{mod3}",
+	"Inflict @{stagger} on a foe and gain @{mod0Stacks} @{mod0} with priority",
+	"Also inflict @{mod1Stacks} @{mod1}",
 	"Technique",
 	"Light",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, stagger, evade, slow] } = module.exports;
+		let { element, modifiers: [evade, slow], stagger } = module.exports;
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			addModifier(target, slow);
 		}
-		addModifier(target, stagger);
+		target.addStagger(stagger);
 		addModifier(user, evade);
 		return `${user.getName(adventure.room.enemyIdMap)} prepares to Evade. ${target.getName(adventure.room.enemyIdMap)} is Staggered${isCrit ? ` and Slowed` : ""}.`;
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Accelerating Sun Flare", "Tormenting Sun Flare")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Evade", stacks: 2 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Slow", stacks: 2 })
+	.setStagger(2)
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/sunflare-tormenting.js
+++ b/source/gear/sunflare-tormenting.js
@@ -4,22 +4,22 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Tormenting Sun Flare",
-	"Inflict @{mod1Stacks} @{mod1} on a foe and duplicate its debuffs with priority",
-	"Also inflict @{mod2Stacks} @{mod2}",
+	"Inflict @{stagger} on a foe and duplicate its debuffs with priority",
+	"Also inflict @{mod0Stacks} @{mod0}",
 	"Technique",
 	"Light",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, stagger, slow] } = module.exports;
+		let { element, modifiers: [slow], stagger } = module.exports;
 		for (const modifier in target.modifiers) {
 			if (isDebuff(modifier)) {
 				addModifier(target, { name: modifier, stacks: 1 });
 			}
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
-		addModifier(target, stagger);
+		target.addStagger(stagger);
 		if (isCrit) {
 			addModifier(target, slow);
 			return `${target.getName(adventure.room.enemyIdMap)} is Staggered, their debuffs are duplicated, and they're slowed.`;
@@ -29,6 +29,7 @@ module.exports = new GearTemplate("Tormenting Sun Flare",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Accelerating Sun Flare", "Evasive Sun Flare")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 2 })
+	.setModifiers({ name: "Slow", stacks: 2 })
+	.setStagger(2)
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/warcry-base.js
+++ b/source/gear/warcry-base.js
@@ -2,8 +2,8 @@ const { GearTemplate } = require('../classes');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("War Cry",
-	"Inflict @{mod1Stacks} @{mod1} on a foe and all foes with Exposed",
-	"@{mod1} +@{bonus}",
+	"Inflict @{stagger} on a foe and all foes with Exposed",
+	"Stagger +@{bonus}",
 	"Technique",
 	"Fire",
 	200,
@@ -17,24 +17,24 @@ module.exports = new GearTemplate("War Cry",
 			}
 		})
 
-		let { element, modifiers: [elementStagger, stagger], bonus } = module.exports;
-		let pendingStaggerStacks = stagger.stacks;
+		let { element, stagger, bonus } = module.exports;
+		let pendingStaggerStacks = stagger;
 		if (user.element === element) {
-			pendingStaggerStacks += elementStagger.stacks;
+			pendingStaggerStacks += 2;
 		}
 		if (isCrit) {
 			pendingStaggerStacks += bonus;
 		}
 		targetArray.forEach(target => {
 			if (target.hp > 0) {
-				addModifier(target, { name: "Stagger", stacks: pendingStaggerStacks });
+				target.addStagger(pendingStaggerStacks);
 			}
 		})
 		return `${[...targetSet].join(", ")} ${targetArray.length === 1 ? "is" : "are"} Staggered by the fierce war cry.`;
 	}
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Charging War Cry", "Slowing War Cry", "Tormenting War Cry")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
-	.setBonus(1) // Stagger stacks
+	.setStagger(2)
+	.setBonus(2) // Stagger stacks
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/warcry-charging.js
+++ b/source/gear/warcry-charging.js
@@ -2,8 +2,8 @@ const { GearTemplate } = require('../classes');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Charging War Cry",
-	"Inflict @{mod1Stacks} @{mod1} on a foe and all foes with Exposed then gain @{mod2Stacks} @{mod2}",
-	"@{mod1} +@{bonus}",
+	"Inflict @{stagger} on a foe and all foes with Exposed then gain @{mod0Stacks} @{mod0}",
+	"Stagger +@{bonus}",
 	"Technique",
 	"Fire",
 	350,
@@ -17,17 +17,17 @@ module.exports = new GearTemplate("Charging War Cry",
 			}
 		})
 
-		let { element, modifiers: [elementStagger, stagger, powerup], bonus } = module.exports;
-		let pendingStaggerStacks = stagger.stacks;
+		let { element, modifiers: [powerup], stagger, bonus } = module.exports;
+		let pendingStaggerStacks = stagger;
 		if (user.element === element) {
-			pendingStaggerStacks += elementStagger.stacks;
+			pendingStaggerStacks += 2;
 		}
 		if (isCrit) {
 			pendingStaggerStacks += bonus;
 		}
 		targetArray.forEach(target => {
 			if (target.hp > 0) {
-				addModifier(target, { name: "Stagger", stacks: pendingStaggerStacks });
+				target.addStagger(pendingStaggerStacks);
 			}
 		});
 		addModifier(user, powerup);
@@ -35,7 +35,8 @@ module.exports = new GearTemplate("Charging War Cry",
 	}
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Slowing War Cry", "Tormenting War Cry")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Power Up", stacks: 25 })
-	.setBonus(1) // Stagger stacks
+	.setModifiers({ name: "Power Up", stacks: 25 })
+	.setStagger(2)
+	.setBonus(2) // Stagger stacks
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/warcry-slowing.js
+++ b/source/gear/warcry-slowing.js
@@ -2,8 +2,8 @@ const { GearTemplate } = require('../classes');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Slowing War Cry",
-	"Inflict @{mod1Stacks} @{mod1} and @{mod2Stacks} @{mod2} on a foe and all foes with Exposed",
-	"@{mod1} +@{bonus}",
+	"Inflict @{stagger} and @{mod0Stacks} @{mod0} on a foe and all foes with Exposed",
+	"Stagger +@{bonus}",
 	"Technique",
 	"Fire",
 	350,
@@ -17,17 +17,17 @@ module.exports = new GearTemplate("Slowing War Cry",
 			}
 		})
 
-		let { element, modifiers: [elementStagger, stagger, slow], bonus } = module.exports;
-		let pendingStaggerStacks = stagger.stacks;
+		let { element, modifiers: [slow], stagger, bonus } = module.exports;
+		let pendingStaggerStacks = stagger;
 		if (user.element === element) {
-			pendingStaggerStacks += elementStagger.stacks;
+			pendingStaggerStacks += 2;
 		}
 		if (isCrit) {
 			pendingStaggerStacks += bonus;
 		}
 		targetArray.forEach(target => {
 			if (target.hp > 0) {
-				addModifier(target, { name: "Stagger", stacks: pendingStaggerStacks });
+				target.addStagger(pendingStaggerStacks);
 				addModifier(target, slow);
 			}
 		})
@@ -35,7 +35,8 @@ module.exports = new GearTemplate("Slowing War Cry",
 	}
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Charging War Cry", "Tormenting War Cry")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 1 })
-	.setBonus(1) // Stagger stacks
+	.setModifiers({ name: "Slow", stacks: 1 })
+	.setStagger(2)
+	.setBonus(2) // Stagger stacks
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/warcry-tormenting.js
+++ b/source/gear/warcry-tormenting.js
@@ -2,8 +2,8 @@ const { GearTemplate } = require('../classes');
 const { addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Tormenting War Cry",
-	"Inflict @{mod1Stacks} @{mod1} and duplicate debuffs on a foe and all foes with Exposed",
-	"@{mod1} +@{bonus}",
+	"Inflict @{stagger} and duplicate debuffs on a foe and all foes with Exposed",
+	"Stagger +@{bonus}",
 	"Technique",
 	"Fire", 350,
 	([initialTarget], user, isCrit, adventure) => {
@@ -16,17 +16,17 @@ module.exports = new GearTemplate("Tormenting War Cry",
 			}
 		})
 
-		let { element, modifiers: [elementStagger, stagger], bonus } = module.exports;
-		let pendingStaggerStacks = stagger.stacks;
+		let { element, stagger, bonus } = module.exports;
+		let pendingStaggerStacks = stagger;
 		if (user.element === element) {
-			pendingStaggerStacks += elementStagger.stacks;
+			pendingStaggerStacks += 2;
 		}
 		if (isCrit) {
 			pendingStaggerStacks += bonus;
 		}
 		targetArray.forEach(target => {
 			if (target.hp > 0) {
-				addModifier(target, { name: "Stagger", stacks: pendingStaggerStacks });
+				target.addStagger(pendingStaggerStacks);
 				for (const modifier in target.modifiers) {
 					if (isDebuff(modifier)) {
 						addModifier(target, { name: modifier, stacks: 1 });
@@ -38,7 +38,7 @@ module.exports = new GearTemplate("Tormenting War Cry",
 	}
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Charging War Cry", "Slowing War Cry")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Stagger", stacks: 1 })
-	.setBonus(1) // Stagger stacks
+	.setStagger(2)
+	.setBonus(2) // Stagger stacks
 	.setDurability(15)
 	.setPriority(1);

--- a/source/gear/warhammer-base.js
+++ b/source/gear/warhammer-base.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Warhammer",
 	"Strike a foe for @{damage} (+@{bonus} if foe is currently stunned) @{element} damage",
@@ -9,12 +9,12 @@ module.exports = new GearTemplate("Warhammer",
 	"Earth",
 	200,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus, critBonus } = module.exports;
-		if (target.getModifierStacks("Stun") > 0) {
+		let { element, damage, bonus, critBonus } = module.exports;
+		if (target.isStunned) {
 			damage += bonus;
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -23,7 +23,6 @@ module.exports = new GearTemplate("Warhammer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setUpgrades("Piercing Warhammer", "Reactive Warhammer", "Slowing Warhammer")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(75); // damage

--- a/source/gear/warhammer-piercing.js
+++ b/source/gear/warhammer-piercing.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Piercing Warhammer",
 	"Strike a foe for @{damage} (+@{bonus} if foe is currently stunned) unblockable @{element} damage",
@@ -9,12 +9,12 @@ module.exports = new GearTemplate("Piercing Warhammer",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger], damage, bonus, critBonus } = module.exports;
-		if (target.getModifierStacks("Stun") > 0) {
+		let { element, damage, bonus, critBonus } = module.exports;
+		if (target.isStunned) {
 			damage += bonus;
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -23,7 +23,6 @@ module.exports = new GearTemplate("Piercing Warhammer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Reactive Warhammer", "Slowing Warhammer")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(75); // damage

--- a/source/gear/warhammer-reactive.js
+++ b/source/gear/warhammer-reactive.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { needsLivingTargets } = require('../shared/actionComponents');
-const { dealDamage, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reactive Warhammer",
 	"Strike a foe for @{damage} (+@{bonus} if after foe or if foe is currently stunned) @{element} damage",
@@ -9,9 +9,9 @@ module.exports = new GearTemplate("Reactive Warhammer",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		const { element, modifiers: [elementStagger], damage, bonus, critBonus } = module.exports;
+		const { element, damage, bonus, critBonus } = module.exports;
 		let pendingDamage = damage;
-		if (target.getModifierStacks("Stun") > 0) {
+		if (target.isStunned) {
 			pendingDamage += bonus;
 		}
 		const userMove = adventure.room.moves.find(move => move.userReference.team === user.team && move.userReference.index === adventure.getCombatantIndex(user));
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Reactive Warhammer",
 		}
 
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			pendingDamage *= critBonus;
@@ -31,7 +31,6 @@ module.exports = new GearTemplate("Reactive Warhammer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Piercing Warhammer", "Slowing Warhammer")
-	.setModifiers({ name: "Stagger", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(75); // damage

--- a/source/gear/warhammer-slowing.js
+++ b/source/gear/warhammer-slowing.js
@@ -3,19 +3,19 @@ const { needsLivingTargets } = require('../shared/actionComponents');
 const { dealDamage, addModifier } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Slowing Warhammer",
-	"Strike a foe for @{damage} (+@{bonus} if foe is currently stunned) @{element} damage and inflict @{mod1Stacks} @{mod1}",
+	"Strike a foe for @{damage} (+@{bonus} if foe is currently stunned) @{element} damage and inflict @{mod0Stacks} @{mod0}",
 	"Damage x@{critBonus}",
 	"Weapon",
 	"Earth",
 	350,
 	needsLivingTargets(([target], user, isCrit, adventure) => {
-		let { element, modifiers: [elementStagger, slow], damage, bonus, critBonus } = module.exports;
+		let { element, modifiers: [slow], damage, bonus, critBonus } = module.exports;
 
-		if (target.getModifierStacks("Stun") > 0) {
+		if (target.isStunned) {
 			damage += bonus;
 		}
 		if (user.element === element) {
-			addModifier(target, elementStagger);
+			target.addStagger("elementMatchFoe");
 		}
 		if (isCrit) {
 			damage *= critBonus;
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Slowing Warhammer",
 	})
 ).setTargetingTags({ target: "single", team: "enemy" })
 	.setSidegrades("Piercing Warhammer", "Reactive Warhammer")
-	.setModifiers({ name: "Stagger", stacks: 1 }, { name: "Slow", stacks: 1 })
+	.setModifiers({ name: "Slow", stacks: 1 })
 	.setDurability(15)
 	.setDamage(75)
 	.setBonus(75); // damage

--- a/source/modifiers/_modifierDictionary.js
+++ b/source/modifiers/_modifierDictionary.js
@@ -15,6 +15,7 @@ for (const file of [
 	"curse-of-midas.js",
 	"evade.js",
 	"exposed.js",
+	"frail.js",
 	"oblivious.js",
 	"poison.js",
 	"power-down.js",
@@ -23,7 +24,6 @@ for (const file of [
 	"quicken.js",
 	"regen.js",
 	"slow.js",
-	"stagger.js",
 	"stance-floating-mist.js",
 	"stance-iron-fist.js",
 	"stasis.js",
@@ -34,8 +34,7 @@ for (const file of [
 	"weakness-light.js",
 	"weakness-untyped.js",
 	"weakness-water.js",
-	"weakness-wind.js",
-	"stun.js"
+	"weakness-wind.js"
 ]) {
 	/** @type {ModifierTemplate} */
 	const modifier = require(`./${file}`);

--- a/source/modifiers/frail.js
+++ b/source/modifiers/frail.js
@@ -1,0 +1,9 @@
+const { ModifierTemplate } = require("../classes");
+
+module.exports = new ModifierTemplate("Frail",
+	"Take @{stacks*10} damage when Stunned.",
+	false,
+	true,
+	false,
+	1
+);

--- a/source/modifiers/stagger.js
+++ b/source/modifiers/stagger.js
@@ -1,9 +1,0 @@
-const { ModifierTemplate } = require("../classes");
-
-module.exports = new ModifierTemplate("Stagger",
-	"This combatant gets Stunned at @{poise} Stagger. Lose @{roundDecrement} stack per round.",
-	false,
-	false,
-	false,
-	1
-);

--- a/source/modifiers/stun.js
+++ b/source/modifiers/stun.js
@@ -1,9 +1,0 @@
-const { ModifierTemplate } = require("../classes");
-
-module.exports = new ModifierTemplate("Stun",
-	"The combatant's next turn is skipped.",
-	false,
-	false,
-	true,
-	0
-);

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -15,7 +15,7 @@ const { getItem } = require("../items/_itemDictionary");
 const { rollGear, rollItem, getLabyrinthProperty, prerollBoss, rollRoom } = require("../labyrinths/_labyrinthDictionary");
 const { getTurnDecrement } = require("../modifiers/_modifierDictionary");
 
-const { clearBlock, removeModifier, addModifier, dealDamage } = require("../util/combatantUtil");
+const { clearBlock, removeModifier, addModifier, dealModifierDamage } = require("../util/combatantUtil");
 const { getWeaknesses, getEmoji, getOpposite } = require("../util/elementUtil");
 const { renderRoom, updateRoomHeader } = require("../util/embedUtil");
 const { ensuredPathSave } = require("../util/fileUtil");
@@ -302,38 +302,35 @@ function newRound(adventure, thread, lastRoundText) {
 				const critRoll = adventure.generateRandomNumber(max, "battle");
 				combatant.crit = critRoll < threshold;
 
-				// Roll Enemy Moves and Generate Dummy Moves
-				const move = new Move(new CombatantReference(combatant.team, i), "action", combatant.crit)
-					.setSpeedByCombatant(combatant);
-				if (combatant.getModifierStacks("Stun") > 0) {
-					// Dummy move for Stunned combatants
-					move.setName("Stun");
-				} else {
-					if (teamName === "enemy") {
-						if (combatant.archetype !== "@{clone}") {
-							const enemyTemplate = getEnemy(combatant.archetype);
-							let actionName = combatant.nextAction;
-							if (actionName === "random") {
-								const actionPool = Object.keys(enemyTemplate.actions);
-								actionName = actionPool[adventure.generateRandomNumber(actionPool.length, "battle")];
-							}
-							if (actionName === "a random protocol") {
-								const actionPool = Object.keys(enemyTemplate.actions).filter(actionName => actionName.includes("Protocol"));
-								actionName = actionPool[adventure.generateRandomNumber(actionPool.length, "battle")];
-							}
-							move.setName(actionName);
-							move.setPriority(enemyTemplate.actions[move.name].priority)
-							enemyTemplate.actions[actionName].selector(combatant, adventure).forEach(({ team, index }) => {
-								move.addTarget(new CombatantReference(team, index));
-							})
-							combatant.nextAction = enemyTemplate.actions[actionName].next(actionName);
-						} else {
-							move.setName("@{clone}");
+				// Roll Enemy Moves
+				if (teamName === "enemy") {
+					if (combatant.archetype !== "@{clone}") {
+						const enemyTemplate = getEnemy(combatant.archetype);
+						let actionName = combatant.nextAction;
+						if (actionName === "random") {
+							const actionPool = Object.keys(enemyTemplate.actions);
+							actionName = actionPool[adventure.generateRandomNumber(actionPool.length, "battle")];
 						}
+						if (actionName === "a random protocol") {
+							const actionPool = Object.keys(enemyTemplate.actions).filter(actionName => actionName.includes("Protocol"));
+							actionName = actionPool[adventure.generateRandomNumber(actionPool.length, "battle")];
+						}
+						const move = new Move(new CombatantReference(combatant.team, i), "action", combatant.crit)
+							.setName(actionName)
+							.setSpeedByCombatant(combatant)
+							.setPriority(enemyTemplate.actions[move.name].priority);
+						enemyTemplate.actions[actionName].selector(combatant, adventure).forEach(({ team, index }) => {
+							move.addTarget(new CombatantReference(team, index));
+						});
+						adventure.room.moves.push(move);
+						combatant.nextAction = enemyTemplate.actions[actionName].next(actionName);
+					} else {
+						adventure.room.moves.push(
+							new Move(new CombatantReference(combatant.team, i), "action", combatant.crit)
+								.setName("@{clone}")
+								.setSpeedByCombatant(combatant)
+						);
 					}
-				}
-				if (move.name) {
-					adventure.room.moves.push(move);
 				}
 
 				// Decrement Modifiers
@@ -373,7 +370,7 @@ function resolveMove(move, adventure) {
 	}
 
 	let moveText = `**${user.getName(adventure.room.enemyIdMap)}** `;
-	if (move.name !== "Stun" && user.getModifierStacks("Stun") < 1) {
+	if (!user.isStunned) {
 		if (move.isCrit) {
 			moveText = `💥${moveText}`;
 		}
@@ -439,7 +436,6 @@ function resolveMove(move, adventure) {
 
 		moveText += `used ${move.name}. ${resultText}${breakText}`;
 	} else {
-		removeModifier(user, { name: "Stun", stacks: "all" });
 		moveText = `💫 ${moveText} is Stunned!`;
 	}
 
@@ -454,7 +450,7 @@ function resolveMove(move, adventure) {
 
 	const regenStacks = user.getModifierStacks("Regen");
 	if (poisonDamage) {
-		moveText += ` ${dealDamage([user], null, poisonDamage, true, "Poison", adventure)}`;
+		moveText += ` ${dealModifierDamage([user], poisonDamage, "Poison", adventure)}`;
 	} else if (regenStacks) {
 		moveText += ` ${gainHealth(user, regenStacks * 10, adventure)}`;
 	}
@@ -494,36 +490,14 @@ function endRound(adventure, thread) {
 	for (const move of adventure.room.moves) {
 		lastRoundText += resolveMove(move, adventure);
 
-		// Check for end of combat
-		if (adventure.lives <= 0) {
-			adventure.room.round++;
-			return thread.send(completeAdventure(adventure, thread, "defeat", lastRoundText));
-		}
-
-		if (adventure.room.enemies.every(enemy => enemy.hp === 0)) {
-			if (adventure.depth === getLabyrinthProperty(adventure.labyrinth, "maxDepth")) {
-				return thread.send(completeAdventure(adventure, thread, "success", lastRoundText));
-			}
-
-			// Gear drops
-			const gearThreshold = 1;
-			const gearMax = 16;
-			if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
-				const tier = rollGearTier(adventure);
-				const droppedGear = rollGear(tier, adventure);
-				adventure.addResource(droppedGear, "gear", "loot", 1);
-			}
-
-			// Item drops
-			const itemThreshold = 1;
-			const itemMax = 8;
-			if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
-				adventure.addResource(rollItem(adventure), "item", "loot", 1);
-			}
-
-			return thread.send(renderRoom(adventure, thread, lastRoundText)).then(message => {
-				adventure.messageIds.battleRound = message.id;
-			});
+		const { payload, type } = checkEndCombat(adventure, thread, lastRoundText);
+		if (payload) {
+			thread.send(payload).then(message => {
+				if (type === "endCombat") {
+					adventure.messageIds.battleRound = message.id;
+				}
+			})
+			return;
 		}
 
 		// remove Slow and Quicken
@@ -532,7 +506,77 @@ function endRound(adventure, thread) {
 		removeModifier(moveUser, { name: "Quicken", stacks: 1, force: true });
 	}
 	adventure.room.moves = [];
+
+	/** @type {Combatant[]} */
+	const combatants = adventure.delvers.concat(adventure.room.enemies);
+	for (const combatant of combatants) {
+		if (combatant.isStunned) {
+			combatant.isStunned = false;
+			combatant.stagger = 0;
+		} else if (combatant.stagger >= combatant.poise) {
+			combatant.isStunned = true;
+
+			if ("Progress" in combatant.modifiers) {
+				combatant.modifiers.Progress = Math.ceil(combatant.getModifierStacks("Progress") * 0.8);
+			}
+
+			if ("Frail" in combatant.modifiers) {
+				lastRoundText += dealModifierDamage([combatant], combatant.modifiers.Frail * 25, "Frail", adventure);
+				removeModifier(combatant, { name: "Frail", stacks: "all" });
+
+				const { payload, type } = checkEndCombat(adventure, thread, lastRoundText);
+				if (payload) {
+					thread.send(payload).then(message => {
+						if (type === "endCombat") {
+							adventure.messageIds.battleRound = message.id;
+						}
+					})
+					return;
+				}
+			}
+		} else {
+			combatant.addStagger(-1);
+		}
+	}
+
 	newRound(adventure, thread, lastRoundText);
+}
+
+/**
+ * @param {Adventure} adventure
+ * @param {ThreadChannel} thread
+ * @param {string} lastRoundText
+ */
+function checkEndCombat(adventure, thread, lastRoundText) {
+	if (adventure.lives <= 0) {
+		adventure.room.round++;
+		return { payload: completeAdventure(adventure, thread, "defeat", lastRoundText), type: "adventureDefeat" };
+	}
+
+	if (adventure.room.enemies.every(enemy => enemy.hp === 0)) {
+		if (adventure.depth === getLabyrinthProperty(adventure.labyrinth, "maxDepth")) {
+			return { payload: completeAdventure(adventure, thread, "success", lastRoundText), type: "adventureSuccess" };
+		}
+
+		// Gear drops
+		const gearThreshold = 1;
+		const gearMax = 16;
+		if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
+			const tier = rollGearTier(adventure);
+			const droppedGear = rollGear(tier, adventure);
+			adventure.addResource(droppedGear, "gear", "loot", 1);
+		}
+
+		// Item drops
+		const itemThreshold = 1;
+		const itemMax = 8;
+		if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
+			adventure.addResource(rollItem(adventure), "item", "loot", 1);
+		}
+
+		return { payload: renderRoom(adventure, thread, lastRoundText), type: "endCombat" };
+	}
+	return { type: "continueCombat" };
 }
 
 /** The round ends when all combatants have readied all their moves

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -26,7 +26,7 @@ const potlTips = [
 	"Combatants lose their next turn (Stun) when their Stagger reaches their Poise.",
 	"Using items has priority.",
 	"Gear that matches your element removes 1 Stagger on allies.",
-	"Gear that matches your element adds 1 Stagger on foes.",
+	"Gear that matches your element adds 2 Stagger on foes.",
 	"Combatant speed varies every round.",
 	"Damage is capped to 500 in one attack without any Power Up."
 ];
@@ -321,7 +321,7 @@ function inspectSelfPayload(delver, gearCapacity) {
 	const embed = new EmbedBuilder().setColor(getColor(delver.element))
 		.setAuthor(randomAuthorTip())
 		.setTitle(`${delver.getName()} the ${delver.archetype}`)
-		.setDescription(`${generateTextBar(delver.hp, delver.maxHP, 11)} ${delver.hp}/${delver.maxHP} HP\nYour ${getEmoji(delver.element)} moves add 1 Stagger to enemies and remove 1 Stagger from allies.`);
+		.setDescription(`${generateTextBar(delver.hp, delver.maxHP, 11)} ${delver.hp}/${delver.maxHP} HP\nStagger: ${generateTextBar(delver.stagger, delver.stagger, delver.stagger)}\nYour ${getEmoji(delver.element)} moves add 2 Stagger to enemies and remove 1 Stagger from allies.`);
 	if (delver.block > 0) {
 		embed.addFields({ name: "Block", value: delver.block.toString() })
 	}


### PR DESCRIPTION
Summary
-------
- make Stagger and Stun combatant properties instead of modifiers
- combatant Stagger can't change while Stunned
- Stun check moved to between rounds
- double Poise and Stagger sources, leave per round falloff and matching element removal at 1
- added Frail debuff
- created `dealModifierDamage` for Poison and Frail

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)

Issue
-----
Closes #17 