### PR TITLE
#16: pacts early out if the hp cost ends the adventure

### DIFF
--- a/source/gear/bloodaegis-base.js
+++ b/source/gear/bloodaegis-base.js
@@ -9,6 +9,11 @@ module.exports = new GearTemplate("Blood Aegis",
 	200,
 	([target], user, isCrit, adventure) => {
 		const { element, protection, critMultiplier, hpCost } = module.exports;
+		const paymentSentence = payHP(user, hpCost, adventure);
+		if (adventure.lives < 1) {
+			return paymentSentence;
+		}
+		const resultsSentences = [`Gaining protection, ${paymentSentence}`];
 		let pendingProtection = protection;
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
@@ -27,10 +32,9 @@ module.exports = new GearTemplate("Blood Aegis",
 		});
 		if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-			return `Gaining protection, ${payHP(user, hpCost, adventure)} ${getNames([target], adventure)[0]} falls for the provocation.`;
-		} else {
-			return `Gaining protection, ${payHP(user, hpCost, adventure)}`;
+			resultsSentences.push(`${getNames([target], adventure)[0]} falls for the provocation.`);
 		}
+		return resultsSentences.join(" ");
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Charging Blood Aegis", "Reinforced Blood Aegis", "Toxic Blood Aegis")

--- a/source/gear/bloodaegis-charging.js
+++ b/source/gear/bloodaegis-charging.js
@@ -9,6 +9,11 @@ module.exports = new GearTemplate("Charging Blood Aegis",
 	350,
 	([target], user, isCrit, adventure) => {
 		const { element, modifiers: [powerUp], protection, critMultiplier, hpCost } = module.exports;
+		const paymentSentence = payHP(user, hpCost, adventure);
+		if (adventure.lives < 1) {
+			return paymentSentence;
+		}
+		const resultsSentences = [`Gaining protection, ${paymentSentence}`];
 		let pendingProtection = protection;
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
@@ -18,6 +23,9 @@ module.exports = new GearTemplate("Charging Blood Aegis",
 		}
 		addProtection([user], pendingProtection);
 		const addedPowerUp = addModifier([user], powerUp).length > 0;
+		if (addedPowerUp) {
+			resultsSentences.push(`${userName} is Powered Up.`);
+		}
 		const [userName, targetName] = getNames([user, target], adventure);
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
@@ -29,10 +37,9 @@ module.exports = new GearTemplate("Charging Blood Aegis",
 		});
 		if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-			return `Gaining protection, ${payHP(user, hpCost, adventure)}${addedPowerUp ? ` ${userName} is Powered Up.` : ""} ${targetName} falls for the provocation.`;
-		} else {
-			return `Gaining protection, ${payHP(user, hpCost, adventure)}${addedPowerUp ? ` ${userName} is Powered Up.` : ""}`;
+			resultsSentences.push(`${targetName} falls for the provocation.`);
 		}
+		return resultsSentences.join(" ");
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Reinforced Blood Aegis", "Toxic Blood Aegis")

--- a/source/gear/bloodaegis-reinforced.js
+++ b/source/gear/bloodaegis-reinforced.js
@@ -9,6 +9,11 @@ module.exports = new GearTemplate("Reinforced Blood Aegis",
 	350,
 	([target], user, isCrit, adventure) => {
 		const { element, protection, critMultiplier, hpCost } = module.exports;
+		const paymentSentence = payHP(user, hpCost, adventure);
+		if (adventure.lives < 1) {
+			return paymentSentence;
+		}
+		const resultsSentences = [`Gaining protection, ${paymentSentence}`];
 		let pendingProtection = protection;
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
@@ -27,10 +32,9 @@ module.exports = new GearTemplate("Reinforced Blood Aegis",
 		});
 		if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-			return `Gaining protection, ${payHP(user, hpCost, adventure)} ${getNames([target], adventure)[0]} falls for the provocation.`;
-		} else {
-			return `Gaining protection, ${payHP(user, hpCost, adventure)}`;
+			resultsSentences.push(`${getNames([target], adventure)[0]} falls for the provocation.`);
 		}
+		return resultsSentences.join(" ");
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Charging Blood Aegis", "Toxic Blood Aegis")

--- a/source/gear/certainvictory-base.js
+++ b/source/gear/certainvictory-base.js
@@ -17,7 +17,7 @@ module.exports = new GearTemplate("Certain Victory",
 			pendingDamage *= critMultiplier;
 		}
 		const addedPowerUp = addModifier([user], powerUp).length > 0;
