### PR TITLE
#69: add challenge Unlabelled Placebos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 - New Debuff: Frail - Deals damage when the bearer is Stunned
 - Iron Fist Stance crits now apply Frail to all enemies instead of granting the user Power Up
 - Some enemies's poise now scales with party size
+- New Challenge: Placebos - Items have a chance to do nothing
 - Tweaked room rarities, largely to make Battles and Events more common
 ## Prophets of the Labyrinth Version 0.12.0:
 - Reintroduced Light and Darkness elements

--- a/source/challenges/_challengeDictionary.js
+++ b/source/challenges/_challengeDictionary.js
@@ -7,7 +7,8 @@ for (const file of [
 	"blindavarice.js",
 	"cantholdallthisvalue.js",
 	"restless.js",
-	"rushing.js"
+	"rushing.js",
+	"unlabelledplacebos.js"
 ]) {
 	/** @type {ChallengeTemplate} */
 	const challenge = require(`./${file}`);

--- a/source/challenges/unlabelledplacebos.js
+++ b/source/challenges/unlabelledplacebos.js
@@ -1,0 +1,15 @@
+const { ChallengeTemplate } = require("../classes");
+
+module.exports = new ChallengeTemplate("Unlabelled Placebos",
+	"Items only have a 1/@{intensity} chance of having their effect for @{duration} rooms. Afterwards gain @{reward} gold.",
+	2
+).setDuration(3)
+	.setScoreMultiplier(1.1)
+	.setReward(250)
+	.setCompleteEffect(
+		function (adventure, thread) {
+			const { reward } = adventure.challenges[module.exports.name];
+			adventure.gainGold(reward);
+			thread.send({ content: `Having completed *${module.exports.name}*, the party gains ${reward} gold!` });
+		}
+	);

--- a/source/items/_itemDictionary.js
+++ b/source/items/_itemDictionary.js
@@ -13,6 +13,7 @@ for (const file of [
 	"healthpotion.js",
 	"inkypotion.js",
 	"oblivionsalt.js",
+	"placebo.js",
 	"quickpepper.js",
 	"regenroot.js",
 	"repairkit.js",

--- a/source/items/placebo.js
+++ b/source/items/placebo.js
@@ -1,0 +1,12 @@
+const { ItemTemplate } = require("../classes");
+const { selectNone } = require("../shared/actionComponents");
+
+module.exports = new ItemTemplate("Placebo",
+	"Does nothing (on purpose).",
+	"Untyped",
+	30,
+	selectNone,
+	(targets, user, isCrit, adventure) => {
+		return "But nothing happened!";
+	}
+);

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -419,7 +419,14 @@ function resolveMove(move, adventure) {
 				moveText = `${getEmoji(getGearProperty(move.name, "element"))} ${moveText}`;
 				break;
 			case "item":
-				const { effect: itemEffect, element } = getItem(move.name);
+				let isPlacebo = false;
+				if (move.userReference.team === "delver") {
+					const placeboDillution = adventure.getChallengeIntensity("Unlabelled Placebos");
+					if (placeboDillution > 0) {
+						isPlacebo = (placeboDillution - 1) === adventure.generateRandomNumber(placeboDillution, "battle");
+					}
+				}
+				const { effect: itemEffect, element } = getItem(isPlacebo ? "Placebo" : move.name);
 				effect = itemEffect;
 				if (move.userReference.team !== "enemy") {
 					adventure.items[move.name]--;


### PR DESCRIPTION
Summary
-------
- add challenge Unlabelled Placebos
  - changed name to sound cooler
  - set challenge to 3 room duration, after which challenge completion grants 250g; having a windowed duration may influence routing decisions in interesting ways (switch back to global if not effective on routing decisions)

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)

Issue
-----
Closes #69