### PR TITLE
#291: increase player purchasing power

### DIFF
--- a/source/classes/RoomTemplate.js
+++ b/source/classes/RoomTemplate.js
@@ -32,8 +32,8 @@ class RoomTemplate {
 	/** @type {[enemyName: string, countExpression: string][]} */
 	enemyList = [];
 
-	/** @param {...[enemyName: string, countExpression: string]} enemyListInput */
-	setEnemies(...enemyListInput) {
+	/** @param {[enemyName: string, countExpression: string][]} enemyListInput */
+	setEnemies(enemyListInput) {
 		this.enemyList = enemyListInput;
 		return this;
 	}

--- a/source/rooms/_room_blueprint.js
+++ b/source/rooms/_room_blueprint.js
@@ -1,5 +1,7 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 
+const enemies = [["name", "countExpression"], ["name", "countExpression"]];
+
 module.exports = new RoomTemplate("name",
 	"element",
 	"primary category",
@@ -20,4 +22,4 @@ module.exports = new RoomTemplate("name",
 			]
 		};
 	}
-).setEnemies(["name", "countExpression"], ["name", "countExpression"]);
+).setEnemies(enemies);

--- a/source/rooms/artifactguardian-royalslime.js
+++ b/source/rooms/artifactguardian-royalslime.js
@@ -1,6 +1,8 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Royal Slime", "0.5*n"]];
+
 module.exports = new RoomTemplate("A Slimy Throneroom",
 	"@{adventure}",
 	"Artifact Guardian",
@@ -8,8 +10,8 @@ module.exports = new RoomTemplate("A Slimy Throneroom",
 	[
 		new ResourceTemplate("3", "internal", "levelsGained"),
 		new ResourceTemplate("1", "loot", "artifact"),
-		new ResourceTemplate("50*n", "loot", "gold")
+		new ResourceTemplate(`${enemies[0][1]}*100`, "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Royal Slime", "0.5*n"]);
+).setEnemies(enemies);

--- a/source/rooms/artifactguardian-treasureelemental.js
+++ b/source/rooms/artifactguardian-treasureelemental.js
@@ -1,14 +1,17 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Treasure Elemental", "1"]];
+
 module.exports = new RoomTemplate("A windfall of treasure!",
 	"Earth",
 	"Artifact Guardian",
 	"Floor to ceiling, gold coins, gems and other valuables are stacked in massive piles. Out of the corner of your eyes, you notice a mass of treasure meld together...",
 	[
 		new ResourceTemplate("3", "internal", "levelsGained"),
-		new ResourceTemplate("1", "loot", "artifact")
+		new ResourceTemplate("1", "loot", "artifact"),
+		new ResourceTemplate("75", "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder(["greed"])
-).setEnemies(["Treasure Elemental", "1"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-bloodtailhawks.js
+++ b/source/rooms/battle-bloodtailhawks.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Bloodtail Hawk", "1.5*n"]];
+
 module.exports = new RoomTemplate("Hawk Fight",
 	"Wind",
 	"Battle",
 	"A flock of birds of prey swoop down looking for a meal.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("1.5*25*n", "loot", "gold")
+		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Bloodtail Hawk", "1.5*n"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-frogranch.js
+++ b/source/rooms/battle-frogranch.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Mechabee Soldier", "1"], ["Fire-Arrow Frog", "0.5*n"], ["Mechabee Soldier", "1"]];
+
 module.exports = new RoomTemplate("Frog Ranch",
 	"Earth",
 	"Battle",
 	"Two Mechabee Soldiers are interrupted while escorting a set of domesticated Fire-Arrow Frogs to another pasture.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("50*n", "loot", "gold")
+		new ResourceTemplate(`${enemies[1][1]}*25+35`, "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Mechabee Soldier", "1"], ["Fire-Arrow Frog", "0.5*n"], ["Mechabee Soldier", "1"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-mechabees.js
+++ b/source/rooms/battle-mechabees.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Mechabee Drone", "n*0.25"], ["Mechabee Soldier", "1"], ["Mechabee Drone", "n*0.25"]];
+
 module.exports = new RoomTemplate("Mechabee Fight",
 	"Earth",
 	"Battle",
 	"Some mechabees charge at you. In addition to starting a fight, it prompts you to wonder if mechabees are more mech or more bee.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("25*n", "loot", "gold")
+		new ResourceTemplate("25*n+35", "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Mechabee Drone", "n*0.25"], ["Mechabee Soldier", "1"], ["Mechabee Drone", "n*0.25"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-meteorknight.js
+++ b/source/rooms/battle-meteorknight.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Earthly Knight", "0.5*n"], ["Meteor Knight", "1"], ["Asteroid", "0.25*n-1"]];
+
 module.exports = new RoomTemplate("Meteor Knight Fight",
 	"Fire",
 	"Battle",
 	"You are halted by a company of knights. By the time a Earthly Knight has advanced one step towards you, the Meteor Knight has recklessly charged across most of the gap!",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("1.5*25*n", "loot", "gold")
+		new ResourceTemplate("45*n", "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Earthly Knight", "0.5*n"], ["Meteor Knight", "1"], ["Asteroid", "0.25*n-1"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-slimes.js
+++ b/source/rooms/battle-slimes.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["@{adventure} Slime", "0.5*n"], ["@{adventureOpposite} Ooze", "0.5*n"]];
+
 module.exports = new RoomTemplate("Slime Fight",
 	"@{adventure}",
 	"Battle",
 	"Some slimes and oozes approach...",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("25*n", "loot", "gold")
+		new ResourceTemplate("35*n", "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["@{adventure} Slime", "0.5*n"], ["@{adventureOpposite} Ooze", "0.5*n"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-tortoises.js
+++ b/source/rooms/battle-tortoises.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Geode Tortoise", "2"]];
+
 module.exports = new RoomTemplate("Tortoise Fight",
 	"Earth",
 	"Battle",
 	"The rocky terrain rises up to reveal a pair of shelled menaces.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("80", "loot", "gold")
+		new ResourceTemplate("40*n", "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Geode Tortoise", "2"]);
+).setEnemies(enemies);

--- a/source/rooms/battle-wildfirearrowfrogs.js
+++ b/source/rooms/battle-wildfirearrowfrogs.js
@@ -1,14 +1,16 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Fire-Arrow Frog", "n"]];
+
 module.exports = new RoomTemplate("Wild Fire-Arrow Frogs",
 	"Fire",
 	"Battle",
 	"A blaze of orange and red in the muck outs itself as a warning sign to a blast of heated mud and venom.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("25*n", "loot", "gold")
+		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "gold")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Fire-Arrow Frog", "n"]);
+).setEnemies(enemies);

--- a/source/rooms/finalbattle-elkemist.js
+++ b/source/rooms/finalbattle-elkemist.js
@@ -1,6 +1,8 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Elkemist", "1"]];
+
 module.exports = new RoomTemplate("A Northern Laboratory",
 	"Water",
 	"Final Battle",
@@ -10,4 +12,4 @@ module.exports = new RoomTemplate("A Northern Laboratory",
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Elkemist", "1"]);
+).setEnemies(enemies);

--- a/source/rooms/finalbattle-mechaqueenbee.js
+++ b/source/rooms/finalbattle-mechaqueenbee.js
@@ -1,6 +1,8 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Mecha Queen: Mech Mode", "1"], ["Mechabee Drone", "n"]];
+
 module.exports = new RoomTemplate("The Hexagon: Mech Mode",
 	"Darkness",
 	"Final Battle",
@@ -10,4 +12,4 @@ module.exports = new RoomTemplate("The Hexagon: Mech Mode",
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Mecha Queen: Mech Mode", "1"], ["Mechabee Drone", "n"]);
+).setEnemies(enemies);

--- a/source/rooms/finalbattle-mechaqueenmech.js
+++ b/source/rooms/finalbattle-mechaqueenmech.js
@@ -1,6 +1,8 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Mecha Queen: Bee Mode", "1"], ["Mechabee Drone", "n"]];
+
 module.exports = new RoomTemplate("The Hexagon: Bee Mode",
 	"Earth",
 	"Final Battle",
@@ -10,4 +12,4 @@ module.exports = new RoomTemplate("The Hexagon: Bee Mode",
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["Mecha Queen: Bee Mode", "1"], ["Mechabee Drone", "n"]);
+).setEnemies(enemies);

--- a/source/rooms/finalbattle-mirrors.js
+++ b/source/rooms/finalbattle-mirrors.js
@@ -1,6 +1,8 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["@{clone}", "n"]];
+
 module.exports = new RoomTemplate("Hall of Mirrors",
 	"Untyped",
 	"Final Battle",
@@ -10,4 +12,4 @@ module.exports = new RoomTemplate("Hall of Mirrors",
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])
-).setEnemies(["@{clone}", "n"]);
+).setEnemies(enemies);

--- a/source/rooms/finalbattle-starryknight.js
+++ b/source/rooms/finalbattle-starryknight.js
@@ -1,6 +1,8 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
+const enemies = [["Starry Knight", "1"]];
+
 module.exports = new RoomTemplate("Confronting the Top Celestial Knight",
 	"Light",
 	"Final Battle",
@@ -10,4 +12,4 @@ module.exports = new RoomTemplate("Confronting the Top Celestial Knight",
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder(["appease"])
-).setEnemies(["Starry Knight", "1"]);
+).setEnemies(enemies);

--- a/source/rooms/merchant-gear.js
+++ b/source/rooms/merchant-gear.js
@@ -12,8 +12,8 @@ module.exports = new RoomTemplate("Gear Merchant",
 	"Merchant",
 	"A masked figure sits in front of a rack of weapons and other gear. \"Care to trade?\"",
 	[
-		new ResourceTemplate("n", "always", "gear").setTier("?").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("1", "always", "gear").setTier("Rare").setUIGroup(uiGroups[1])
+		new ResourceTemplate("n+1", "always", "gear").setTier("?").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("2", "always", "gear").setTier("Rare").setUIGroup(uiGroups[1])
 	],
 	function (adventure) { return {}; },
 	function (roomEmbed, adventure) {

--- a/source/rooms/merchant-gearbuying.js
+++ b/source/rooms/merchant-gearbuying.js
@@ -10,7 +10,7 @@ module.exports = new RoomTemplate("Gear Buying Merchant",
 	"Merchant",
 	"A masked figure sits in front of a half-full rack of weapons and other gear. \"Care to trade?\"",
 	[
-		new ResourceTemplate("n", "always", "gear").setTier("?")
+		new ResourceTemplate("n+1", "always", "gear").setTier("?")
 	],
 	function (adventure) { return {}; },
 	function (roomEmbed, adventure) {

--- a/source/rooms/merchant-item.js
+++ b/source/rooms/merchant-item.js
@@ -13,8 +13,8 @@ module.exports = new RoomTemplate("Item Merchant",
 	"Merchant",
 	"A masked figure sits in front of a a line up of flasks and vials. \"Care to trade?\"",
 	[
-		new ResourceTemplate("n", "always", "gear").setTier("?").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("n", "always", "item").setUIGroup(uiGroups[1])
+		new ResourceTemplate("n+1", "always", "gear").setTier("?").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("n+1", "always", "item").setUIGroup(uiGroups[1])
 	],
 	function (adventure) { return {}; },
 	function (roomEmbed, adventure) {

--- a/source/rooms/merchant-overpriced.js
+++ b/source/rooms/merchant-overpriced.js
@@ -12,8 +12,8 @@ module.exports = new RoomTemplate("Overpriced Merchant",
 	"Merchant",
 	"A masked figure sits in front of a packed rack of weapons and other gear. \"Best selction around! Looking for something particular?\"",
 	[
-		new ResourceTemplate("2*n", "always", "gear").setTier("?").setCostExpression("1.5*n").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("2", "always", "gear").setTier("Rare").setCostExpression("1.5*n").setUIGroup(uiGroups[1])
+		new ResourceTemplate("2*n+2", "always", "gear").setTier("?").setCostExpression("1.5*n").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("4", "always", "gear").setTier("Rare").setCostExpression("1.5*n").setUIGroup(uiGroups[1])
 	],
 	function (adventure) { return {}; },
 	function (roomEmbed, adventure) {


### PR DESCRIPTION
Summary
-------
- increase loot gold and merchant options
- abstract enemy list from setter to allow using enemy countExpressions to generate loot

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)

Issue
-----
Closes #291