### PR TITLE
#293: remove decimal part of numbers intended to be integers in parsed text

### DIFF
--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -229,7 +229,7 @@ function buildGearDescription(gearName, buildFullDescription, holder) {
 		const element = getGearProperty(gearName, "element");
 		if (holder) {
 			damage += holder.power + holder.getModifierStacks("Power Up");
-			damage = Math.min(damage, holder.getDamageCap());
+			damage = Math.floor(Math.min(damage, holder.getDamageCap()));
 
 			if (holder.element === element) {
 				description = description

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -78,7 +78,7 @@ function calculateTagContent(text, tags) {
 			const countExpression = match?.[1].replace(untagged, "n");
 			if (countExpression) {
 				let parsedExpression = parseExpression(countExpression, count);
-				if (typeof parsedExpression === "number") {
+				if (typeof parsedExpression === "number" && !Number.isInteger(parsedExpression)) {
 					parsedExpression = parsedExpression.toFixed(2);
 				}
 				text = text.replace(taggedSingle, parsedExpression);


### PR DESCRIPTION
Summary
-------
- remove decimal part of numbers intended to be integers in parsed text

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] checked gear descriptions
- [x] checked artifact descriptions
- [x] checked modifier descriptions

Issue
-----
Closes #293