-		return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${dealDamage(targets, user, pendingDamage, false, element, adventure)}${addedPowerUp ? ` ${getNames([user], adventure)[0]} is Powered Up.` : ""}`;
+		return `${dealDamage(targets, user, pendingDamage, false, element, adventure)}${addedPowerUp ? ` ${getNames([user], adventure)[0]} is Powered Up.` : ""}${payHP(user, user.getModifierStacks("Power Up"), adventure)}`;
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Hunter's Certain Victory", "Lethal Certain Victory", "Reckless Certain Victory")

--- a/source/gear/certainvictory-hunters.js
+++ b/source/gear/certainvictory-hunters.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Hunter's Certain Victory",
 			adventure.gainGold(bounty);
 			damageText += ` ${getNames([user], adventure)[0]} gains ${bounty}g of victory spoils.`;
 		}
-		return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${damageText}${addedPowerUp ? ` ${getNames([user], adventure)[0]} is Powered Up.` : ""}`;
+		return `${damageText}${addedPowerUp ? ` ${getNames([user], adventure)[0]} is Powered Up.` : ""}${payHP(user, user.getModifierStacks("Power Up"), adventure)}`;
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Lethal Certain Victory", "Reckless Certain Victory")

--- a/source/gear/certainvictory-lethal.js
+++ b/source/gear/certainvictory-lethal.js
@@ -17,7 +17,7 @@ module.exports = new GearTemplate("Lethal Certain Victory",
 			pendingDamage *= critMultiplier;
 		}
 		const addedPowerUp = addModifier([user], powerUp).length > 0;
