### PR TITLE
#267: Passive tag in gear description, Cursed gear has negative base cost

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,9 @@
 # Prophets of the Labyrinth Change Log
 ## Prophets of the Labyrinth v0.15.0:
-After the systems focus in v0.14, this update is looping back to give some love to balance and content. One focus is adding more differences between archetypes so picking party composition is a more interesting decision, a step toward getting to a place where it may vary based on labyrinth choice as well. Predicts are now unique combinations of information, as opposed to fully unique types of information. For example, multiple different archetypes will be able to predcit HP, but only the Hemomancer will be able to predict both HP and Speed.
+After the systems focus in v0.14, this update is looping back to give some love to balance and content. One focus is adding more archetype differences so picking party composition is a more interesting decision; a step toward composition varying based on labyrinth choice. Predicts are now unique combinations of information. For example, multiple archetypes can predict HP, but only the Hemomancer can predict both HP and Speed.
 ### Detective
 - Predict: Elements & Modifiers
-- Added **Flanking Pistol**: damage rewards for coordinating with allies
+- Added **Flanking Pistol**: damage reward for coordinating
 - Added **Urgent Sabotage Kit**: priority improves the party's chance to get mileage out of the debuffs
 - Fixed Pistol reporting the wrong ally getting Powered Up
 ### Hemomancer
@@ -20,6 +20,11 @@ After the systems focus in v0.14, this update is looping back to give some love 
 - Predict: Modifiers & Stagger
 - Fate-Sealing Censor → **Staggering Censor**: to add Stun potential
 - Flanking Corrosion → **Fate-Sealing Corrosion**: Ritualist doesn't have a speed predict for Exposed
+### New Content
+- Artifacts: Floating Multiplier, Peacock Charm, Best-in-Class Hammer
+- Gear: Shoulder Throw, Goad Futility, Evasive Shoulder Throw, Sabotaging Cauldron Stir, Corrosive Cauldron Stir, Bouncing Medicine, Cleansing Medicine, Soothing Medicine, Distracting Poison Torrent
+- Challenge: Into the Deep End
+- Modifiers: Agility (buff: inverse of Paralysis, allows the bearer to shrug off 2 Stagger per turn), Lucky & Unlucky (buff/debuff pair, double/halve your chance to crit), Distracted (debuff: inverse of Vigilance, causes Exposed to be retained between rounds)
 ### Artifact Elements
 Some artifacts are now associated with an element and will only available when a party member has that element (Untyped always available).
 - Fire: Best-in-Class Hammer
@@ -28,10 +33,6 @@ Some artifacts are now associated with an element and will only available when a
 - Wind: Hawk Tailfeather
 - Light: Hammerspace Holster
 - Darkness: Enchanted Map
-### New Content
-- Artifacts: Floating Multiplier, Peacock Charm, Best-in-Class Hammer
-- Gear: Shoulder Throw, Goad Futility, Evasive Shoulder Throw, Sabotaging Cauldron Stir, Corrosive Cauldron Stir, Bouncing Medicine, Cleansing Medicine, Soothing Medicine, Distracting Poison Torrent
-- Challenge: Into the Deep End
 ### Changed Gear
 - Removed starting gear from drop pool
 - Increased Hunter's gear's reward to 30g per kill
@@ -45,10 +46,7 @@ Some artifacts are now associated with an element and will only available when a
 - **Infinite Regenerations** Light → Fire: Regen is Fire-style
 - **Spears** Wind → Earth: Stagger is Earth-style
 - **Wise Chainmail** now increases stat growths by 10% instead of 1 level per combat
-### New Modifiers
-- Agility (buff: inverse of Paralysis) allows the bearer to shrug off 2 Stagger per turn
-- Lucky & Unlucky (buff/debuff pair) double/halve your chance to crit
-- Distracted (debuff: inverse of Vigilance) causes Exposed to be retained between rounds
+- Cursed gear now has negative base cost
 ### Other Changes
 - New command: `/share-seed`
 - Fixed Celestial Knight Insiginia triggering on turns the player is stunned
@@ -57,6 +55,7 @@ Some artifacts are now associated with an element and will only available when a
 - Fixed some crashes when looking up items
 - Exposed: increased bonus to 100%, fixed a bug where it didn't decrement on hit
 - Manual Manual now increases stat growths by 10% instead of 1 level per combat
+- Reduced crit rate gained from levelup from 1 to 0.25
 
 ## Prophets of the Labyrinth v0.14.0:
 This update has a systems focus: making damage mitigation less situational by having Block (now protection) expire at end of combat instead of end of turn and adding a reward for the risk of combat via combat levels. There's also new content and balance such as: a new final boss, the Chemist rework, adding more AoE with the Blasting gear variant, and a few new artifacts.

