### PR TITLE
#196: add slash command mentions to relevant text responses

### DIFF
--- a/source/buttons/buyscouting.js
+++ b/source/buttons/buyscouting.js
@@ -2,7 +2,7 @@ const { ButtonWrapper } = require('../classes');
 const { prerollBoss } = require('../labyrinths/_labyrinthDictionary');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { renderRoom } = require('../util/embedUtil');
-const { ordinalSuffixEN } = require('../util/textUtil');
+const { ordinalSuffixEN, commandMention } = require('../util/textUtil');
 
 const mainId = "buyscouting";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -19,10 +19,10 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		if (type === "Final Battle") {
 			adventure.scouting.bosses++;
 			adventure.updateArtifactStat("Amethyst Spyglass", "Gold Saved", 150 - cost);
-			interaction.reply(`The merchant reveals that final battle for this adventure will be **${adventure.bosses[adventure.scouting.bossesEncountered]}** (you can review this with \`/party-stats\`).`);
+			interaction.reply(`The merchant reveals that final battle for this adventure will be **${adventure.bosses[adventure.scouting.bossesEncountered]}** (you can review this with ${commandMention("adventure", "party-stats")}).`);
 		} else {
 			adventure.updateArtifactStat("Amethyst Spyglass", "Gold Saved", 100 - cost);
-			interaction.reply(`The merchant reveals that the ${ordinalSuffixEN(adventure.scouting.artifactGuardiansEncountered + adventure.scouting.artifactGuardians + 1)} artifact guardian for this adventure will be **${adventure.artifactGuardians[adventure.scouting.artifactGuardiansEncountered + adventure.scouting.artifactGuardians]}** (you can review this with \`/adventure party-stats\`).`);
+			interaction.reply(`The merchant reveals that the ${ordinalSuffixEN(adventure.scouting.artifactGuardiansEncountered + adventure.scouting.artifactGuardians + 1)} artifact guardian for this adventure will be **${adventure.artifactGuardians[adventure.scouting.artifactGuardiansEncountered + adventure.scouting.artifactGuardians]}** (you can review this with ${commandMention("adventure", "party-stats")}).`);
 			adventure.scouting.artifactGuardians++;
 			while (adventure.artifactGuardians.length <= adventure.scouting.artifactGuardiansEncountered + adventure.scouting.artifactGuardians) {
 				prerollBoss("Artifact Guardian", adventure);

--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -2,6 +2,7 @@ const { ButtonWrapper } = require('../classes');
 const { getArchetype } = require('../archetypes/_archetypeDictionary');
 const { buildGearRecord } = require('../gear/_gearDictionary');
 const { getAdventure, nextRoom, fetchRecruitMessage, setAdventure } = require('../orcustrators/adventureOrcustrator');
+const { commandMention } = require('../util/textUtil');
 
 const mainId = "ready";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -42,7 +43,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				});
 			})
 
-			interaction.reply({ content: `The adventure has begun (and closed to new delvers joining)! You can use the \`/adventure\` commands to check adventure status.`, fetchReply: true }).then(message => {
+			interaction.reply({ content: `The adventure has begun (and closed to new delvers joining)! You can use ${commandMention("adventure", "party-stats")} or ${commandMention("adventure", "inspect-self")} to check adventure status.`, fetchReply: true }).then(message => {
 				message.pin();
 				adventure.state = "ongoing";
 				adventure.messageIds.utility = message.id;

--- a/source/constants.js
+++ b/source/constants.js
@@ -27,6 +27,7 @@ module.exports = {
 	testGuildId,
 	feedbackChannelId,
 	announcementsChannelId,
+	commandIds: {},
 
 	// Internal Convention
 	lastPostedVersion,

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -1,3 +1,5 @@
+const { commandIds } = require("../constants");
+
 /** @type {Record<number, string>} */
 const NUMBER_EMOJI = {
 	0: '0️⃣',
@@ -144,6 +146,18 @@ function listifyEN(texts, isMutuallyExclusive) {
 	}
 }
 
+/**
+ * @param {string} commandName
+ * @param {string?} subcommandName
+ */
+function commandMention(commandName, subcommandName) {
+	if (!(commandName in commandIds)) {
+		return `\`/${commandName}${subcommandName ? ` ${subcommandName}` : ""}\``;
+	}
+
+	return `</${commandName}${subcommandName ? ` ${subcommandName}` : ""}:${commandIds[commandName]}>`;
+}
+
 module.exports = {
 	getNumberEmoji,
 	generateTextBar,
@@ -152,5 +166,6 @@ module.exports = {
 	calculateTagContent,
 	ordinalSuffixEN,
 	trimForSelectOptionDescription,
-	listifyEN
+	listifyEN,
+	commandMention
 };


### PR DESCRIPTION
Summary
-------
- add command id mapping to startup
- add `commandMention` function for constructing command mentions
- replace commands mentioned in text with actual mentions

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] command mentions are properly parsed in ready button

Issue
-----
Closes #196