### PR TITLE
#132: centralize frontend logic in Apple Pie Wishing Well

### DIFF
--- a/source/buttons/stealwishingwellcore.js
+++ b/source/buttons/stealwishingwellcore.js
@@ -1,8 +1,6 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
-const { updateRoomHeader } = require('../util/embedUtil');
-const { EMPTY_SELECT_OPTION_SET } = require('../constants');
+const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "stealwishingwellcore";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -16,27 +14,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		adventure.gainGold(250);
+		delete adventure.room.resources["Wishing Well Core"];
 		setAdventure(adventure);
-		updateRoomHeader(adventure, interaction.message).then(message => {
-			interaction.update({
-				embeds: message.embeds,
-				components: [
-					new ActionRowBuilder().addComponents(
-						new StringSelectMenuBuilder().setCustomId("applepiewishingwell")
-							.setPlaceholder("Wishing well core stolen!")
-							.setOptions(EMPTY_SELECT_OPTION_SET)
-							.setDisabled(true)
-					),
-					new ActionRowBuilder().addComponents(
-						new ButtonBuilder().setCustomId(mainId)
-							.setLabel("+250g")
-							.setEmoji("✔️")
-							.setStyle(ButtonStyle.Primary)
-							.setDisabled(true)
-					),
-					message.components[2]
-				]
-			});
-		});
+		interaction.update(renderRoom(adventure, interaction.channel));
 	}
 );

--- a/source/rooms/event-applepiewishingwell.js
+++ b/source/rooms/event-applepiewishingwell.js
@@ -1,37 +1,61 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder } = require("discord.js");
-const { RoomTemplate } = require("../classes");
+const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 const { EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 module.exports = new RoomTemplate("Apple Pie Wishing Well",
 	"Light",
 	"In the center of the room sits a wishing well with a glowing crystal core. Pinned to a post in front of the well are instructions indicating that tossing an item into the well will float it back as a delicious apple pie.",
-	[],
+	[
+		new ResourceTemplate("1", "internal", "Wishing Well Core")
+	],
 	function (roomEmbed, adventure) {
-		const itemSelectRow = new ActionRowBuilder();
-		const partyItems = Object.entries(adventure.items);
-		if (partyItems.length > 0) {
-			itemSelectRow.addComponents(
-				new StringSelectMenuBuilder().setCustomId("applepiewishingwell")
-					.setPlaceholder("Select an item to toss...")
-					.setOptions(partyItems.map(([itemName, count]) => ({ label: itemName, description: `Stock: ${count}`, value: itemName })))
-			);
+		let wellLabel, wellOptions, isWellDisabled, stealEmoji, stealLabel, isStealDisabled;
+		const isCoreIntact = "Wishing Well Core" in adventure.room.resources;
+		if (isCoreIntact) {
+			const partyItems = Object.entries(adventure.items);
+			if (partyItems.length > 0) {
+				wellLabel = "Select an item to toss...";
+				wellOptions = partyItems.map(([itemName, count]) => ({ label: itemName, description: `Stock: ${count}`, value: itemName }));
+				isWellDisabled = false;
+			} else {
+				wellLabel = "No items to toss";
+				wellOptions = EMPTY_SELECT_OPTION_SET;
+				isWellDisabled = true;
+			}
+
+			if ("Well used" in adventure.room.resources) {
+				stealEmoji = "✖️";
+				stealLabel = "Well used";
+				isStealDisabled = true;
+			} else {
+				stealEmoji = "💰";
+				stealLabel = "Steal the core [+250g]";
+				isStealDisabled = false;
+			}
 		} else {
-			itemSelectRow.addComponents(
-				new StringSelectMenuBuilder().setCustomId("applepiewishingwell")
-					.setPlaceholder("No items to toss")
-					.setOptions(EMPTY_SELECT_OPTION_SET)
-					.setDisabled(true)
-			);
+			wellLabel = "Wishing Well Core stolen";
+			wellOptions = EMPTY_SELECT_OPTION_SET;
+			isWellDisabled = true;
+			stealEmoji = "✔️";
+			stealLabel = "+250g";
+			isStealDisabled = true;
 		}
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [
-				itemSelectRow,
+				new ActionRowBuilder().addComponents(
+					new StringSelectMenuBuilder().setCustomId("applepiewishingwell")
+						.setPlaceholder(wellLabel)
+						.setOptions(wellOptions)
+						.setDisabled(isWellDisabled)
+				),
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("stealwishingwellcore")
-						.setLabel("Steal the core [+250g]")
 						.setStyle(ButtonStyle.Primary)
+						.setEmoji(stealEmoji)
+						.setLabel(stealLabel)
+						.setDisabled(isStealDisabled)
 				),
 				generateRoutingRow(adventure)
 			]

--- a/source/selects/applepiewishingwell.js
+++ b/source/selects/applepiewishingwell.js
@@ -1,8 +1,7 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { EMPTY_SELECT_OPTION_SET } = require('../constants');
 const { gainHealth } = require('../util/combatantUtil');
+const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "applepiewishingwell";
 module.exports = new SelectWrapper(mainId, 3000,
@@ -17,25 +16,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 		const [tossedItem] = interaction.values;
 		adventure.decrementItem(tossedItem, 1);
+		adventure.addResource("Well used", "history", "internal", 1);
 		gainHealth(delver, delver.maxHP, adventure);
-		interaction.update({
-			components: [
-				new ActionRowBuilder().addComponents(
-					new StringSelectMenuBuilder().setCustomId(mainId)
-						.setPlaceholder(`${tossedItem} tossed`)
-						.setOptions(EMPTY_SELECT_OPTION_SET)
-						.setDisabled(true)
-				),
-				new ActionRowBuilder().addComponents(
-					new ButtonBuilder().setCustomId("stealwishingwellcore")
-						.setLabel("Core left alone")
-						.setEmoji("✖️")
-						.setStyle(ButtonStyle.Primary)
-						.setDisabled(true)
-				),
-				interaction.message.components[2]
-			]
-		});
-		interaction.channel.send(`The ${tossedItem} becomes an apple pie. ${delver.getName()} is fully healed by the delicious pie.`)
+		interaction.update(renderRoom(adventure, interaction.channel));
+		interaction.channel.send(`The ${tossedItem} becomes an apple pie. **${delver.getName()} is fully healed** by the delicious pie.`)
 	}
 );


### PR DESCRIPTION
Summary
-------
- centralize frontend logic in Apple Pie Wishing Well
- disable steal core option after using wishing well

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] using the wishing well disables the steal option, but allows further uses
- [x] stealing the core disables the use option
- [x] leaving without interacting doesn't cause issues

Issue
-----
Closes #132