### PR TITLE
#138: consolidate frontend logic in Free Repair Kit event

### DIFF
--- a/source/buttons/freerepairkit.js
+++ b/source/buttons/freerepairkit.js
@@ -13,9 +13,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		if (adventure.room.resources["Repair Kit"].count > 0) {
+			delete adventure.room.resources["Repair Kit"];
 			adventure.gainItem("Repair Kit", 1);
-			adventure.room.resources["Repair Kit"].count = 0;
-			adventure.addResource("Repair Kit taken", "history", "internal", 1);
 			interaction.update(renderRoom(adventure, interaction.message.channel)).then(() => {
 				setAdventure(adventure);
 			});

--- a/source/buttons/repairkittinker.js
+++ b/source/buttons/repairkittinker.js
@@ -29,15 +29,15 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		if (adventure.room.resources["Repair Kit"].count > 0) {
+			delete adventure.room.resources["Repair Kit"];
 			const gearIndex = adventure.generateRandomNumber(eligibleGear.length, "general");
 			const [gearToUpgrade, upgradePool] = eligibleGear[gearIndex];
 			const upgradeName = upgradePool[adventure.generateRandomNumber(upgradePool.length, "general")];
+			adventure.addResource(`${delver.name}: ${upgradeName}`, "history", "internal", 1);
 			transformGear(delver, gearIndex, gearToUpgrade, upgradeName);
-			adventure.room.resources["Repair Kit"].count = 0;
 			interaction.update(renderRoom(adventure, interaction.message.channel)).then(() => {
 				setAdventure(adventure);
 			});
-			interaction.channel.send(`**${delver.name}** uses the Repair Kit to upgrade their ${gearToUpgrade} to a **${upgradeName}**.`);
 		} else {
 			interaction.update({ content: ZERO_WIDTH_WHITESPACE });
 		}

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -134,7 +134,7 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["The Score Beggar", "Free Gold?", "Apple Pie Wishing Well", "Twin Pedestals", "Gear Collector"],
+		"Event": ["The Score Beggar", "Free Gold?", "Apple Pie Wishing Well", "Twin Pedestals", "Gear Collector", "Repair Kit, just hanging out"],
 		"Battle": ["Frog Ranch", "Wild Fire-Arrow Frogs"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
 		"Final Battle": ["The Hexagon: Bee Mode", "The Hexagon: Mech Mode", "Confronting the Top Celestial Knight"],

--- a/source/rooms/event-freerepairkit.js
+++ b/source/rooms/event-freerepairkit.js
@@ -6,25 +6,45 @@ module.exports = new RoomTemplate("Repair Kit, just hanging out",
 	"Earth",
 	"There's a Repair Kit hanging in the middle of the room tied to the ceiling by a rope.",
 	[
-		new ResourceTemplate("1", "internal", "Repair Kit").setCostExpression("0")
+		new ResourceTemplate("1", "internal", "Repair Kit")
 	],
 	function (roomEmbed, adventure) {
-		const wasRepairKitTaken = "Repair Kit taken" in adventure.room.resources;
-		const isRepairKitRemaining = adventure.room.resources["Repair Kit"].count > 0;
+		let saveEmoji, saveLabel, tinkerEmoji, tinkerLabel;
+		const isRepairKitRemaining = "Repair Kit" in adventure.room.resources;
+		if (isRepairKitRemaining) {
+			saveEmoji = "🔧";
+			saveLabel = "Save the Repair Kit";
+			tinkerEmoji = "⬆️";
+			tinkerLabel = "Use the Repair Kit for a random random upgrade";
+		} else {
+			const upgradeResource = Object.values(adventure.room.resources).find(resource => resource.name.includes(": "));
+			if (upgradeResource) {
+				const [user, upgrade] = upgradeResource.name.split(": ")
+				saveEmoji = "✖️";
+				saveLabel = "Repair Kit used";
+				tinkerEmoji = "✔️";
+				tinkerLabel = `${upgrade} for ${user}`;
+			} else {
+				saveEmoji = "✔️";
+				saveLabel = "Repair Kit saved";
+				tinkerEmoji = "✖️";
+				tinkerLabel = "Upgrade skipped";
+			}
+		}
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("freerepairkit")
-						.setLabel(isRepairKitRemaining ? "Save the Repair Kit" : wasRepairKitTaken ? "Repair Kit saved" : "Repair Kit used")
-						.setEmoji(isRepairKitRemaining ? "🔧" : wasRepairKitTaken ? "✔️" : "✖️")
-						.setDisabled(!isRepairKitRemaining)
-						.setStyle(ButtonStyle.Primary),
-					new ButtonBuilder().setCustomId("repairkittinker")
-						.setLabel(isRepairKitRemaining ? "Use the Repair Kit for a random random upgrade" : wasRepairKitTaken ? "Repair Kit saved" : "Repair Kit used")
-						.setEmoji(isRepairKitRemaining ? "⬆️" : wasRepairKitTaken ? "✖️" : "✔️")
-						.setDisabled(!isRepairKitRemaining)
 						.setStyle(ButtonStyle.Primary)
+						.setEmoji(saveEmoji)
+						.setLabel(saveLabel)
+						.setDisabled(!isRepairKitRemaining),
+					new ButtonBuilder().setCustomId("repairkittinker")
+						.setStyle(ButtonStyle.Primary)
+						.setEmoji(tinkerEmoji)
+						.setLabel(tinkerLabel)
+						.setDisabled(!isRepairKitRemaining)
 				),
 				generateRoutingRow(adventure)
 			]


### PR DESCRIPTION
Summary
-------
- consolidate frontend logic in Free Repair Kit event

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] buttons are mutually exclusive
- [x] buttons have correct side-effects when used (add Repair Kit, do upgrade)
- [x] buttons switch to correct labels when used
- [x] no issues when leaving room

Issue
-----
Closes #138 