### PR TITLE
#182: fix Manual Manual bonus levels not reported by combat victory message

### DIFF
--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -100,10 +100,11 @@ function generateCombatRoomBuilder(extraButtons) {
 					}
 				}
 			} else {
-				if (baseLevels === 1) {
+				const levels = parseInt(levelEntries[0][0].split("levelsGained:")[1]);
+				if (levels === 1) {
 					levelUpField.value = `Everyone gains 1 level.`;
 				} else {
-					levelUpField.value = `Everyone gains ${baseLevels} levels.`;
+					levelUpField.value = `Everyone gains ${levels} levels.`;
 				}
 			}
 			roomEmbed.addFields(levelUpField, { name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." });


### PR DESCRIPTION
Summary
-------
- fix Manual Manual bonus levels not reported by combat victory message

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] checked a combat victory message while holding a Manual Manual

Issue
-----
Closes #182 