### PR TITLE
#191: Change Crystal Shard stat to "Spells Cast"

### DIFF
--- a/source/buttons/readymove.js
+++ b/source/buttons/readymove.js
@@ -197,10 +197,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						targetIndices.forEach(index => {
 							newMove.addTarget(new CombatantReference(targetTeam, index));
 						});
-
-						if (crystalShardCount > 0) {
-							adventure.updateArtifactStat("Crystal Shard", "Extra Targets", (targetIndices[targetIndices.length - 1] - targetIndices[0]) - (prebuffedMaxIndex - prebuffedMinIndex));
-						}
 					} else {
 						newMove.addTarget(new CombatantReference(targetTeam, targetIndex));
 						targetIndices.push(targetIndex);

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -426,6 +426,9 @@ function resolveMove(move, adventure) {
 				effect = getGearProperty(move.name, "effect");
 				needsLivingTargets = getGearProperty(move.name, "targetingTags").needsLivingTargets;
 				moveText = `${getEmoji(getGearProperty(move.name, "element"))} ${moveText}`;
+				if (move.userReference.team === "delver" && adventure.getArtifactCount("Crystal Shard") > 0 && getGearProperty(move.name, "category") === "Spell") {
+					adventure.updateArtifactStat("Crystal Shard", "Spells Cast", 1);
+				}
 				break;
 			case "item":
 				let isPlacebo = false;

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -168,7 +168,7 @@ function commandMention(fullCommand) {
 function joinAsStatement(shouldListifyExclusively, entities, singularVerb, pluralVerb, descriptor) {
 	if (entities.length > 1) {
 		return `${listifyEN(entities, shouldListifyExclusively)} ${pluralVerb} ${descriptor}`;
-	} else if (entities === 1) {
+	} else if (entities.length === 1) {
 		return `${entities[0]} ${singularVerb} ${descriptor}`;
 	} else {
 		return "";


### PR DESCRIPTION
Summary
-------
- change Crystal Shard stat to "Spells Cast"
- fix joinAsStatement skipping case where length of entities is 1

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Casting a Spell with a Crystal Shard increases stat value
- [x] Using non-Spell moves with a Crystal Shard does not increase stat value
- [x] joinAsStatement no longer skips the case where length of entities is 1

Issue
-----
Closes #191