### PR TITLE
#81: add command `/share-seed`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@
 ### Artifacts
 - Floating Multiplier (new): Increases the adventure's score by 25% per copy
 
+### Other Changes
+- New command: `/share-seed` lets players share the seed of their completed adventure with others
+
 ## Prophets of the Labyrinth v0.14.0:
 This update has a systems focus: making damage midigation less situation by having Block (now protection) expire at end of combat instead of end of turn and adding a reward for the risk of combat via combat levels. There's also new content and balance such as: a new final boss, the Chemist rework, adding more AoE with the Blasting gear variant, and a few new artifacts.
 ### Labyrinths

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -19,6 +19,7 @@ module.exports = {
 		"player-stats.js",
 		"regenerate.js",
 		"reset.js",
+		"share-seed.js",
 		"support.js",
 		"version.js"
 	],

--- a/source/commands/share-seed.js
+++ b/source/commands/share-seed.js
@@ -1,0 +1,49 @@
+const { PermissionFlagsBits } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { getAdventure } = require('../orcustrators/adventureOrcustrator');
+const { listifyEN } = require('../util/textUtil');
+
+const mainId = "share-seed";
+module.exports = new CommandWrapper(mainId, "Recommend this seed and Labyrinth to someone", PermissionFlagsBits.SendMessages, false, false, 300000,
+	(interaction) => {
+		const adventure = getAdventure(interaction.channelId);
+		if (!adventure) {
+			interaction.reply({ content: "This channel doesn't appear to be an adventure's thread.", ephemeral: true });
+			return;
+		}
+
+		if (["config", "ongoing"].includes(adventure.state)) {
+			interaction.reply({ content: "Please wait to recommend the seed until after the adventure is over.", ephemeral: true });
+			return;
+		}
+
+		const recipient = interaction.options.getUser("user");
+		if (adventure.delvers.map(delver => delver.id).includes(recipient.id)) {
+			interaction.reply({ content: `${recipient} was already a part of this adventure.`, ephemeral: true });
+			return;
+		}
+
+		const partyElements = new Set();
+		for (const delver of adventure.delvers) {
+			if (delver.element && !partyElements.has(delver.element)) {
+				partyElements.add(delver.element);
+			}
+		}
+		const personalizedMessage = interaction.options.getString("personalized-message");
+		recipient.send(`${interaction.member} has recommended you try a delve into the **${adventure.labyrinth}** with a seed **${adventure.initialSeed}**.${partyElements.size > 0 ? ` Their party had the following elements: ${listifyEN([...partyElements])}` : ""}${personalizedMessage ? `\nExtra Message: ${personalizedMessage}` : ""}`)
+		interaction.reply({ content: `Delving into the **${adventure.labyrinth}** on seed **${adventure.initialSeed}** has been recommended to ${recipient}.`, ephemeral: true });
+	}
+).setOptions(
+	{
+		type: "User",
+		name: "user",
+		description: "The user with whom to share this adventure's seed with",
+		required: true
+	},
+	{
+		type: "String",
+		name: "personalized-message",
+		description: "A personalized message to send with the share (like the interesting part of the seed)",
+		required: false
+	}
+);


### PR DESCRIPTION
Summary
-------
- add command `/share-seed`

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] command shares labyrinth, seed, and party element composition (if extent) with the recipient
- [x] command early outs if not used in an adventure thread
- [x] command early outs if adventure is in config or ongoing
- [x] command early outs if recipient is a party member
- [x] command appends personalized message to recommendation, and doesn't crash if not provided one

Issue
-----
Closes #81 