### PR TITLE
#207: recruiting embed has desync bugs

### DIFF
--- a/source/commands/delve.js
+++ b/source/commands/delve.js
@@ -1,14 +1,14 @@
-const { ActionRowBuilder, ButtonBuilder, EmbedBuilder, StringSelectMenuBuilder, ButtonStyle, ChannelType, MessageFlags } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, StringSelectMenuBuilder, ButtonStyle, ChannelType, MessageFlags } = require('discord.js');
 const { PermissionFlagsBits } = require('discord.js');
 const { CommandWrapper, Adventure, Delver } = require('../classes');
 const { setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { getChallenge } = require('../challenges/_challengeDictionary');
-const { getColor } = require('../util/elementUtil');
 const { getCompany, setCompany } = require('../orcustrators/companyOrcustrator');
 const { prerollBoss, defaultLabyrinths, labyrinthExists, getLabyrinthProperty } = require('../labyrinths/_labyrinthDictionary');
 const { SAFE_DELIMITER } = require('../constants');
 const { isSponsor } = require('../util/fileUtil');
 const { trimForSelectOptionDescription } = require('../util/textUtil');
+const { generateRecruitEmbed } = require('../util/embedUtil');
 
 const mainId = "delve";
 module.exports = new CommandWrapper(mainId, "Start a new adventure", PermissionFlagsBits.SendMessages, false, false, 3000,
@@ -37,13 +37,7 @@ module.exports = new CommandWrapper(mainId, "Start a new adventure", PermissionF
 		prerollBoss("Final Battle", adventure);
 		prerollBoss("Artifact Guardian", adventure);
 
-		const embed = new EmbedBuilder().setColor(getColor(adventure.element))
-			.setAuthor({ name: "Imaginary Horizons Productions", iconURL: "https://cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png", url: "https://github.com/Imaginary-Horizons-Productions/prophets-of-the-labyrinth" })
-			.setTitle(adventure.name)
-			.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/734093574031016006/bountyboard.png")
-			.setDescription("A new adventure is starting!")
-			.addFields({ name: "1 Party Member", value: `${interaction.member} 👑` })
-		interaction.reply({ embeds: [embed], fetchReply: true }).then(recruitMessage => {
+		interaction.reply({ embeds: [generateRecruitEmbed(adventure)], fetchReply: true }).then(recruitMessage => {
 			adventure.messageIds.recruit = recruitMessage.id;
 			interaction.channel.threads.create({
 				name: adventure.name,

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const { ThreadChannel, EmbedBuilder, Message } = require("discord.js");
+const { ThreadChannel, Message } = require("discord.js");
 
 const { Adventure, CombatantReference, Move, Enemy, Delver, Room, Combatant } = require("../classes");
 
@@ -17,7 +17,7 @@ const { getTurnDecrement } = require("../modifiers/_modifierDictionary");
 
 const { removeModifier, addModifier, dealModifierDamage, gainHealth, changeStagger, addProtection, getNames } = require("../util/combatantUtil");
 const { getWeaknesses, getEmoji, getOpposite } = require("../util/elementUtil");
-const { renderRoom, updateRoomHeader } = require("../util/embedUtil");
+const { renderRoom, updateRoomHeader, generateRecruitEmbed } = require("../util/embedUtil");
 const { ensuredPathSave } = require("../util/fileUtil");
 const { clearComponents } = require("../util/messageComponentUtil");
 const { spawnEnemy } = require("../util/roomUtil");
@@ -715,14 +715,9 @@ async function fetchRecruitMessage(thread, messageId) {
 function completeAdventure(adventure, thread, endState, descriptionOverride) {
 	const { messages: messageManager } = thread;
 	fetchRecruitMessage(thread, adventure.messageIds.recruit).then(recruitMessage => {
-		const [{ data: recruitEmbed }] = recruitMessage.embeds;
 		recruitMessage.edit({
-			embeds: [
-				new EmbedBuilder(recruitEmbed)
-					.setTitle(recruitEmbed.title + ": COMPLETE!")
-					.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/734092918369026108/completion.png")
-					.addFields({ name: "Seed", value: adventure.initialSeed })
-			], components: []
+			embeds: [generateRecruitEmbed(adventure)],
+			components: []
 		});
 	})
 	clearComponents(adventure.messageIds.battleRound, messageManager);

--- a/source/selects/startingchallenges.js
+++ b/source/selects/startingchallenges.js
@@ -1,7 +1,7 @@
-const { EmbedBuilder } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { getAdventure, setAdventure, fetchRecruitMessage } = require('../orcustrators/adventureOrcustrator');
 const { getChallenge } = require('../challenges/_challengeDictionary');
+const { generateRecruitEmbed } = require('../util/embedUtil');
 
 const mainId = "startingchallenges";
 module.exports = new SelectWrapper(mainId, 3000,
@@ -15,15 +15,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 		if (interaction.values.includes("None")) {
 			adventure.challenges = {};
 			fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
-				const [{ data: recruitEmbed }] = recruitMessage.embeds;
-				recruitMessage.edit({
-					embeds: [
-						new EmbedBuilder({
-							...recruitEmbed,
-							fields: recruitEmbed.fields.filter(field => field.name !== "Challenges")
-						})
-					]
-				});
+				recruitMessage.edit({ embeds: [generateRecruitEmbed(adventure)] });
 			})
 			interaction.reply({ content: "Starting Challenges have been cleared for this adventure." });
 		} else {
@@ -32,17 +24,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 				adventure.challenges[challengeName] = { intensity: challenge.intensity, duration: challenge.duration, reward: challenge.reward };
 			})
 			fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
-				const [{ data: recruitEmbed }] = recruitMessage.embeds;
-				const updatedEmbed = new EmbedBuilder(recruitEmbed);
-
-				const challengeField = { name: "Challenges", value: `• ${Object.keys(adventure.challenges).join("\n• ")}` };
-				const fieldIndex = recruitEmbed.fields.findIndex(field => field.name === "Challenges");
-				if (fieldIndex !== -1) {
-					updatedEmbed.spliceFields(fieldIndex, 1, challengeField)
-				} else {
-					updatedEmbed.addFields(challengeField);
-				}
-				recruitMessage.edit({ embeds: [updatedEmbed] });
+				recruitMessage.edit({ embeds: [generateRecruitEmbed(adventure)] });
 			})
 			interaction.reply({ content: `The following challenge(s) have been added to this adventure: "${interaction.values.join("\", \"")}"` });
 		}


### PR DESCRIPTION
Summary
-------
- refactor recruiting embed handling to generate clean from adventure state to fix desync bugs

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] adding starting challenges doesn't clobber party list
- [x] ending adventure doesn't clobber party list or challenges

Issue
-----
Closes #207 