### PR TITLE
#332: type improvements

### DIFF
--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -5,6 +5,7 @@ const { Combatant, Delver } = require("./Combatant.js");
 const { elementsList } = require("../util/elementUtil.js");
 const { parseExpression } = require("../util/textUtil.js");
 
+/** @typedef {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} CombatantElement */
 const allElements = elementsList();
 const DESCRIPTORS = ["Shining", "New", "Dusty", "Old", "Floating", "Undersea", "Future", "Intense"];
 
@@ -29,7 +30,7 @@ class Adventure {
 	id;
 	/** @type {string} */
 	name;
-	/** @type {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} */
+	/** @type {CombatantElement} */
 	element;
 	/** @type {"config" | "ongoing" | "success" | "defeat" | "giveup"} */
 	state = "config";
@@ -123,7 +124,7 @@ class Adventure {
 	}
 
 	/** Get an array with Untyped and all elements in the party
-	 * @returns {("Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped")[]}
+	 * @returns {CombatantElement[]}
 	 */
 	getElementPool() {
 		const pool = ["Untyped"];
@@ -278,9 +279,9 @@ class Challenge {
 };
 
 class Room {
-	/** This read-write payload class describes a room in an adventure
+	/** This read-write instance class describes a room in an adventure
 	 * @param {string} titleInput
-	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} elementEnum
+	 * @param {CombatantElement} elementEnum
 	 * @param {Record<string, string[]>} initialHistoryMap
 	 * @param {[enemyName: string, countExpression: string][]} enemyList
 	 */
@@ -356,9 +357,9 @@ class Room {
 }
 
 class Enemy extends Combatant {
-	/** This read-only data class defines an enemy players can fight
+	/** This read-write instance class defines an enemy currently in combat
 	 * @param {string} nameInput
-	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}" | "@{clone}"} elementEnum
+	 * @param {CombatantElement} elementEnum
 	 * @param {number} powerInput
 	 * @param {number} speedInput
 	 * @param {number} poiseExpression
@@ -371,7 +372,7 @@ class Enemy extends Combatant {
 		super(nameInput, "enemy");
 		this.archetype = nameInput;
 		this.level = bossesBeaten;
-		/** @type {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} */
+		/** @type {CombatantElement} */
 		this.element = elementEnum;
 		this.power = powerInput;
 		this.speed = speedInput;
@@ -401,12 +402,10 @@ class Enemy extends Combatant {
 		}
 	}
 
-	/** @returns {number} */
 	getMaxHP() {
 		return Math.floor(this.maxHP);
 	}
 
-	/** @returns {number} */
 	getPower() {
 		return Math.floor(this.power + this.getModifierStacks("Power Up") - this.getModifierStacks("Power Down"));
 	}
@@ -428,12 +427,10 @@ class Enemy extends Combatant {
 		return Math.floor(totalSpeed);
 	}
 
-	/** @returns {number} */
 	getCritRate() {
 		return Math.floor(this.critRate);
 	}
 
-	/** @returns {number} */
 	getPoise() {
 		return Math.floor(this.poise);
 	}

--- a/source/classes/EnemyTemplate.js
+++ b/source/classes/EnemyTemplate.js
@@ -3,10 +3,12 @@ const { BuildError } = require("./BuildError");
 const { Combatant } = require("./Combatant");
 const { CombatantReference } = require("./Move");
 
+/** @typedef {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} CombatantElement */
+
 class EnemyTemplate {
 	/**
 	 * @param {string} nameInput
-	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}" | "@{clone}"} elementEnum
+	 * @param {CombatantElement | "@{adventure}" | "@{adventureOpposite}" | "@{custom}"} elementEnum
 	 * @param {number} maxHPInput
 	 * @param {number} speedInput
 	 * @param {string} poiseExpressionInput expression, where n = delver count, that parses to number of Stagger to Stun
@@ -35,7 +37,7 @@ class EnemyTemplate {
 		this.firstAction = firstActionName;
 		this.shouldRandomizeHP = !isBoss;
 	}
-	/** @type {Record<string, {name: string, element: "Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}", priority: number, effect: (targets: Combatant[], user: Combatant, isCrit: boolean, adventure: Adventure) => string, selector: (self: Combatant, adventure: Adventure) => CombatantReference[], next: (actionName: string) => string}>} */
+	/** @type {Record<string, {name: string, element: CombatantElement | "@{adventure}" | "@{adventureOpposite}", priority: number, effect: (targets: Combatant[], user: Combatant, isCrit: boolean, adventure: Adventure) => string, selector: (self: Combatant, adventure: Adventure) => CombatantReference[], next: (actionName: string) => string}>} */
 	actions = {};
 	/** @type {[modifierName: string]: number} */
 	startingModifiers = {};
@@ -60,7 +62,7 @@ class EnemyTemplate {
 	/** Set the name, effect, target selector, and move selector of an enemy attack
 	 * @param {object} actionsInput
 	 * @param {string} actionsInput.name
-	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}"} actionsInput.element
+	 * @param {CombatantElement | "@{adventure}" | "@{adventureOpposite}"} actionsInput.element
 	 * @param {string} actionsInput.description
 	 * @param {number} actionsInput.priority
 	 * @param {(targets: Combatant[], user: Combatant, isCrit: boolean, adventure: Adventure) => string} actionsInput.effect

--- a/source/classes/LabyrinthTemplate.js
+++ b/source/classes/LabyrinthTemplate.js
@@ -1,14 +1,16 @@
 const { BuildError } = require("./BuildError");
 
+/** @typedef {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} CombatantElement */
+
 class LabyrinthTemplate {
 	/** This read-only data class defines the contents and properties of a specific labyrinth
 	 * @param {string} nameInput
-	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped"} elementInput
+	 * @param {CombatantElement} elementInput
 	 * @param {string} descriptionInput
 	 * @param {number} maxDepthInput integer
 	 * @param {number[]} bossRoomDepthsInput
-	 * @param {Record<"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped", string[]} itemMap
-	 * @param {Record<"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped", Record<"Cursed" | "Common" | "Rare", string[]>>} gearMap
+	 * @param {Record<CombatantElement, string[]} itemMap
+	 * @param {Record<CombatantElement, Record<"Cursed" | "Common" | "Rare", string[]>>} gearMap
 	 * @param {Record<"Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Workshop" | "Artifact Guardian" | "Treasure" | "Empty", string[]>} roomMap if a room category is rolled, it rolls again on that category
 	 */
 	constructor(nameInput, elementInput, descriptionInput, maxDepthInput, bossRoomDepthsInput, itemMap, gearMap, roomMap) {

--- a/source/enemies/asteroid.js
+++ b/source/enemies/asteroid.js
@@ -1,48 +1,48 @@
 const { EnemyTemplate } = require("../classes/index.js");
 const { dealDamage, changeStagger, getNames } = require("../util/combatantUtil.js");
-const { selectRandomFoe, selectAllOtherCombatants, nextRandom } = require("../shared/actionComponents.js");
+const { selectRandomFoe, selectAllOtherCombatants } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/elementUtil.js");
 
 module.exports = new EnemyTemplate("Asteroid",
-  "Earth",
-  85,
-  10,
-  "2",
-  0,
-  "Fragment",
-  false
+	"Earth",
+	85,
+	10,
+	"2",
+	0,
+	"Fragment",
+	false
 ).addAction({
-  name: "Fragment",
-  element: "Earth",
-  description: `Inflict ${getEmoji("Earth")} damage to delver, and loses some health`,
-  priority: 0,
-  effect: (targets, user, isCrit, adventure) => {
-    let damage = user.getPower() + 30;
-    const recoilDmg = 20;
-    if (isCrit) {
-      damage *= 2;
-    }
-    changeStagger(targets, "elementMatchFoe");
-    return `${dealDamage(targets, user, damage, false, user.element, adventure)} ${dealDamage([user], user, recoilDmg, true, "Untyped", adventure)}`;
-  },
-  selector: selectRandomFoe,
-  needsLivingTargets: true,
-  next: "random"
+	name: "Fragment",
+	element: "Earth",
+	description: `Inflict ${getEmoji("Earth")} damage to delver, and loses some health`,
+	priority: 0,
+	effect: (targets, user, isCrit, adventure) => {
+		let damage = user.getPower() + 30;
+		const recoilDmg = 20;
+		if (isCrit) {
+			damage *= 2;
+		}
+		changeStagger(targets, "elementMatchFoe");
+		return `${dealDamage(targets, user, damage, false, user.element, adventure)} ${dealDamage([user], user, recoilDmg, true, "Untyped", adventure)}`;
+	},
+	selector: selectRandomFoe,
+	needsLivingTargets: true,
+	next: "random"
 }).addAction({
-  name: "Bolide Burst",
-  element: "Earth",
-  description: `Sacrifice self to attack all combatants with ${getEmoji("Earth")} damage equal to its remaining hp`,
-  priority: 0,
-  effect: (targets, user, isCrit, adventure) => {
-    let damage = user.getPower() + user.hp;
-    if (isCrit) {
-      damage *= 2;
-    }
-    user.hp = 0;
-    changeStagger(targets, "elementMatchFoe");
-    return `${dealDamage(targets, user, damage, false, user.element, adventure)} ${getNames([user], adventure)[0]} is downed.`;
-  },
-  selector: selectAllOtherCombatants,
-  needsLivingTargets: true,
-  next: "random"
+	name: "Bolide Burst",
+	element: "Earth",
+	description: `Sacrifice self to attack all combatants with ${getEmoji("Earth")} damage equal to its remaining hp`,
+	priority: 0,
+	effect: (targets, user, isCrit, adventure) => {
+		let damage = user.getPower() + user.hp;
+		if (isCrit) {
+			damage *= 2;
+		}
+		user.hp = 0;
+		changeStagger(targets, "elementMatchFoe");
+		return `${dealDamage(targets, user, damage, false, user.element, adventure)} ${getNames([user], adventure)[0]} is downed.`;
+	},
+	selector: selectAllOtherCombatants,
+	needsLivingTargets: true,
+	next: "random"
 });

--- a/source/enemies/clone.js
+++ b/source/enemies/clone.js
@@ -1,12 +1,12 @@
 const { EnemyTemplate } = require("../classes");
 
 module.exports = new EnemyTemplate("@{clone}",
-	"@{clone}", // this shouldn't get used, clones always copy delvers
+	"@{custom}",
 	300,
 	100,
 	"6",
 	0,
-	"clone", // this shouldn't get used, clones always copy delvers
+	"@{clone}",
 	true
 ).setPower(35)
 	.addAction({

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -147,7 +147,7 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 		"Event": ["Imp Contract Faire", "The Score Beggar", "Free Gold?", "Apple Pie Wishing Well", "Twin Pedestals", "Gear Collector", "Repair Kit, just hanging out"],
 		"Battle": ["Frog Ranch", "Wild Fire-Arrow Frogs", "Meteor Knight Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
-		"Final Battle": ["A Northern Laboratory", "Confronting the Top Celestial Knight"],
+		"Final Battle": ["Hall of Mirrors"],
 
 		// Labyrinth Infrastructure - less customized
 		"Merchant": ["Gear Buying Merchant"],

--- a/source/util/roomUtil.js
+++ b/source/util/roomUtil.js
@@ -9,17 +9,26 @@ const anyTagRegex = generateRuntimeTemplateStringRegExp(null);
  * @param {Adventure} adventure
  */
 function spawnEnemy(enemyTemplate, adventure) {
-	const enemy = new Enemy(enemyTemplate.name, adventure.scouting.bossesEncountered, enemyTemplate.element, enemyTemplate.power ?? 0, enemyTemplate.speed, enemyTemplate.poiseExpression, enemyTemplate.critRate, enemyTemplate.firstAction, { ...enemyTemplate.startingModifiers }, adventure.delvers.length);
-	if (enemy.archetype === "@{clone}") {
+	let enemy;
+	if (enemyTemplate.name === "@{clone}") {
 		const counterpart = adventure.delvers[adventure.room.enemies.length];
+		enemy = new Enemy(enemyTemplate.name, adventure.scouting.bossesEncountered, counterpart.element, enemyTemplate.power + counterpart.gear.reduce((totalPower, currentGear) => totalPower + currentGear.power, 0), enemyTemplate.speed + counterpart.gear.reduce((totalSpeed, currentGear) => totalSpeed + currentGear.speed, 0), enemyTemplate.poiseExpression, counterpart.gear.reduce((totalCritRate, currentGear) => totalCritRate + currentGear.critRate, 0), enemyTemplate.firstAction, {}, adventure.delvers.length);
 		enemy.name = `Mirror ${counterpart.archetype}`;
-		enemy.element = counterpart.element;
 		enemy.setHP(enemyTemplate.maxHP + counterpart.gear.reduce((totalMaxHP, currentGear) => totalMaxHP + currentGear.maxHP, 0));
-		enemy.power += counterpart.gear.reduce((totalPower, currentGear) => totalPower + currentGear.power, 0);
-		enemy.speed += counterpart.gear.reduce((totalSpeed, currentGear) => totalSpeed + currentGear.speed, 0);
-		enemy.critRate += counterpart.gear.reduce((totalCritRate, currentGear) => totalCritRate + currentGear.critRate, 0);
 		enemy.poise += counterpart.gear.reduce((totalPoise, currentGear) => totalPoise + currentGear.poise, 0);
 	} else {
+		let pendingElement;
+		switch (enemyTemplate.element) {
+			case "@{adventure}":
+				pendingElement = adventure.element;
+				break;
+			case "@{adventureOpposite}":
+				pendingElement = getOpposite(adventure.element);
+				break;
+			default:
+				pendingElement = enemyTemplate.element;
+		}
+		enemy = new Enemy(enemyTemplate.name, adventure.scouting.bossesEncountered, pendingElement, enemyTemplate.power ?? 0, enemyTemplate.speed, enemyTemplate.poiseExpression, enemyTemplate.critRate, enemyTemplate.firstAction, { ...enemyTemplate.startingModifiers }, adventure.delvers.length);
 		let hpPercent = 85 + 15 * adventure.delvers.length;
 		if (enemyTemplate.shouldRandomizeHP) {
 			hpPercent += 10 * (2 - adventure.generateRandomNumber(5, "battle"));
@@ -27,18 +36,8 @@ function spawnEnemy(enemyTemplate, adventure) {
 		const pendingHP = Math.ceil(enemyTemplate.maxHP * hpPercent / 100);
 		enemy.setHP(pendingHP);
 		enemy.name = enemyTemplate.name
-			.replace("@{adventure}", adventure.element)
-			.replace("@{adventureOpposite}", getOpposite(adventure.element));
-
-		// Look for exact matches because element is a whitelist
-		switch (enemyTemplate.element.match(anyTagRegex)?.[0]) {
-			case "@{adventure}":
-				enemy.element = adventure.element;
-				break;
-			case "@{adventureOpposite}":
-				enemy.element = getOpposite(adventure.element);
-				break;
-		}
+			.replace(/@{adventure}/g, adventure.element)
+			.replace(/@{adventureOpposite}/g, getOpposite(adventure.element));
 	}
 	enemy.setId(adventure);
 	if (adventure.room.enemies) {


### PR DESCRIPTION
Summary
-------
- use @typedef JSDoc to consolidate types
- narrow type of elementEnum in Enemy constructor, reduce redundant property reassignment in spawnEnemy
- remove redundant return type documentation
- remove unused import in asteroid
- multiple tag support in enemy names

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] observed no crash when spawning clone
- [x] observed no crash when spawning non-clone

Issue
-----
Closes #332, Closes #32