### PR TITLE
#106: allow Clones to copy gear stats

### DIFF
--- a/source/enemies/clone.js
+++ b/source/enemies/clone.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 
 module.exports = new EnemyTemplate("@{clone}",
-	"@{clone}",
+	"@{clone}", // this shouldn't get used, clones always copy delvers
 	300,
 	100,
 	"6",
@@ -12,5 +12,5 @@ module.exports = new EnemyTemplate("@{clone}",
 	.addAction({
 		name: "Mirroring Moves",
 		element: "Untyped",
-		description: "Clones will use the same move on a mirrored target as the delver they've copied."
+		description: "Clones come with the same gear and will use the same move on a mirrored target as the delver they've copied."
 	});

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -138,7 +138,7 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 		"Event": ["Imp Contract Faire", "The Score Beggar", "Free Gold?", "Apple Pie Wishing Well", "Twin Pedestals", "Gear Collector", "Repair Kit, just hanging out"],
 		"Battle": ["Frog Ranch", "Wild Fire-Arrow Frogs"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
-		"Final Battle": ["The Hexagon: Bee Mode", "The Hexagon: Mech Mode", "Confronting the Top Celestial Knight"],
+		"Final Battle": ["Hall of Mirrors", "The Hexagon: Bee Mode", "The Hexagon: Mech Mode", "Confronting the Top Celestial Knight"],
 
 		// Labyrinth Infrastructure - less customized
 		"Merchant": ["Gear Buying Merchant"],


### PR DESCRIPTION
Summary
-------
- allow Clones to copy gear stats. level-up stats omitted as official way to create asymmetry (not visible in a mirror compared to gear)

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] entered the Hall of Mirrors with a Wolf Ring equipped. Clone had 8 poise and no other increased stats

Issue
-----
Closes #106 