### PR TITLE
#111: delver combat levels

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,11 @@
 # Prophets of the Labyrinth Change Log
 ## Prophets of the Labyrinth v0.14.0:
+- New Gear: Wise Chainmail
 - Combined event rooms "Elemental Research" and "HP Redistribution" into "Imp Contract Faire"
 - New Gear: Prismatic Blast, Vexing Prismatic Blast
 - Crystal Shard (artifact) now increases range of Spells--durability saving effect is now on the new Weapon Polish artifact, which applies to Weapons
+- Delvers now levelup after combat, increasing their stats (1 level for normal battles, 3 levels for artifact guardians, 5 levels for final bosses)
+- New Artifact: Manual Manual
 ## Prophets of the Labyrinth v0.13.0:
 - New Gear: Refreshing Breeze, Shattering Sabotage Kit, Harmful Corrosion, Shattering Corrosion, Wolf Ring, Surpassing Wolf Ring, Swift Wolf Ring, Harmful Poison Torrent, Ice Bolt, Scarf, Hearty Scarf, Chainmail
 - Reworked Thick Cloak to Accurate Cloak

--- a/source/archetypes/_archetype_blueprint.js
+++ b/source/archetypes/_archetype_blueprint.js
@@ -3,6 +3,13 @@ const { ArchetypeTemplate } = require("../classes");
 module.exports = new ArchetypeTemplate("name",
 	"description",
 	"Untyped",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	[],
 	(embed, adventure) => {
 

--- a/source/archetypes/assassin.js
+++ b/source/archetypes/assassin.js
@@ -5,6 +5,13 @@ const { getEmoji, getResistances } = require("../util/elementUtil");
 module.exports = new ArchetypeTemplate("Assassin",
 	"They'll be able to predict which combatants will critically hit and assess combatant elemental affinities, lining up massive damage with thier Daggers.",
 	"Wind",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Daggers", "Cloak"],
 	(embed, adventure) => {
 		adventure.room.enemies.filter(combatant => combatant.hp > 0).concat(adventure.delvers).forEach(combatant => {

--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -5,6 +5,13 @@ const { generateTextBar } = require("../util/textUtil.js");
 module.exports = new ArchetypeTemplate("Chemist",
 	"They'll be able to assess combatant modifiers and hp levels. They'll also be able to make items with their Potion Kit.",
 	"Water",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Sickle", "Potion Kit"],
 	(embed, adventure) => {
 		adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0).forEach(combatant => {

--- a/source/archetypes/detective.js
+++ b/source/archetypes/detective.js
@@ -5,6 +5,13 @@ const { getEmoji, getResistances } = require("../util/elementUtil");
 module.exports = new ArchetypeTemplate("Detective",
 	"They'll be able to predict which combatants will critically hit and assess combatant elemental affinities and even induce weaknesses on foes with their Sabotage Kit.",
 	"Earth",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Pistol", "Sabotage Kit"],
 	(embed, adventure) => {
 		adventure.room.enemies.filter(combatant => combatant.hp > 0).concat(adventure.delvers).forEach(combatant => {

--- a/source/archetypes/hemomancer.js
+++ b/source/archetypes/hemomancer.js
@@ -4,6 +4,13 @@ const { generateTextBar } = require("../util/textUtil");
 module.exports = new ArchetypeTemplate("Hemomancer",
 	"They'll be able to predict the order combatants will act in and their how much Stagger to Stun them. They'll also be able to redirect enemy attacks with Blood Aegis.",
 	"Darkness",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Life Drain", "Blood Aegis"],
 	(embed, adventure) => {
 		const activeCombatants = adventure.room.enemies.filter(enemy => enemy.hp > 0)

--- a/source/archetypes/knight.js
+++ b/source/archetypes/knight.js
@@ -4,6 +4,13 @@ const { listifyEN } = require("../util/textUtil");
 module.exports = new ArchetypeTemplate("Knight",
 	"They'll be able to predict who enemies are targeting with which moves. They'll gain Power Up for protecting allies with their Buckler too.",
 	"Earth",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Lance", "Buckler"],
 	(embed, adventure) => {
 		adventure.room.moves.forEach(({ userReference, targets, name, priority }) => {

--- a/source/archetypes/legionnaire.js
+++ b/source/archetypes/legionnaire.js
@@ -4,6 +4,13 @@ const { listifyEN } = require("../util/textUtil");
 module.exports = new ArchetypeTemplate("Legionnaire",
 	"They'll be able to predict who enemies are targeting with which moves. They'll be able to coodinate for big damage by inflicting Exposed on foes with their Shortsword.",
 	"Fire",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Shortsword", "Scutum"],
 	(embed, adventure) => {
 		adventure.room.moves.forEach(({ userReference, targets, name, priority }) => {

--- a/source/archetypes/martialartist.js
+++ b/source/archetypes/martialartist.js
@@ -4,6 +4,13 @@ const { generateTextBar } = require("../util/textUtil");
 module.exports = new ArchetypeTemplate("Martial Artist",
 	"They'll be able to predict the order combatants will act in and their how much Stagger to Stun them. They'll also be able enhance their Punches with various stances.",
 	"Light",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Iron Fist Stance", "Floating Mist Stance"],
 	(embed, adventure) => {
 		const activeCombatants = adventure.room.enemies.filter(enemy => enemy.hp > 0)

--- a/source/archetypes/ritualist.js
+++ b/source/archetypes/ritualist.js
@@ -6,6 +6,13 @@ const { generateTextBar } = require("../util/textUtil");
 module.exports = new ArchetypeTemplate("Ritualist",
 	"They'll be able to assess combatant modifiers and hp levels. They'll also be able to inflict great harm on foes suffering debuffs with their Censer.",
 	"Fire",
+	{
+		maxHPGrowth: 25,
+		powerGrowth: 5,
+		speedGrowth: 0.5,
+		critRateGrowth: 1,
+		poiseGrowth: 0.25
+	},
 	["Censer", "Corrosion"],
 	(embed, adventure) => {
 		adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0).forEach(combatant => {

--- a/source/artifacts/_artifactDictionary.js
+++ b/source/artifacts/_artifactDictionary.js
@@ -23,6 +23,7 @@ for (const file of [
 	"hammerspaceholster.js",
 	"hawktailfeather.js",
 	"healthinsuranceloophole.js",
+	"manualmanual.js",
 	"negativeoneleafclover.js",
 	"oilpainting.js",
 	"phoenixfruitblossom.js",

--- a/source/artifacts/manualmanual.js
+++ b/source/artifacts/manualmanual.js
@@ -1,0 +1,7 @@
+const { ArtifactTemplate } = require("../classes");
+
+module.exports = new ArtifactTemplate("Manual Manual",
+	"Increase the number of levels gained from combat by @{copies}.",
+	"Increase the level boost by 1 per manual",
+	"Untyped"
+).setFlavorText({ name: "*Additional Notes*", value: "*Though written in a lost language, its title appears to be 'Reading for Dummies'.*" });

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -367,12 +367,12 @@ class Enemy extends Combatant {
 
 	/** @returns {number} */
 	getMaxHP() {
-		return this.maxHP;
+		return Math.floor(this.maxHP);
 	}
 
 	/** @returns {number} */
 	getPower() {
-		return this.power + this.getModifierStacks("Power Up") - this.getModifierStacks("Power Down");
+		return Math.floor(this.power + this.getModifierStacks("Power Up") - this.getModifierStacks("Power Down"));
 	}
 
 	/** @param {boolean} includeRoundSpeed */
@@ -389,17 +389,17 @@ class Enemy extends Combatant {
 			const quickenStacks = this.getModifierStacks("Quicken");
 			totalSpeed += quickenStacks * 5;
 		}
-		return Math.ceil(totalSpeed);
+		return Math.floor(totalSpeed);
 	}
 
 	/** @returns {number} */
 	getCritRate() {
-		return this.critRate;
+		return Math.floor(this.critRate);
 	}
 
 	/** @returns {number} */
 	getPoise() {
-		return this.poise;
+		return Math.floor(this.poise);
 	}
 
 	getDamageCap() {

--- a/source/classes/ArchetypeTemplate.js
+++ b/source/classes/ArchetypeTemplate.js
@@ -8,11 +8,12 @@ class ArchetypeTemplate {
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} elementLabel
+	 * @param {{maxHPGrowth: number, powerGrowth: number, speedGrowth: number, critRateGrowth: number, poiseGrowth: number}} growthRates
 	 * @param {string[]} startingGearNames
 	 * @param {(embed: EmbedBuilder, adventure: Adventure ) => EmbedBuilder} predictFunction
 	 * @param {(combatant: Combatant) => string} miniPredictFunction
 	 */
-	constructor(nameInput, descriptionInput, elementLabel, startingGearNames, predictFunction, miniPredictFunction) {
+	constructor(nameInput, descriptionInput, elementLabel, { maxHPGrowth, powerGrowth, speedGrowth, critRateGrowth, poiseGrowth }, startingGearNames, predictFunction, miniPredictFunction) {
 		if (!nameInput) throw new BuildError("Falsy nameInput");
 		if (!descriptionInput) throw new BuildError("Falsy descriptionInput");
 		if (!elementLabel) throw new BuildError("Falsy elementLabel");
@@ -24,6 +25,11 @@ class ArchetypeTemplate {
 		this.description = descriptionInput;
 		this.element = elementLabel;
 		this.startingGear = startingGearNames;
+		this.maxHPGrowth = maxHPGrowth;
+		this.powerGrowth = powerGrowth;
+		this.speedGrowth = speedGrowth;
+		this.critRateGrowth = critRateGrowth;
+		this.poiseGrowth = poiseGrowth;
 		this.predict = predictFunction;
 		this.miniPredict = miniPredictFunction;
 	}

--- a/source/classes/Combatant.js
+++ b/source/classes/Combatant.js
@@ -15,6 +15,7 @@ class Combatant {
 	archetype;
 	/** @type {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} */
 	element;
+	level = 1;
 	maxHP = 300;
 	power = 0;
 	speed = 100;
@@ -103,7 +104,7 @@ class Delver extends Combatant {
 	}
 
 	getMaxHP() {
-		return this.maxHP + this.gear.reduce((totalGearMaxHP, gear) => {
+		return Math.floor(this.maxHP) + this.gear.reduce((totalGearMaxHP, gear) => {
 			if (parseInt(gear.maxHP)) {
 				return totalGearMaxHP + gear.maxHP;
 			} else {
@@ -113,13 +114,13 @@ class Delver extends Combatant {
 	}
 
 	getPower() {
-		return this.power + this.getModifierStacks("Power Up") - this.getModifierStacks("Power Down") + this.gear.reduce((totalPower, gear) => {
+		return Math.floor(this.power + this.getModifierStacks("Power Up") - this.getModifierStacks("Power Down") + this.gear.reduce((totalPower, gear) => {
 			if (parseInt(gear.power)) {
 				return totalPower + gear.power;
 			} else {
 				return totalPower;
 			}
-		}, 0);
+		}, 0));
 	}
 
 	/** @param {boolean} includeRoundSpeed */
@@ -143,27 +144,27 @@ class Delver extends Combatant {
 			const quickenStacks = this.getModifierStacks("Quicken");
 			totalSpeed += quickenStacks * 5;
 		}
-		return Math.ceil(totalSpeed);
+		return Math.floor(totalSpeed);
 	}
 
 	getCritRate() {
-		return this.critRate + this.gear.reduce((totalCritRate, gear) => {
+		return Math.floor(this.critRate + this.gear.reduce((totalCritRate, gear) => {
 			if (parseInt(gear.critRate)) {
 				return totalCritRate + gear.critRate;
 			} else {
 				return totalCritRate;
 			}
-		}, 0);
+		}, 0));
 	}
 
 	getPoise() {
-		return this.poise + this.gear.reduce((totalGearPoise, gear) => {
+		return Math.floor(this.poise + this.gear.reduce((totalGearPoise, gear) => {
 			if (parseInt(gear.poise)) {
 				return totalGearPoise + gear.poise;
 			} else {
 				return totalGearPoise;
 			}
-		}, 0);
+		}, 0));
 	}
 
 	getDamageCap() {

--- a/source/commands/manual/glossary.js
+++ b/source/commands/manual/glossary.js
@@ -61,6 +61,15 @@ async function executeSubcommand(interaction, ...args) {
 				ephemeral: true
 			});
 			break;
+		case "Leveling Up":
+			interaction.reply({
+				embeds: [
+					embedTemplate().setTitle("Leveling Up")
+						.setDescription("Delvers will level up and gain stats after each battle. They'll gain 1 level after normal combat, 3 after artifact guardians, and 5 after final bosses.")
+				],
+				ephemeral: true
+			});
+			break;
 	}
 };
 
@@ -78,7 +87,8 @@ module.exports = {
 					{ name: "Tutorial", value: "Tutorial" },
 					{ name: "Elements", value: "Elements" },
 					{ name: "Stagger", value: "Stagger" },
-					{ name: "Damage Cap", value: "Damage Cap" }
+					{ name: "Damage Cap", value: "Damage Cap" },
+					{ name: "Leveling Up", value: "Leveling Up" }
 				]
 			},
 		]

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -35,6 +35,7 @@ for (const file of [
 	"certainvictory-lethal.js",
 	"certainvictory-reckless.js",
 	"chainmail-base.js",
+	"chainmail-wise.js",
 	"cloak-accelerating.js",
 	"cloak-accurate.js",
 	"cloak-base.js",

--- a/source/gear/chainmail-wise.js
+++ b/source/gear/chainmail-wise.js
@@ -1,13 +1,12 @@
 const { GearTemplate } = require('../classes');
 
-module.exports = new GearTemplate("Chainmail",
-	"Gain @{maxHP} Max HP",
+module.exports = new GearTemplate("Wise Chainmail",
+	"Gain @{maxHP} Max HP. Gain 1 extra level after each battle.",
 	"N/A",
 	"Trinket",
 	"Untyped",
-	200,
+	350,
 	(targets, user, isCrit, adventure) => ""
 ).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setUpgrades("Wise Chainmail")
 	.setDurability(0)
 	.setMaxHP(50);

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -170,14 +170,10 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 			Cursed: [
 			],
 			Common: [
-				"Chainmail",
-				"Scarf",
-				"Wolf Ring"
+				"Chainmail"
 			],
 			Rare: [
-				"Hearty Scarf",
-				"Surpassing Wolf Ring",
-				"Swift Wolf Ring"
+				"Wise Chainmail"
 			]
 		}
 	},

--- a/source/labyrinths/everythingbagel.js
+++ b/source/labyrinths/everythingbagel.js
@@ -208,6 +208,7 @@ module.exports = new LabyrinthTemplate("Everything Bagel",
 				"Wolf Ring"
 			],
 			Rare: [
+				"Wise Chainmail",
 				"Hearty Scarf",
 				"Surpassing Wolf Ring",
 				"Swift Wolf Ring"

--- a/source/rooms/artifactguardian-royalslime.js
+++ b/source/rooms/artifactguardian-royalslime.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("A Slimy Throneroom",
 	"@{adventure}",
 	"A long hall of wavy mirrors sits silently between the party and the door... until a bunch of shadows step out of the mirror and attack the party!",
 	[
+		new ResourceTemplate("3", "internal", "levelsGained"),
 		new ResourceTemplate("1", "loot", "artifact"),
 		new ResourceTemplate("50*n", "loot", "gold")
 	]

--- a/source/rooms/artifactguardian-treasureelemental.js
+++ b/source/rooms/artifactguardian-treasureelemental.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("A windfall of treasure!",
 	"Earth",
 	"Floor to ceiling, gold coins, gems and other valuables are stacked in massive piles. Out of the corner of your eyes, you notice a mass of treasure meld together...",
 	[
+		new ResourceTemplate("3", "internal", "levelsGained"),
 		new ResourceTemplate("1", "loot", "artifact")
 	]
 ).addEnemy("Treasure Elemental", "1");

--- a/source/rooms/battle-bloodtailhawks.js
+++ b/source/rooms/battle-bloodtailhawks.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("Hawk Fight",
 	"Wind",
 	"A flock of birds of prey swoop down looking for a meal.",
 	[
+		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("1.5*25*n", "loot", "gold")
 	]
 ).addEnemy("Bloodtail Hawk", "1.5*n");

--- a/source/rooms/battle-firearrowfrogs.js
+++ b/source/rooms/battle-firearrowfrogs.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("Frog Fight",
 	"Fire",
 	"A blaze of orange and red in the muck the outs itself as a warning sign to a blast of heated mud and venom.",
 	[
+		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("25*n", "loot", "gold")
 	]
 ).addEnemy("Fire-Arrow Frog", "n");

--- a/source/rooms/battle-mechabees.js
+++ b/source/rooms/battle-mechabees.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("Mechabee Fight",
 	"Earth",
 	"Some mechabees charge at you. In addition to starting a fight, it prompts you to wonder if mechabees are more mech or more bee.",
 	[
+		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("25*n", "loot", "gold")
 	]
 ).addEnemy("Mechabee Drone", "n*0.25")

--- a/source/rooms/battle-slimes.js
+++ b/source/rooms/battle-slimes.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("Slime Fight",
 	"@{adventure}",
 	"Some slimes and oozes approach...",
 	[
+		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("25*n", "loot", "gold")
 	]
 ).addEnemy("@{adventure} Slime", "0.5*n")

--- a/source/rooms/battle-tortoises.js
+++ b/source/rooms/battle-tortoises.js
@@ -4,6 +4,7 @@ module.exports = new RoomTemplate("Tortoise Fight",
 	"Earth",
 	"The rocky terrain rises up to reveal a pair of shelled menaces.",
 	[
+		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("80", "loot", "gold")
 	]
 ).addEnemy("Geode Tortoise", "2");

--- a/source/rooms/finalbattle-elkemist.js
+++ b/source/rooms/finalbattle-elkemist.js
@@ -1,7 +1,9 @@
-const { RoomTemplate } = require("../classes");
+const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 module.exports = new RoomTemplate("A Northern Laboratory",
 	"Water",
 	"Flasks, beakers, vials and a myriad unknown substances line the innumerable tables and shelves of this room. An elk wanders from table to whiteboard to shelf, muttering various alchemical formuae to itself and taking absolutely no notice of the party.",
-	[]
+	[
+		new ResourceTemplate("5", "internal", "levelsGained")
+	]
 ).addEnemy("Elkemist", "1");

--- a/source/rooms/finalbattle-mechaqueen.js
+++ b/source/rooms/finalbattle-mechaqueen.js
@@ -1,8 +1,10 @@
-const { RoomTemplate } = require("../classes");
+const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 module.exports = new RoomTemplate("The Hexagon",
 	"Earth",
 	"Myriad six-sided holograms flicker on as you enter the room displaying formations, statistics, and supply information. An alarm blares, and some mechabees (and their queen!) charge you. It dawns on you: they are in fact, more bee than mech.",
-	[]
+	[
+		new ResourceTemplate("5", "internal", "levelsGained")
+	]
 ).addEnemy("Mecha Queen", "1")
 	.addEnemy("Mechabee Drone", "n");

--- a/source/rooms/finalbattle-mirrors.js
+++ b/source/rooms/finalbattle-mirrors.js
@@ -1,7 +1,9 @@
-const { RoomTemplate } = require("../classes");
+const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 module.exports = new RoomTemplate("Hall of Mirrors",
 	"Untyped",
 	"A long hall of wavy mirrors sits silently between the party and the door... until a bunch of shadows step out of the mirror and attack the party!",
-	[]
+	[
+		new ResourceTemplate("5", "internal", "levelsGained")
+	]
 ).addEnemy("@{clone}", "n");

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -158,16 +158,17 @@ function gainHealth(combatant, healing, adventure) {
 	combatant.hp += healing;
 	const loopholeCount = adventure.getArtifactCount("Health Insurance Loophole");
 	let loopholeGold = 0;
-	if (combatant.hp > combatant.getMaxHP()) {
-		combatant.hp = combatant.getMaxHP();
+	const maxHP = combatant.getMaxHP();
+	if (combatant.hp > maxHP) {
+		combatant.hp = maxHP;
 		if (combatant.team === "delver" && loopholeCount > 0) {
-			loopholeGold = (combatant.hp - combatant.getMaxHP()) * loopholeCount;
+			loopholeGold = (combatant.hp - maxHP) * loopholeCount;
 			adventure.gainGold(loopholeGold);
 			adventure.updateArtifactStat("Health Insurance Loophole", "Gold Gained", loopholeGold);
 		}
 	}
 
-	if (combatant.hp === combatant.getMaxHP()) {
+	if (combatant.hp === maxHP) {
 		return `${combatant.getName(adventure.room.enemyIdMap)} was fully healed${loopholeGold > 0 ? ` (${loopholeGold} gold gained)` : ""}!`;
 	} else {
 		return `${combatant.getName(adventure.room.enemyIdMap)} *gained ${healing} hp*.`

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -7,14 +7,16 @@ const { DISCORD_ICON_URL, POTL_ICON_URL, SAFE_DELIMITER, MAX_BUTTONS_PER_ROW, MA
 const { getCompany, setCompany } = require("../orcustrators/companyOrcustrator");
 const { getPlayer, setPlayer } = require("../orcustrators/playerOrcustrator");
 
+const { getArchetype } = require("../archetypes/_archetypeDictionary.js");
 const { getChallenge } = require("../challenges/_challengeDictionary");
 const { getGearProperty, buildGearDescription } = require("../gear/_gearDictionary");
 const { isBuff, isDebuff } = require("../modifiers/_modifierDictionary");
 const { getRoom } = require("../rooms/_roomDictionary");
 
+const { gainHealth } = require("./combatantUtil.js");
 const { getEmoji, getColor } = require("./elementUtil");
 const { generateRoutingRow, generateLootRow } = require("./messageComponentUtil");
-const { ordinalSuffixEN, generateTextBar } = require("./textUtil");
+const { ordinalSuffixEN, generateTextBar, listifyEN } = require("./textUtil");
 
 const discordTips = [
 	"Message starting with @silent don't send notifications; good for when everyone's asleep.",
@@ -62,15 +64,24 @@ function embedTemplate() {
  * @param {string} descriptionOverride
  */
 function renderRoom(adventure, thread, descriptionOverride) {
-	const roomTemplate = getRoom(adventure.room.title);
-	const hasEnemies = adventure.room.enemies;
-	const isCombatVictory = adventure.room.enemies?.every(enemy => enemy.hp === 0);
-
 	const roomEmbed = new EmbedBuilder().setColor(getColor(adventure.room.element))
-		.setAuthor({ name: roomHeaderString(adventure), iconURL: thread.client.user.displayAvatarURL() })
-		.setTitle(`${adventure.room.title}${isCombatVictory ? " - Victory!" : ""}`)
-		.setFooter({ text: `Room #${adventure.depth}${hasEnemies ? ` - Round ${adventure.room.round}` : ""}` });
+		.setAuthor({ name: roomHeaderString(adventure), iconURL: thread.client.user.displayAvatarURL() });
 
+	const isCombatVictory = adventure.room.enemies?.every(enemy => enemy.hp === 0);
+	if (isCombatVictory) {
+		roomEmbed.setTitle(`${adventure.room.title} - Victory!`);
+	} else {
+		roomEmbed.setTitle(adventure.room.title);
+	}
+
+	const hasEnemies = adventure.room.enemies;
+	if (hasEnemies) {
+		roomEmbed.setFooter({ text: `Room #${adventure.depth} - Round ${adventure.room.round}` });
+	} else {
+		roomEmbed.setFooter({ text: `Room #${adventure.depth}` });
+	}
+
+	const roomTemplate = getRoom(adventure.room.title);
 	if (descriptionOverride || roomTemplate) {
 		roomEmbed.setDescription(descriptionOverride || roomTemplate.description.replace("@{roomElement}", adventure.room.element));
 	}
@@ -123,6 +134,73 @@ function renderRoom(adventure, thread, descriptionOverride) {
 			} else {
 				if (isCombatVictory) {
 					components.push(generateLootRow(adventure));
+
+					const baseLevelsGained = adventure.room.resources.levelsGained?.count ?? 0;
+					if (baseLevelsGained > 0) {
+						const fieldPayload = { name: "Level-Up!" };
+						/** @type {Record<number, string[]>} */
+						const levelMap = {};
+						for (const delver of adventure.delvers) {
+							const manualManuallevels = adventure.getArtifactCount("Manual Manual");
+							if (manualManuallevels > 0) {
+								adventure.updateArtifactStat("Manual Manual", "Bonus Levels", manualManuallevels);
+							}
+							const gearLevelBonus = delver.gear.reduce((bonusLevels, currentGear) => {
+								if (currentGear.name.startsWith("Wise")) {
+									return bonusLevels + 1;
+								} else {
+									return bonusLevels;
+								}
+							}, 0);
+							const levelsGained = baseLevelsGained + manualManuallevels + gearLevelBonus;
+							if (levelsGained in levelMap) {
+								levelMap[levelsGained].push(delver.getName());
+							} else {
+								levelMap[levelsGained] = [delver.getName()];
+							}
+							delver.level += levelsGained;
+							const { maxHPGrowth, powerGrowth, speedGrowth, critRateGrowth, poiseGrowth } = getArchetype(delver.archetype);
+							gainHealth(delver, maxHPGrowth * levelsGained, adventure);
+							delver.maxHP += maxHPGrowth * levelsGained;
+							delver.power += powerGrowth * levelsGained;
+							delver.speed += speedGrowth * levelsGained;
+							delver.critRate += critRateGrowth * levelsGained;
+							delver.poise += poiseGrowth * levelsGained;
+						}
+						if (Object.entries(levelMap).length > 1) {
+							fieldPayload.value = Object.entries(levelMap).map(([levelIncrease, delverNames]) => {
+								if (levelIncrease !== baseLevelsGained) {
+									if (delverNames.length === 1) {
+										if (levelIncrease === 1) {
+											return `- ${delverNames[0]} gains 1 level.`;
+										} else {
+											return `- ${delverNames[0]} gains ${levelIncrease} levels.`;
+										}
+									} else {
+										if (levelIncrease === 1) {
+											return `- ${listifyEN(delverNames)} gain 1 level.`;
+										} else {
+											return `- ${listifyEN(delverNames)} gain ${levelIncrease} levels.`;
+										}
+									}
+								}
+							}).join("- \n");
+							if (levelMap[baseLevelsGained].length < adventure.delvers.length) {
+								if (baseLevelsGained === 1) {
+									fieldPayload.value = `\n- Everyone else gains 1 level.`;
+								} else {
+									fieldPayload.value = `\n- Everyone else gains ${baseLevelsGained} levels.`;
+								}
+							}
+						} else {
+							if (baseLevelsGained === 1) {
+								fieldPayload.value = `Everyone gains 1 level.`;
+							} else {
+								fieldPayload.value = `Everyone gains ${baseLevelsGained} levels.`;
+							}
+						}
+						roomEmbed.addFields(fieldPayload);
+					}
 				}
 				roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." });
 				components.push(generateRoutingRow(adventure));

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -160,8 +160,8 @@ function renderRoom(adventure, thread, descriptionOverride) {
 							}
 							delver.level += levelsGained;
 							const { maxHPGrowth, powerGrowth, speedGrowth, critRateGrowth, poiseGrowth } = getArchetype(delver.archetype);
-							gainHealth(delver, maxHPGrowth * levelsGained, adventure);
 							delver.maxHP += maxHPGrowth * levelsGained;
+							gainHealth(delver, maxHPGrowth * levelsGained, adventure);
 							delver.power += powerGrowth * levelsGained;
 							delver.speed += speedGrowth * levelsGained;
 							delver.critRate += critRateGrowth * levelsGained;
@@ -405,7 +405,7 @@ function inspectSelfPayload(delver, gearCapacity, roomHasEnemies) {
 	description += `\nPoise: ${generateTextBar(delver.stagger, delver.getPoise(), delver.getPoise())} Stagger\nPower: ${delver.getPower()}\nSpeed: ${delver.getSpeed(false)}${roomHasEnemies ? ` ${delver.roundSpeed < 0 ? "-" : "+"} ${Math.abs(delver.roundSpeed)} (this round)` : ""}\nCrit Rate: ${delver.getCritRate()}%\n\n*(Your ${getEmoji(delver.element)} moves add 2 Stagger to enemies and remove 1 Stagger from allies.)*`;
 	const embed = new EmbedBuilder().setColor(getColor(delver.element))
 		.setAuthor(randomAuthorTip())
-		.setTitle(`${delver.getName()} the ${delver.archetype}`)
+		.setTitle(`${delver.getName()} the Level ${delver.level} ${delver.archetype}`)
 		.setDescription(description);
 	for (let index = 0; index < gearCapacity; index++) {
 		if (delver.gear[index]) {

--- a/wiki/Element-Themes.md
+++ b/wiki/Element-Themes.md
@@ -177,3 +177,4 @@ Archetypes:
 - Tormenting
 - Vexing
 - Vigilant
+- Wise

--- a/wiki/Gear-Variants.md
+++ b/wiki/Gear-Variants.md
@@ -367,6 +367,12 @@ Adds Vigilance to user
 - Lance (Earth)
 - Scutum (Fire)
 
+### Wise
+Increases levels gained after battle by 1
+
+**Available on**
+- Chainmail (Earth)
+
 ## Unnamed Variants
 - Adds Floating Mist Stance to user (all Floating Mist Stances)
 - Adds Iron Fist Stance to user (all Iron Fist Stances)


### PR DESCRIPTION
Summary
-------
- added combat level system, delvers gain stats after combat
- added Manual Manual
- added Wise Chainmail

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] confirmed end of battle field shows levels gained
- [x] confirmed level up heals
- [x] confirmed normal battles give 1 level and Artifact Guardians give 3 levels
- [x] confirmed levelling up increases delver stats
- [x] proofread the manual entry

Known Issue
--------------
- save happens on room movement (trying to put it in level up logic causes a circular dependency), so levels can be lost if bot is restarted before team exits combat room

Issue
-----
Closes #111