### PR TITLE
#136: add Peacock Charm

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 ## Prophets of the Labyrinth v0.15.0:
 ### Artifacts
 - Floating Multiplier (new): Increases the adventure's score by 25% per copy
+- Peacock Charm (new): Gain copies + your remaining poise in protection each turn
 
 ### Other Changes
 - New command: `/share-seed` lets players share the seed of their completed adventure with others

--- a/source/artifacts/_artifactDictionary.js
+++ b/source/artifacts/_artifactDictionary.js
@@ -28,6 +28,7 @@ for (const file of [
 	"manualmanual.js",
 	"negativeoneleafclover.js",
 	"oilpainting.js",
+	"peacockcharm.js",
 	"phoenixfruitblossom.js",
 	"piggybank.js",
 	"spiralfunnel.js",

--- a/source/artifacts/peacockcharm.js
+++ b/source/artifacts/peacockcharm.js
@@ -1,0 +1,7 @@
+const { ArtifactTemplate } = require("../classes");
+
+module.exports = new ArtifactTemplate("Peacock Charm",
+	"Delvers gain @{copies} + their remaining poise in protection each turn",
+	"Increase the protection gained by 1 per charm",
+	"Untyped"
+);

--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -47,6 +47,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				message.pin();
 				adventure.state = "ongoing";
 				adventure.messageIds.utility = message.id;
+				adventure.gainArtifact("Peacock Charm", 1);
 				nextRoom("Battle", interaction.channel);
 			});
 		}

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -310,11 +310,20 @@ function newRound(adventure, thread, lastRoundText) {
 			 * @param {number} i
 			 */
 			(combatant, i) => {
-				const boatPartsCount = adventure.getArtifactCount("Boat Parts");
-				if (boatPartsCount > 0 && adventure.room.round <= boatPartsCount + 1 && combatant.team === "delver") {
-					const boatProtection = boatPartsCount * 25 + 25;
-					addProtection([combatant], boatProtection);
-					adventure.updateArtifactStat("Protection Generated", boatProtection);
+				if (combatant.team === "delver") {
+					const boatPartsCount = adventure.getArtifactCount("Boat Parts");
+					if (boatPartsCount > 0 && adventure.room.round <= boatPartsCount + 1) {
+						const boatProtection = boatPartsCount * 25 + 25;
+						addProtection([combatant], boatProtection);
+						adventure.updateArtifactStat("Boat Parts", "Protection Generated", boatProtection);
+					}
+
+					const peacockCharmCount = adventure.getArtifactCount("Peacock Charm");
+					if (peacockCharmCount > 0) {
+						const peacockProtection = peacockCharmCount + combatant.poise - combatant.stagger;
+						addProtection([combatant], peacockProtection);
+						adventure.updateArtifactStat("Peacock Charm", "Protection Generated", peacockProtection);
+					}
 				}
 
 				// Roll Round Speed


### PR DESCRIPTION
Summary
-------
- add Peacock Charm
- fix Boat Parts stats recording

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Peacock Charm generates protection each turn
- [x] Peacock Charm protection generated is recorded in stats

Issue
-----
Closes #136 