--- a/source/gear/chainmail-base.js
+++ b/source/gear/chainmail-base.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 
 module.exports = new GearTemplate("Chainmail",
-	"Gain @{maxHP} Max HP",
+	"Passive: Gain @{maxHP} Max HP",
 	"N/A",
 	"Trinket",
 	"Untyped",

--- a/source/gear/chainmail-wise.js
+++ b/source/gear/chainmail-wise.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 
 module.exports = new GearTemplate("Wise Chainmail",
-	"Gain @{maxHP} Max HP. Gain 10% more stats from leveling up.",
+	"Passive: Gain @{maxHP} Max HP and 10% more stats from leveling up.",
 	"N/A",
 	"Trinket",
 	"Untyped",

--- a/source/gear/cloak-accelerating.js
+++ b/source/gear/cloak-accelerating.js
@@ -3,7 +3,7 @@ const { addModifier, changeStagger, getNames } = require('../util/combatantUtil.
 const { listifyEN } = require('../util/textUtil.js');
 
 module.exports = new GearTemplate("Accelerating Cloak",
-	"Gain @{critRate} Crit Rate; gain @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} when used in combat",
+	"Gain @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1}. Passive: Gain @{critRate} Crit Rate",
 	"@{mod0} +@{bonus} and @{mod1} +@{bonus}",
 	"Armor",
 	"Wind",

--- a/source/gear/cloak-accurate.js
+++ b/source/gear/cloak-accurate.js
@@ -2,7 +2,7 @@ const { GearTemplate } = require('../classes/index.js');
 const { addModifier, changeStagger, getNames } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accurate Cloak",
-	"Gain @{critRate} Crit Rate; gain @{mod0Stacks} @{mod0} when used in combat",
+	"Gain @{mod0Stacks} @{mod0}. Passive: Gain @{critRate} Crit Rate",
 	"@{mod0} +@{bonus}",
 	"Armor",
 	"Wind",

--- a/source/gear/cloak-base.js
+++ b/source/gear/cloak-base.js
@@ -2,7 +2,7 @@ const { GearTemplate } = require('../classes');
 const { addModifier, changeStagger, getNames } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Cloak",
-	"Gain @{critRate} Crit Rate; gain @{mod0Stacks} @{mod0} when used in combat",
+	"Gain @{mod0Stacks} @{mod0}. Passive: Gain @{critRate} Crit Rate",
 	"@{mod0} +@{bonus}",
 	"Armor",
 	"Wind",

--- a/source/gear/cloak-long.js
+++ b/source/gear/cloak-long.js
@@ -2,7 +2,7 @@ const { GearTemplate } = require('../classes');
 const { addModifier, changeStagger, getNames } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Long Cloak",
-	"Gain @{critRate} Crit Rate; gain @{mod0Stacks} @{mod0} when used in combat",
+	"Gain @{mod0Stacks} @{mod0}. Passive: Gain @{critRate} Crit Rate",
 	"@{mod0} +@{bonus}",
 	"Armor",
 	"Wind",

--- a/source/gear/cursed-blade.js
+++ b/source/gear/cursed-blade.js
@@ -2,11 +2,11 @@ const { GearTemplate } = require('../classes');
 const { dealDamage, changeStagger } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Cursed Blade",
-	"Passively lose @{maxHP} HP; strike a foe for @{damage} @{element} damage",
+	"Strike a foe for @{damage} @{element} damage. Passive: Reduced your Max HP by @{maxHP}.",
 	"Damage x@{critMultiplier}",
 	"Weapon",
 	"Untyped",
-	50,
+	-50,
 	(targets, user, isCrit, adventure) => {
 		const { element, damage, critMultiplier } = module.exports;
 		let pendingDamage = damage + user.getPower();

--- a/source/gear/cursed-tome.js
+++ b/source/gear/cursed-tome.js
@@ -1,11 +1,11 @@
 const { GearTemplate } = require('../classes');
 
 module.exports = new GearTemplate("Cursed Tome",
-	"Reduce your Poise by @{poise}.",
+	"Passive: Reduce your Poise by @{poise}.",
 	"N/A",
 	"Pact",
 	"Untyped",
-	50,
+	-50,
 	(targets, user, isCrit, adventure) => ""
 ).setTargetingTags({ type: "none", team: "any", needsLivingTargets: false })
 	.setUpgrades("Blood Aegis", "Certain Victory", "Infinite Regeneration", "Power from Wrath")

--- a/source/gear/feverbreak-surpassing.js
+++ b/source/gear/feverbreak-surpassing.js
@@ -4,7 +4,7 @@ const { SURPASSING_VALUE } = require('../constants');
 const { getModifierEmoji } = require('../modifiers/_modifierDictionary');
 
 module.exports = new GearTemplate("Surpassing Fever Break",
-	`Deals @{element} damage to a foe, equal to damage that is pending from any ${getModifierEmoji("Poison")} and Frail on them, and then removes those debuffs. Also, increase your damage cap by @{bonus}`,
+	`Deals @{element} damage to a foe, equal to damage that is pending from any ${getModifierEmoji("Poison")} and Frail on them, and then removes those debuffs. Passive: Increase your damage cap by @{bonus}`,
 	"Poison and Frail not removed",
 	"Spell",
 	"Darkness",

--- a/source/gear/wolfring-base.js
+++ b/source/gear/wolfring-base.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 
 module.exports = new GearTemplate("Wolf Ring",
-	"Gain @{poise} Poise",
+	"Passive: Gain @{poise} Poise",
 	"N/A",
 	"Trinket",
 	"Untyped",

--- a/source/gear/wolfring-surpassing.js
+++ b/source/gear/wolfring-surpassing.js
@@ -2,7 +2,7 @@ const { GearTemplate } = require('../classes');
 const { SURPASSING_VALUE } = require('../constants');
 
 module.exports = new GearTemplate("Surpassing Wolf Ring",
-	"Gain @{poise} Poise, increase your damage cap by @{bonus}",
+	"Passive: Gain @{poise} Poise and increase your damage cap by @{bonus}",
 	"N/A",
 	"Trinket",
 	"Untyped",

--- a/source/gear/wolfring-swift.js
+++ b/source/gear/wolfring-swift.js
@@ -1,7 +1,7 @@
 const { GearTemplate } = require('../classes');
 
 module.exports = new GearTemplate("Swift Wolf Ring",
-	"Gain @{poise} Poise and @{speed} Speed",
+	"Passive: Gain @{poise} Poise and @{speed} Speed",
 	"N/A",
 	"Trinket",
 	"Untyped",

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -20,51 +20,54 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 			],
 			Common: [
 				"Blood Aegis",
-				"Life Drain"
-			],
-			Rare: [
+				"Power from Wrath",
 				"Toxic Blood Aegis",
 				"Furious Life Drain",
 				"Thirsting Life Drain"
+			],
+			Rare: [
 			]
 		},
 		Earth: {
 			Cursed: [
 			],
 			Common: [
+				"Certain Victory",
 				"Goad Futility",
 				"Pistol",
-				"Sabotage Kit",
-				"Spear"
-			],
-			Rare: [
+				"Spear",
+				"Hunter's Certain Victory",
+				"Lethal Certain Victory",
+				"Reckless Certain Victory",
 				"Flanking Pistol",
 				"Urgent Sabotage Kit",
 				"Lethal Spear",
 				"Reactive Spear",
 				"Sweeping Spear",
+			],
+			Rare: [
 			]
 		},
 		Fire: {
 			Cursed: [
 			],
 			Common: [
-				"Battleaxe",
-				"Censer",
-				"Corrosion",
 				"Firecracker",
 				"Infinite Regeneration",
-				"Shortsword"
-			],
-			Rare: [
+				"Shortsword",
 				"Furious Battleaxe",
 				"Reactive Battleaxe",
 				"Staggering Censer",
 				"Fate-Sealing Corrosion",
 				"Midas's Firecracker",
+				"Toxic Firecracker",
 				"Discounted Infinite Regeneration",
 				"Fate-Sealing Infinite Regeneration",
-				"Lethal Shortsword"
+				"Accelerating Shortsword",
+				"Lethal Shortsword",
+				"Toxic Shortsword"
+			],
+			Rare: [
 			]
 		},
 		Light: {
@@ -72,46 +75,51 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 			],
 			Common: [
 				"Shoulder Throw",
-				"War Cry"
-			],
-			Rare: [
+				"War Cry",
 				"Evasive Shoulder Throw",
 				"Charging War Cry",
 				"Slowing War Cry",
 				"Tormenting War Cry"
+			],
+			Rare: [
 			]
 		},
 		Water: {
 			Cursed: [
 			],
 			Common: [
-				"Cauldron Stir",
-				"Medicine",
-				"Poison Torrent"
-			],
-			Rare: [
+				"Blood Aegis",
+				"Charging Blood Aegis",
+				"Reinforced Blood Aegis",
+				"Toxic Blood Aegis",
 				"Corrosive Cauldron Stir",
 				"Sabotaging Cauldron Stir",
 				"Bouncing Medicine",
 				"Cleansing Medicine",
 				"Soothing Medicine",
-				"Distracting Poison Torrent"
+				"Distracting Poison Torrent",
+				"Harmful Poison Torrent"
+			],
+			Rare: [
 			]
 		},
 		Wind: {
 			Cursed: [
 			],
 			Common: [
-				"Bow"
+				"Unstoppable Bow",
+				"Slowing Daggers"
 			],
 			Rare: [
-				"Unstoppable Bow"
 			]
 		},
 		Untyped: {
 			Cursed: [
 			],
 			Common: [
+				"Cursed Tome",
+				"Cursed Blade",
+				"Wise Chainmail"
 			],
 			Rare: [
 			]


### PR DESCRIPTION
Summary
-------
- Passive tag in gear description
- Cursed gear has negative base cost

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Buying and selling Cursed gear grants and removes party gold respectively

Issue
-----
Closes #267