### PR TITLE
#120: fix Rest Sites to reliably record run history

### DIFF
--- a/source/buttons/getgoldonfire.js
+++ b/source/buttons/getgoldonfire.js
@@ -21,7 +21,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		delete adventure.room.resources.gold;
 		// deal damage on 50% chance
 		if (adventure.generateRandomNumber(RN_TABLE_BASE, "general") > (RN_TABLE_BASE / 2)) {
-			adventure.addResource(`Burned: ${interaction.member.displayName}`, "history", "internal", 1);
+			adventure.room.addResource(`Burned: ${interaction.member.displayName}`, "history", "internal", 1);
 			payHP(delver, burnDamage, adventure);
 			interaction.update(renderRoom(adventure, interaction.channel, `A large pile of gold sits quietly in the middle of the room, in a burning pillar of flame.`));
 			if (adventure.lives < 1) {

--- a/source/buttons/repairkittinker.js
+++ b/source/buttons/repairkittinker.js
@@ -29,11 +29,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		if (adventure.room.resources["Repair Kit"].count > 0) {
-			delete adventure.room.resources["Repair Kit"];
+			adventure.room.decrementResource("Repair Kit", "all");
 			const gearIndex = adventure.generateRandomNumber(eligibleGear.length, "general");
 			const [gearToUpgrade, upgradePool] = eligibleGear[gearIndex];
 			const upgradeName = upgradePool[adventure.generateRandomNumber(upgradePool.length, "general")];
-			adventure.addResource(`${delver.name}: ${upgradeName}`, "history", "internal", 1);
+			adventure.room.addResource(`${delver.name}: ${upgradeName}`, "history", "internal", 1);
 			transformGear(delver, gearIndex, gearToUpgrade, upgradeName);
 			interaction.update(renderRoom(adventure, interaction.message.channel)).then(() => {
 				setAdventure(adventure);

--- a/source/buttons/replacegear.js
+++ b/source/buttons/replacegear.js
@@ -19,10 +19,10 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		const discardedName = delver.gear[index].name;
 		delver.gear.splice(index, 1, buildGearRecord(name, "max"));
 		interaction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
-			adventure.room.resources[name].count--;
+			adventure.room.decrementResource(name, 1);
 			adventure.gold -= cost;
 			if (source === "treasure") {
-				adventure.room.resources.roomAction.count--;
+				adventure.room.decrementResource("roomAction", 1);
 			}
 			return roomMessage.edit(renderRoom(adventure, interaction.channel));
 		}).then(() => {

--- a/source/buttons/stealwishingwellcore.js
+++ b/source/buttons/stealwishingwellcore.js
@@ -4,7 +4,7 @@ const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "stealwishingwellcore";
 module.exports = new ButtonWrapper(mainId, 3000,
-	/** Disable wishing well, gain 250g */
+	/** Disable wishing well, gain gold */
 	(interaction, args) => {
 		const adventure = getAdventure(interaction.channelId);
 		const delver = adventure?.delvers.find(delver => delver.id === interaction.user.id);
@@ -13,7 +13,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		adventure.gainGold(250);
+		adventure.gainGold(150);
 		delete adventure.room.resources["Wishing Well Core"];
 		setAdventure(adventure);
 		interaction.update(renderRoom(adventure, interaction.channel));

--- a/source/buttons/trainingdummy.js
+++ b/source/buttons/trainingdummy.js
@@ -1,8 +1,7 @@
 const { ButtonWrapper } = require('../classes');
-const { SAFE_DELIMITER } = require('../constants');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { levelUp } = require('../util/delverUtil');
-const { consumeRoomActions, editButtons } = require('../util/messageComponentUtil');
+const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "trainingdummy";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -16,22 +15,15 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const actionCost = 1;
-		if (adventure.room.resources.roomAction.count < actionCost) {
+		if (!adventure.room.hasResource("roomAction", actionCost)) {
 			interaction.reply({ content: "You don't have time to use the training dummy.", ephemeral: true });
 			return;
 		}
 
 		levelUp(delver, 1, adventure);
-		const { embeds, remainingActions } = consumeRoomActions(adventure, interaction.message.embeds, actionCost);
-		let components = interaction.message.components;
-		if (remainingActions < 1) {
-			const healPercent = Math.trunc(30 * (1 - (adventure.getChallengeIntensity("Restless") / 100)));
-			components = editButtons(components, {
-				[mainId]: { preventUse: true, label: "Some training happened", emoji: "✔️" },
-				[`rest${SAFE_DELIMITER}${healPercent}`]: { preventUse: true, label: "The fire has burned out", emoji: "✔️" }
-			})
-		}
-		interaction.update({ embeds, components }).then(() => {
+		adventure.room.decrementResource("roomAction", actionCost);
+		adventure.room.addResource(`Trained: ${delver.name}`, "history", "internal", 1);
+		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
 			interaction.followUp(`${delver.getName()} leveled up!`);
 			setAdventure(adventure);
 		});

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -261,32 +261,6 @@ class Adventure {
 				return Math.max(100 - (count * 15), 0);
 		}
 	}
-
-	/** Initializes a resource in the room's resources if it's not already present
-	 * @param {string} nameInput Note: all names in the combined pool of gear, artifacts, items, and resources must be unique
-	 * @param {"gear" | "artifact" | "gold" | "scouting" | "roomAction" | "challenge" | "item" | "history"} typeInput
-	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
-	 * @param {number} countInput
-	 * @param {string?} uiGroupInput
-	 * @param {number?} costInput
-	 */
-	addResource(nameInput, typeInput, visibilityInput, countInput, uiGroupInput, costInput) {
-		if (nameInput in this.room.resources) {
-			this.room.resources[nameInput].count += countInput;
-		} else {
-			const resource = {
-				name: nameInput,
-				type: typeInput,
-				visibility: visibilityInput,
-				count: countInput
-			};
-			resource.cost = costInput ?? 0;
-			if (uiGroupInput) {
-				resource.uiGroup = uiGroupInput;
-			}
-			this.room.resources[nameInput] = resource;
-		}
-	}
 };
 
 class Challenge {
@@ -328,6 +302,52 @@ class Room {
 	enemyIdMap = null;
 	/** @type {Record<string, {name: string, type: "gear" | "artifact" | "gold" | "scouting" | "roomAction" | "challenge" | "item" | "history", visibility: "loot" | "always" | "internal", count: number, uiGroup?: string, cost?: number}>} */
 	resources = {};
+
+	/** checks if the given resource has the given count in the room
+	 * @param {string} name
+	 * @param {number?} count
+	 */
+	hasResource(name, count = 0) {
+		return name in this.resources && this.resources[name].count >= count;
+	}
+
+	/** Initializes a resource in the room's resources if it's not already present
+	 * @param {string} nameInput Note: all names in the combined pool of gear, artifacts, items, and resources must be unique
+	 * @param {"gear" | "artifact" | "gold" | "scouting" | "roomAction" | "challenge" | "item" | "history"} typeInput
+	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
+	 * @param {number} countInput
+	 * @param {string?} uiGroupInput
+	 * @param {number?} costInput
+	 */
+	addResource(nameInput, typeInput, visibilityInput, countInput, uiGroupInput, costInput) {
+		if (nameInput in this.resources) {
+			this.resources[nameInput].count += countInput;
+		} else {
+			const resource = {
+				name: nameInput,
+				type: typeInput,
+				visibility: visibilityInput,
+				count: countInput
+			};
+			resource.cost = costInput ?? 0;
+			if (uiGroupInput) {
+				resource.uiGroup = uiGroupInput;
+			}
+			this.resources[nameInput] = resource;
+		}
+	}
+
+	/** decrements a resource's count, deletes if reaching zero
+	 * @param {string} name
+	 * @param {number | "all"} decrement
+	 */
+	decrementResource(name, decrement) {
+		if (decrement === "all" || this.resources[name].count <= decrement) {
+			delete this.resources[name];
+		} else {
+			this.resources[name].count -= decrement;
+		}
+	}
 }
 
 class Enemy extends Combatant {

--- a/source/gear/cauldronstir-base.js
+++ b/source/gear/cauldronstir-base.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Cauldron Stir",
 		}
 		if (isCrit) {
 			const rolledPotion = rollablePotions[adventure.generateRandomNumber(rollablePotions.length, "battle")];
-			adventure.addResource(rolledPotion, "item", "loot", 1);
+			adventure.room.addResource(rolledPotion, "item", "loot", 1);
 			return `${dealDamage([target], user, pendingDamage, false, element, adventure)} ${user.getName(adventure.room.enemyIdMap)} sets a batch of ${rolledPotion} to simmer.`;
 		} else {
 			return dealDamage([target], user, pendingDamage, false, element, adventure);

--- a/source/gear/cauldronstir-toxic.js
+++ b/source/gear/cauldronstir-toxic.js
@@ -29,7 +29,7 @@ module.exports = new GearTemplate("Toxic Cauldron Stir",
 		const addedPoison = addModifier(target, poison);
 		if (isCrit) {
 			const rolledPotion = rollablePotions[adventure.generateRandomNumber(rollablePotions.length, "battle")];
-			adventure.addResource(rolledPotion, "item", "loot", 1);
+			adventure.room.addResource(rolledPotion, "item", "loot", 1);
 			if (addedPoison) {
 				return `${dealDamage([target], user, pendingDamage, false, element, adventure)} ${target.getName(adventure.room.enemyIdMap)} was Poisoned. ${user.getName(adventure.room.enemyIdMap)} sets a batch of ${rolledPotion} to simmer.`;
 			} else {

--- a/source/gear/herbbasket-base.js
+++ b/source/gear/herbbasket-base.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Herb Basket",
 			user.addStagger("elementMatchAlly");
 		}
 		const randomHerb = rollableHerbs[adventure.generateRandomNumber(rollableHerbs.length, "battle")];
-		adventure.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
 		if (isCrit) {
 			return `${user.getName(adventure.room.enemyIdMap)} gathers a double-batch of ${randomHerb}.`;
 		} else {

--- a/source/gear/herbbasket-organic.js
+++ b/source/gear/herbbasket-organic.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Organic Herb Basket",
 			user.addStagger("elementMatchAlly");
 		}
 		const randomHerb = rollableHerbs[adventure.generateRandomNumber(rollableHerbs.length, "battle")];
-		adventure.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
 		if (isCrit) {
 			return `${user.getName(adventure.room.enemyIdMap)} gathers a double-batch of ${randomHerb}.`;
 		} else {

--- a/source/gear/herbbasket-reinforced.js
+++ b/source/gear/herbbasket-reinforced.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Reinforced Herb Basket",
 		}
 		user.protection += protection;
 		const randomHerb = rollableHerbs[adventure.generateRandomNumber(rollableHerbs.length, "battle")];
-		adventure.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
 		if (isCrit) {
 			return `${user.getName(adventure.room.enemyIdMap)} gains protection and gathers a double-batch of ${randomHerb}.`;
 		} else {

--- a/source/gear/herbbasket-urgent.js
+++ b/source/gear/herbbasket-urgent.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Urgent Herb Basket",
 			user.addStagger("elementMatchAlly");
 		}
 		const randomHerb = rollableHerbs[adventure.generateRandomNumber(rollableHerbs.length, "battle")];
-		adventure.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
 		if (isCrit) {
 			return `${user.getName(adventure.room.enemyIdMap)} gathers a double-batch of ${randomHerb}.`;
 		} else {

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -141,7 +141,7 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 
 		// Labyrinth Infrastructure - less customized
 		"Merchant": ["Gear Buying Merchant"],
-		"Rest Site": ["Rest Site: Training Dummy"],
+		"Rest Site": ["Rest Site: Mysterious Challenger", "Rest Site: Training Dummy"],
 		"Workshop": ["Abandoned Forge", "Workshop with Black Box", "Tanning Workshop"],
 		"Treasure": ["Treasure! Artifact or Gear?", "Treasure! Artifact or Gold?", "Treasure! Artifact or Items?", "Treasure! Gear or Items?", "Treasure! Gold or Gear?", "Treasure! Gold or Items?"],
 		"Empty": ["Empty Room"]

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -196,7 +196,7 @@ function nextRoom(roomType, thread) {
 		switch (resourceType) {
 			case "challenge":
 				rollChallenges(Math.min(MAX_SELECT_OPTIONS, count), adventure).forEach(challengeName => {
-					adventure.addResource(challengeName, resourceType, visibility, 1);
+					adventure.room.addResource(challengeName, resourceType, visibility, 1);
 				})
 				break;
 			case "gear":
@@ -206,16 +206,16 @@ function nextRoom(roomType, thread) {
 						tier = rollGearTier(adventure);
 					}
 					const gearName = rollGear(tier, adventure);
-					adventure.addResource(gearName, resourceType, visibility, 1, uiGroup, Math.ceil(parseExpression(unparsedCostExpression ?? "0", getGearProperty(gearName, "cost", resourceType))));
+					adventure.room.addResource(gearName, resourceType, visibility, 1, uiGroup, Math.ceil(parseExpression(unparsedCostExpression ?? "0", getGearProperty(gearName, "cost", resourceType))));
 				}
 				break;
 			case "artifact":
 				const artifact = rollArtifact(adventure);
-				adventure.addResource(artifact, resourceType, visibility, count, uiGroup);
+				adventure.room.addResource(artifact, resourceType, visibility, count, uiGroup);
 				break;
 			case "item":
 				const item = rollItem(adventure);
-				adventure.addResource(item, resourceType, visibility, count, uiGroup, Math.ceil(parseExpression(unparsedCostExpression, getItem(item).cost)));
+				adventure.room.addResource(item, resourceType, visibility, count, uiGroup, Math.ceil(parseExpression(unparsedCostExpression, getItem(item).cost)));
 				break;
 			case "gold":
 				// Randomize loot gold
@@ -223,10 +223,10 @@ function nextRoom(roomType, thread) {
 				if (visibility !== "internal") {
 					goldCount = Math.ceil(count * (90 + adventure.generateRandomNumber(21, "general")) / 100);
 				}
-				adventure.addResource(resourceType, resourceType, visibility, goldCount, uiGroup);
+				adventure.room.addResource(resourceType, resourceType, visibility, goldCount, uiGroup);
 				break;
 			default:
-				adventure.addResource(resourceType, resourceType, visibility, count, uiGroup);
+				adventure.room.addResource(resourceType, resourceType, visibility, count, uiGroup);
 		}
 	}
 
@@ -633,14 +633,14 @@ function checkEndCombat(adventure, thread, lastRoundText) {
 		if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
 			const tier = rollGearTier(adventure);
 			const droppedGear = rollGear(tier, adventure);
-			adventure.addResource(droppedGear, "gear", "loot", 1);
+			adventure.room.addResource(droppedGear, "gear", "loot", 1);
 		}
 
 		// Item drops
 		const itemThreshold = 1;
 		const itemMax = 8;
 		if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
-			adventure.addResource(rollItem(adventure), "item", "loot", 1);
+			adventure.room.addResource(rollItem(adventure), "item", "loot", 1);
 		}
 
 		return { payload: renderRoom(adventure, thread, lastRoundText), type: "endCombat" };

--- a/source/rooms/event-applepiewishingwell.js
+++ b/source/rooms/event-applepiewishingwell.js
@@ -11,10 +11,9 @@ module.exports = new RoomTemplate("Apple Pie Wishing Well",
 	],
 	function (roomEmbed, adventure) {
 		let wellLabel, wellOptions, isWellDisabled, stealEmoji, stealLabel, isStealDisabled;
-		const isCoreIntact = "Wishing Well Core" in adventure.room.resources;
-		if (isCoreIntact) {
+		if (adventure.room.hasResource("Wishing Well Core")) {
 			wellOptions = Object.entries(adventure.items).map(([itemName, count]) => ({ label: itemName, description: `Stock: ${count}`, value: itemName }));
-			isWellDisabled = wellOptions.length > 0;
+			isWellDisabled = wellOptions.length < 1;
 			if (!isWellDisabled) {
 				wellLabel = "Select an item to toss...";
 			} else {
@@ -28,7 +27,7 @@ module.exports = new RoomTemplate("Apple Pie Wishing Well",
 				isStealDisabled = true;
 			} else {
 				stealEmoji = "💰";
-				stealLabel = "Steal the core [+250g]";
+				stealLabel = "Steal the core [+150g]";
 				isStealDisabled = false;
 			}
 		} else {
@@ -36,7 +35,7 @@ module.exports = new RoomTemplate("Apple Pie Wishing Well",
 			wellOptions = EMPTY_SELECT_OPTION_SET;
 			isWellDisabled = true;
 			stealEmoji = "✔️";
-			stealLabel = "+250g";
+			stealLabel = "+150g";
 			isStealDisabled = true;
 		}
 		return {

--- a/source/rooms/event-artifactdupe.js
+++ b/source/rooms/event-artifactdupe.js
@@ -12,9 +12,8 @@ module.exports = new RoomTemplate("Twin Pedestals",
 		new ResourceTemplate("1", "internal", "roomAction")
 	],
 	function (roomEmbed, adventure) {
-		const hasRoomActions = adventure.room.resources.roomAction.count > 0;
 		let duperLabel, duperOptions, isDuperDisabled, pillageLabel, pillageEmoji, isPillageDisabled;
-		if (hasRoomActions) {
+		if (adventure.room.hasResource("roomAction")) {
 			duperOptions = Object.keys(adventure.artifacts).map(artifact => {
 				const count = adventure.getArtifactCount(artifact);
 				return {

--- a/source/rooms/event-gearcollector.js
+++ b/source/rooms/event-gearcollector.js
@@ -10,7 +10,7 @@ module.exports = new RoomTemplate("Gear Collector",
 		new ResourceTemplate("0.5*n", "internal", "roomAction")
 	],
 	function (roomEmbed, adventure) {
-		const isOutOfRoomActions = adventure.room.resources.roomAction.count < 1;
+		const isOutOfRoomActions = !adventure.room.hasResource("roomAction");
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [

--- a/source/rooms/restsite-challenger.js
+++ b/source/rooms/restsite-challenger.js
@@ -12,18 +12,49 @@ module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 	],
 	function (roomEmbed, adventure) {
 		const healPercent = Math.trunc(30 * (1 - (adventure.getChallengeIntensity("Restless") / 100)));
+		let restEmoji, restLabel, challengeEmoji, challengeLabel;
+		const hasRoomActions = adventure.room.hasResource("roomAction");
+		if (hasRoomActions) {
+			restEmoji = "1️⃣";
+			restLabel = `Rest [+${healPercent}% hp]`;
+			challengeEmoji = "1️⃣";
+			challengeLabel = "Take a challenge";
+		} else {
+			const restedResources = Object.values(adventure.room.resources).filter(resource => resource.name.startsWith("Rested: "));
+			if (restedResources.length > 0) {
+				restEmoji = "✔️";
+				restLabel = "The party rested";
+			} else {
+				restEmoji = "✖️";
+				restLabel = "The fire has burned out";
+			}
+			const challengerResources = Object.values(adventure.room.resources).filter(resource => resource.name.startsWith("Challenge taken: "));
+			if (challengerResources.length > 0) {
+				challengeEmoji = "✔️";
+				if (challengerResources.length === 1) {
+					challengeLabel = "New challenge taken";
+				} else {
+					challengeLabel = "New challenges taken";
+				}
+			} else {
+				challengeEmoji = "✖️";
+				challengeLabel = "The challenger is gone";
+			}
+		}
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId(`rest${SAFE_DELIMITER}${healPercent}`)
-						.setLabel(`Rest [+${healPercent}% hp]`)
-						.setEmoji("1️⃣")
-						.setStyle(ButtonStyle.Primary),
+						.setStyle(ButtonStyle.Primary)
+						.setEmoji(restEmoji)
+						.setLabel(restLabel)
+						.setDisabled(!hasRoomActions),
 					new ButtonBuilder().setCustomId("viewchallenges")
-						.setLabel("Take a challenge")
-						.setEmoji("1️⃣")
 						.setStyle(ButtonStyle.Danger)
+						.setEmoji(challengeEmoji)
+						.setLabel(challengeLabel)
+						.setDisabled(!hasRoomActions)
 				),
 				generateRoutingRow(adventure)
 			]

--- a/source/rooms/restsite-trainingdummy.js
+++ b/source/rooms/restsite-trainingdummy.js
@@ -11,18 +11,45 @@ module.exports = new RoomTemplate("Rest Site: Training Dummy",
 	],
 	function (roomEmbed, adventure) {
 		const healPercent = Math.trunc(30 * (1 - (adventure.getChallengeIntensity("Restless") / 100)));
+		let restEmoji, restLabel, trainingEmoji, trainingLabel;
+		const hasRoomActions = adventure.room.hasResource("roomAction");
+		if (hasRoomActions) {
+			restEmoji = "1️⃣";
+			restLabel = `Rest [+${healPercent}% hp]`;
+			trainingEmoji = "1️⃣";
+			trainingLabel = "Use the training dummy";
+		} else {
+			const restedResources = Object.values(adventure.room.resources).filter(resource => resource.name.startsWith("Rested: "));
+			if (restedResources.length > 0) {
+				restEmoji = "✔️";
+				restLabel = "The party rested";
+			} else {
+				restEmoji = "✖️";
+				restLabel = "The fire has burned out";
+			}
+			const trainingResources = Object.values(adventure.room.resources).filter(resource => resource.name.startsWith("Trained: "));
+			if (trainingResources.length > 0) {
+				trainingEmoji = "✔️";
+				trainingLabel = "The party trained";
+			} else {
+				trainingEmoji = "✖️";
+				trainingLabel = "The party didn't train";
+			}
+		}
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId(`rest${SAFE_DELIMITER}${healPercent}`)
-						.setLabel(`Rest [+${healPercent}% hp]`)
-						.setEmoji("1️⃣")
-						.setStyle(ButtonStyle.Primary),
-					new ButtonBuilder().setCustomId("trainingdummy")
-						.setLabel("Use the training dummy")
-						.setEmoji("1️⃣")
 						.setStyle(ButtonStyle.Primary)
+						.setEmoji(restEmoji)
+						.setLabel(restLabel)
+						.setDisabled(!hasRoomActions),
+					new ButtonBuilder().setCustomId("trainingdummy")
+						.setStyle(ButtonStyle.Primary)
+						.setEmoji(trainingEmoji)
+						.setLabel(trainingLabel)
+						.setDisabled(!hasRoomActions)
 				),
 				generateRoutingRow(adventure)
 			]

--- a/source/selects/applepiewishingwell.js
+++ b/source/selects/applepiewishingwell.js
@@ -16,7 +16,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 		const [tossedItem] = interaction.values;
 		adventure.decrementItem(tossedItem, 1);
-		adventure.addResource("Well used", "history", "internal", 1);
+		adventure.room.addResource("Well used", "history", "internal", 1);
 		gainHealth(delver, delver.maxHP, adventure);
 		interaction.update(renderRoom(adventure, interaction.channel));
 		interaction.channel.send(`The ${tossedItem} becomes an apple pie. **${delver.getName()} is fully healed** by the delicious pie.`)

--- a/source/selects/artifactdupe.js
+++ b/source/selects/artifactdupe.js
@@ -16,7 +16,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 		if (adventure.room.resources.roomAction.count > 0) {
 			adventure.room.resources.roomAction.count = 0;
 			const artifactName = interaction.values[0];
-			adventure.addResource(`Duped: ${artifactName}`, "history", "internal", 1);
+			adventure.room.addResource(`Duped: ${artifactName}`, "history", "internal", 1);
 			adventure.gainArtifact(artifactName, 1);
 			interaction.update(renderRoom(adventure, interaction.channel));
 			setAdventure(adventure);

--- a/source/selects/buygear.js
+++ b/source/selects/buygear.js
@@ -22,7 +22,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 			if (adventure.gold >= cost) {
 				if (delver.gear.length < adventure.getGearCapacity()) {
 					adventure.gold -= cost;
-					adventure.room.resources[name].count--;
+					adventure.room.decrementResource(name, 1);
 					delver.gear.push(buildGearRecord(name, "max"));
 					interaction.message.edit(renderRoom(adventure, interaction.channel));
 					interaction.reply({ content: `${interaction.member.displayName} buys a ${name} for ${cost}g.` });

--- a/source/selects/buyitem.js
+++ b/source/selects/buyitem.js
@@ -26,7 +26,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 		}
 
 		adventure.gold -= cost;
-		adventure.room.resources[name].count--;
+		adventure.room.decrementResource(name, 1);
 		adventure.gainItem(name, 1);
 		interaction.message.edit(renderRoom(adventure, interaction.channel));
 		interaction.reply({ content: `${interaction.member.displayName} buys a ${name} for ${cost}g.` });

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -25,7 +25,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 		let result;
 		const { type, count } = adventure.room.resources[name];
 		if (count > 0) { // Prevents double message if multiple players take near same time
-			adventure.addResource(`Picked: ${name}`, "history", "internal", count);
+			adventure.room.addResource(`Picked: ${name}`, "history", "internal", count);
 			switch (type) {
 				case "gold":
 					adventure.gainGold(count);
@@ -73,7 +73,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 			setAdventure(adventure);
 			interaction.reply(result).then(() => {
 				if (source === "treasure") {
-					adventure.room.resources.roomAction.count -= 1;
+					adventure.room.decrementResource("roomAction", 1);
 				}
 				interaction.message.edit(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
 			});

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -46,7 +46,7 @@ function editButtons(components, edits) {
  * @returns {{embeds: MessageEmbed[], remainingActions: number}}
  */
 function consumeRoomActions(adventure, embeds, actionsConsumed) {
-	adventure.room.resources.roomAction.count -= actionsConsumed;
+	adventure.room.decrementResource("roomAction", actionsConsumed);
 	const remainingActions = adventure.room.resources.roomAction.count;
 	return {
 		embeds: embeds.map(({ data: embed }) => {


### PR DESCRIPTION
Summary
-------
- fix Rest Sites to reliably record run history
- fix crash on arrive at wishing well with no items
- add Room.hasResource()
- create Room.decrementResource()
- move addResource from Adventure to Room

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] went through all rest site options

Issue
-----
Closes #120 