### PR TITLE
#213: refactor "None" option in starting artifacts and starting challenges to "Clear" buttons

### DIFF
--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -9,6 +9,7 @@ for (const file of [
 	"buylife.js",
 	"buyscouting.js",
 	"challenges.js",
+	"clearstartingchallenges.js",
 	"collectartifact.js",
 	"deploy.js",
 	"elementresearch.js",

--- a/source/buttons/clearstartingchallenges.js
+++ b/source/buttons/clearstartingchallenges.js
@@ -1,0 +1,18 @@
+const { ButtonWrapper } = require('../classes');
+const { fetchRecruitMessage, setAdventure, getAdventure } = require('../orcustrators/adventureOrcustrator');
+const { generateRecruitEmbed, generateAdventureConfigMessage } = require('../util/embedUtil');
+
+const mainId = "clearstartingchallenges";
+module.exports = new ButtonWrapper(mainId, 3000,
+	/** Clears the starting challenges from the adventure, then rerenders the challenges select */
+	(interaction, args) => {
+		const adventure = getAdventure(interaction.channelId);
+		adventure.challenges = {};
+		setAdventure(adventure);
+		fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
+			recruitMessage.edit({ embeds: [generateRecruitEmbed(adventure)] });
+		})
+		interaction.message.edit(generateAdventureConfigMessage(adventure));
+		interaction.reply({ content: "Starting Challenges have been cleared for this adventure." });
+	}
+);

--- a/source/buttons/startingartifacts.js
+++ b/source/buttons/startingartifacts.js
@@ -1,9 +1,9 @@
-const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { getPlayer } = require('../orcustrators/playerOrcustrator');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { getArtifact, artifactNames } = require('../artifacts/_artifactDictionary');
-const { RN_TABLE_BASE, SKIP_INTERACTION_HANDLING } = require('../constants');
+const { RN_TABLE_BASE, SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants');
 const { trimForSelectOptionDescription } = require('../util/textUtil');
 
 const mainId = "startingartifacts";
@@ -17,7 +17,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const playerProfile = getPlayer(interaction.user.id, interaction.guild.id);
-		const options = [{ label: "None", description: "Deselect your picked starting artifact", value: "None" }];
+		const options = [];
 
 		// This randomizer is separate from the Adventure method because it doesn't advance the rnIndex so that players can't reroll starting artifacts by pushing the button again
 		let start = parseInt(interaction.user.id) % adventure.rnTable.length;
@@ -53,10 +53,14 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			content: `You can bring 1 of the following artifacts on this adventure (if you've collected that artifact from a previous adventure):${artifactBulletList}\nEach player will have a different set of artifacts to select from.`,
 			components: [
 				new ActionRowBuilder().addComponents(
-					new StringSelectMenuBuilder()
-						.setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}add`)
 						.setPlaceholder("Select an artifact...")
 						.addOptions(options)
+				),
+				new ActionRowBuilder().addComponents(
+					new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}clear`)
+						.setStyle(ButtonStyle.Danger)
+						.setLabel("Deselect Starting Artifact")
 				)
 			],
 			ephemeral: true,
@@ -66,23 +70,24 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			collector.on("collect", collectedInteraction => {
 				const adventure = getAdventure(collectedInteraction.channelId);
 				const delver = adventure?.delvers.find(delver => delver.id === collectedInteraction.user.id);
-				const [artifactName] = collectedInteraction.values;
-				if (delver?.startingArtifact === "" && artifactName === "None" || adventure.state !== "config") {
-					return;
-				}
+				const [_, mainId] = collectedInteraction.customId.split(SAFE_DELIMITER);
 
-				if (artifactName === "None") {
+				if (!delver || adventure.state !== "config") {
+					return;
+				} else if (mainId === "add") {
+					const isSwitching = delver.startingArtifact !== "";
+					const [artifactName] = collectedInteraction.values;
+					delver.startingArtifact = artifactName;
+					collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}** ${isSwitching ? "has switched to" : "is taking"} *${artifactName}* for their starting artifact.`);
+				} else {
 					delver.startingArtifact = "";
 					collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}** has decided not to bring a starting artifact.`);
-				} else {
-					const isSwitching = delver.startingArtifact !== "";
-					delver.startingArtifact = artifactName;
-					collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}** ${isSwitching ? "has switched to" : "is taking"} ${artifactName} for their starting artifact.`);
 				}
 				setAdventure(adventure);
 			})
 
-			collector.on("end", () => {
+			collector.on("end", async (interactionCollection) => {
+				await interactionCollection.first().update({ components: [] });
 				interaction.deleteReply();
 			})
 		})

--- a/source/selects/startingchallenges.js
+++ b/source/selects/startingchallenges.js
@@ -12,22 +12,14 @@ module.exports = new SelectWrapper(mainId, 3000,
 			return;
 		}
 
-		if (interaction.values.includes("None")) {
-			adventure.challenges = {};
-			fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
-				recruitMessage.edit({ embeds: [generateRecruitEmbed(adventure)] });
-			})
-			interaction.reply({ content: "Starting Challenges have been cleared for this adventure." });
-		} else {
-			interaction.values.forEach(challengeName => {
-				const challenge = getChallenge(challengeName);
-				adventure.challenges[challengeName] = { intensity: challenge.intensity, duration: challenge.duration, reward: challenge.reward };
-			})
-			fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
-				recruitMessage.edit({ embeds: [generateRecruitEmbed(adventure)] });
-			})
-			interaction.reply({ content: `The following challenge(s) have been added to this adventure: "${interaction.values.join("\", \"")}"` });
-		}
+		interaction.values.forEach(challengeName => {
+			const challenge = getChallenge(challengeName);
+			adventure.challenges[challengeName] = { intensity: challenge.intensity, duration: challenge.duration, reward: challenge.reward };
+		})
+		fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
+			recruitMessage.edit({ embeds: [generateRecruitEmbed(adventure)] });
+		})
+		interaction.reply({ content: `The following challenge(s) have been added to this adventure: "${interaction.values.join("\", \"")}"` });
 		setAdventure(adventure);
 	}
 );


### PR DESCRIPTION
Summary
-------
- refactor "None" option in starting artifacts and starting challenges to "Clear" buttons

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] adding a starting artifact still reaches its response message without crashing
- [x] clearing a starting artifact reaches its response message without crashing
- [x] adding a starting challenge updates the recruit message
- [x] clearing starting challenges updates the recruit message

Issue
-----
Closes #213 