-		return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${dealDamage(targets, user, pendingDamage, false, element, adventure)}${addedPowerUp ? ` ${getNames([user], adventure)[0]} is Powered Up.` : ""}`;
+		return `${dealDamage(targets, user, pendingDamage, false, element, adventure)}${addedPowerUp ? ` ${getNames([user], adventure)[0]} is Powered Up.` : ""}${payHP(user, user.getModifierStacks("Power Up"), adventure)}`;
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Hunter's Certain Victory", "Reckless Certain Victory")

--- a/source/gear/certainvictory-reckless.js
+++ b/source/gear/certainvictory-reckless.js
@@ -1,5 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { dealDamage, addModifier, payHP, changeStagger, getNames } = require('../util/combatantUtil.js');
+const { listifyEN } = require('../util/textUtil.js');
 
 module.exports = new GearTemplate("Reckless Certain Victory",
 	"Strike a foe for @{damage} @{element} damage, gain @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1}; pay HP for your @{mod0}",
@@ -16,15 +17,21 @@ module.exports = new GearTemplate("Reckless Certain Victory",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
+		const resultsSentences = [dealDamage(targets, user, pendingDamage, false, element, adventure)];
+		const addedModifiers = [];
 		const addedPowerUp = addModifier([user], powerUp).length > 0;
-		const addedExposed = addModifier([user], exposed).length > 0;
 		if (addedPowerUp) {
-			return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${dealDamage(targets, user, pendingDamage, false, element, adventure)} ${getNames([user], adventure)[0]} is Powered Up and Exposed.`;
-		} else if (addedExposed) {
-			return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${dealDamage(targets, user, pendingDamage, false, element, adventure)} ${getNames([user], adventure)[0]} is Exposed.`;
-		} else {
-			return `${payHP(user, user.getModifierStacks("Power Up"), adventure)}${dealDamage(targets, user, pendingDamage, false, element, adventure)}`;
+			addedModifiers.push("Powered Up");
 		}
+		const addedExposed = addModifier([user], exposed).length > 0;
+		if (addedExposed) {
+			addedModifiers.push("Exposed");
+		}
+		if (addedPowerUp) {
+			resultsSentences.push(`${getNames([user], adventure)[0]} is ${listifyEN(addedModifiers)}.`);
+		}
+		resultsSentences.push(payHP(user, user.getModifierStacks("Power Up"), adventure));
+		return resultsSentences.join(" ");
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Hunter's Certain Victory", "Lethal Certain Victory")

--- a/source/gear/infiniteregeneration-base.js
+++ b/source/gear/infiniteregeneration-base.js
@@ -11,13 +11,17 @@ module.exports = new GearTemplate("Infinite Regeneration",
 	(targets, user, isCrit, adventure) => {
 		const { element, modifiers: [regen], hpCost, critMultiplier } = module.exports;
 		let pendingHPCost = hpCost;
-		if (user.element === element) {
-			changeStagger(targets, "elementMatchAlly");
-		}
 		if (isCrit) {
 			pendingHPCost /= critMultiplier;
 		}
-		const resultSentences = [payHP(user, pendingHPCost, adventure)];
+		const paymentSentence = payHP(user, pendingHPCost, adventure);
+		if (adventure.lives < 1) {
+			return paymentSentence;
+		}
+		if (user.element === element) {
+			changeStagger(targets, "elementMatchAlly");
+		}
+		const resultSentences = [paymentSentence];
 		const regenedTargets = addModifier(targets, regen);
 		if (regenedTargets.length > 0) {
 			resultSentences.push(joinAsStatement(false, getNames(regenedTargets, adventure), "gains", "gain", "Regen."));

--- a/source/gear/infiniteregeneration-discounted.js
+++ b/source/gear/infiniteregeneration-discounted.js
@@ -11,13 +11,17 @@ module.exports = new GearTemplate("Discounted Infinite Regeneration",
 	(targets, user, isCrit, adventure) => {
 		const { element, modifiers: [regen], hpCost, critMultiplier } = module.exports;
 		let pendingHPCost = hpCost;
-		if (user.element === element) {
-			changeStagger(targets, "elementMatchAlly");
-		}
 		if (isCrit) {
 			pendingHPCost /= critMultiplier;
 		}
-		const resultSentences = [payHP(user, pendingHPCost, adventure)];
+		const paymentSentence = payHP(user, pendingHPCost, adventure);
+		if (adventure.lives < 1) {
+			return paymentSentence;
+		}
+		if (user.element === element) {
+			changeStagger(targets, "elementMatchAlly");
+		}
+		const resultSentences = [paymentSentence];
 		const regenedTargets = addModifier(targets, regen);
 		if (regenedTargets.length > 0) {
 			resultSentences.push(joinAsStatement(false, getNames(targets, adventure), "gains", "gain", "Regen."));

--- a/source/gear/infiniteregeneration-fatesealing.js
+++ b/source/gear/infiniteregeneration-fatesealing.js
@@ -11,15 +11,19 @@ module.exports = new GearTemplate("Fate-Sealing Infinite Regeneration",
 	(targets, user, isCrit, adventure) => {
 		const { element, modifiers: [regen, stasis], hpCost, critMultiplier } = module.exports;
 		let pendingHPCost = hpCost;
-		if (user.element === element) {
-			changeStagger(targets, "elementMatchAlly");
-		}
 		let stasisedTargets = [];
 		if (isCrit) {
 			pendingHPCost /= critMultiplier;
 			stasisedTargets = addModifier(targets, stasis);
 		}
-		const resultSentences = [payHP(user, pendingHPCost, adventure)];
+		const paymentSentence = payHP(user, pendingHPCost, adventure);
+		if (adventure.lives < 1) {
+			return paymentSentence;
+		}
+		if (user.element === element) {
+			changeStagger(targets, "elementMatchAlly");
+		}
+		const resultSentences = [paymentSentence];
 		const regenedTargets = addModifier(targets, regen);
 		if (regenedTargets.length > 0) {
 			resultSentences.push(joinAsStatement(false, getNames(regenedTargets, adventure), "gains", "gain", "Regen."));

--- a/source/gear/powerfromwrath-base.js
+++ b/source/gear/powerfromwrath-base.js
@@ -9,6 +9,7 @@ module.exports = new GearTemplate("Power from Wrath",
 	200,
 	(targets, user, isCrit, adventure) => {
 		const { element, damage, hpCost } = module.exports;
+		const paymentSentence = payHP(user, hpCost, adventure);
 		const furiousness = (user.getMaxHP() - user.hp) / user.getMaxHP() + 1;
 		let pendingDamage = (user.getPower() + damage) * furiousness;
 		if (user.element === element) {
@@ -17,7 +18,7 @@ module.exports = new GearTemplate("Power from Wrath",
 		if (isCrit) {
 			pendingDamage *= 2;
 		}
-		return `${payHP(user, hpCost, adventure)}${dealDamage(targets, user, pendingDamage, false, element, adventure)}`;
+		return `${paymentSentence}${dealDamage(targets, user, pendingDamage, false, element, adventure)}`;
 	}
 ).setTargetingTags({ type: "single", team: "enemy", needsLivingTargets: true })
 	.setDurability(15)


### PR DESCRIPTION

Summary
-------
- pacts early out if the hp cost ends the adventure
- per instance implementation was chosen for increased effect flexibility
- Certain Victory hp payment moved to end of effect to match description

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)

Issue
-----
Closes #16