### PR TITLE
#N/A: automated modifier statement combining

### DIFF
--- a/source/classes/ModifierTemplate.js
+++ b/source/classes/ModifierTemplate.js
@@ -30,6 +30,39 @@ class ModifierTemplate {
 	}
 };
 
+class ModifierReceipt {
+	/**
+	 * @param {string} combatantNameInput
+	 * @param {"add" | "remove"} receiptType
+	 * @param {string[]} succeededEmojiArray
+	 * @param {string[]} failedEmojiArray
+	 */
+	constructor(combatantNameInput, receiptType, succeededEmojiArray, failedEmojiArray) {
+		this.combatantNames = new Set([combatantNameInput]);
+		this.type = receiptType;
+		this.succeeded = new Set(succeededEmojiArray);
+		this.failed = new Set(failedEmojiArray);
+	}
+
+	/** @param {ModifierReceipt} incomingReceipt */
+	combineCombatantNames(incomingReceipt) {
+		for (const name of incomingReceipt.combatantNames) {
+			this.combatantNames.add(name);
+		}
+	}
+
+	/** @param {ModifierReceipt} incomingReceipt */
+	combineModifierSets(incomingReceipt) {
+		for (const success of incomingReceipt.succeeded) {
+			this.succeeded.add(success);
+		}
+		for (const failure of incomingReceipt.failed) {
+			this.failed.add(failure);
+		}
+	}
+}
+
 module.exports = {
-	ModifierTemplate
+	ModifierTemplate,
+	ModifierReceipt
 };

--- a/source/classes/index.js
+++ b/source/classes/index.js
@@ -10,7 +10,7 @@ const { GearTemplate } = require("./GearTemplate");
 const { ButtonWrapper, CommandWrapper, SelectWrapper } = require("./InteractionWrapper");
 const { ItemTemplate } = require("./ItemTemplate");
 const { LabyrinthTemplate } = require("./LabyrinthTemplate");
-const { ModifierTemplate } = require("./ModifierTemplate");
+const { ModifierTemplate, ModifierReceipt } = require("./ModifierTemplate");
 const { CombatantReference, Move } = require("./Move");
 const { Player } = require("./Player");
 const { ResourceTemplate, RoomTemplate } = require("./RoomTemplate");
@@ -35,6 +35,7 @@ module.exports = {
 	ItemTemplate,
 	LabyrinthTemplate,
 	ModifierTemplate,
+	ModifierReceipt,
 	Move,
 	Player,
 	ResourceTemplate,

--- a/source/enemies/earthlyknight.js
+++ b/source/enemies/earthlyknight.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, removeModifier, changeStagger } = require("../util/combatantUtil.js");
+const { dealDamage, removeModifier, changeStagger, generateModifierResultLines } = require("../util/combatantUtil.js");
 const { isBuff } = require("../modifiers/_modifierDictionary");
 const { selectRandomFoe, selectNone, selectAllFoes } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/elementUtil.js");
@@ -33,7 +33,7 @@ module.exports = new EnemyTemplate("Earthly Knight",
 			if (targetBuffs.length > 0) {
 				const buffIndex = adventure.generateRandomNumber(targetBuffs.length, "battle");
 				const rolledBuff = targetBuffs[buffIndex];
-				resultLines.push(...removeModifier([target], { name: rolledBuff, stacks: "all" }));
+				resultLines.push(...generateModifierResultLines(removeModifier([target], { name: rolledBuff, stacks: "all" })));
 			}
 		}
 		return resultLines;

--- a/source/enemies/elkemist.js
+++ b/source/enemies/elkemist.js
@@ -1,6 +1,6 @@
-const { EnemyTemplate } = require("../classes");
+const { EnemyTemplate, ModifierReceipt, Enemy } = require("../classes");
 const { isBuff, isDebuff } = require("../modifiers/_modifierDictionary.js");
-const { dealDamage, addModifier, removeModifier, changeStagger, addProtection } = require("../util/combatantUtil");
+const { dealDamage, addModifier, removeModifier, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { selectSelf, selectRandomFoe, selectAllFoes } = require("../shared/actionComponents.js");
 const { listifyEN } = require("../util/textUtil.js");
 const { getEmoji } = require("../util/elementUtil.js");
@@ -17,20 +17,22 @@ module.exports = new EnemyTemplate("Elkemist",
 ).addAction({
 	name: "Toil",
 	element: "Untyped",
-	description: "Gains protection, cures a random debuff, and grants a large amount of Progress",
+	description: "Gains protection, cures a random debuff, and grants a large amount of @e{Progress}",
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
 		changeStagger([user], "elementMatchAlly");
 		const resultLines = [`${user.name} gains protection.`];
 		if (isCrit) {
-			resultLines.push(...addModifier([user], { name: "Progress", stacks: 60 + adventure.generateRandomNumber(46, "battle") }));
+			const wrappedProgressReceipt = addModifier([user], { name: "Progress", stacks: 60 + adventure.generateRandomNumber(46, "battle") });
+			progressCheck(user, wrappedProgressReceipt, resultLines);
 		} else {
-			resultLines.push(...addModifier([user], { name: "Progress", stacks: 45 + adventure.generateRandomNumber(31, "battle") }));
+			const wrappedProgressReceipt = addModifier([user], { name: "Progress", stacks: 45 + adventure.generateRandomNumber(31, "battle") });
+			progressCheck(user, wrappedProgressReceipt, resultLines);
 		}
 		const targetDebuffs = Object.keys(user.modifiers).filter(modifier => isDebuff(modifier));
 		if (targetDebuffs.length > 0) {
 			const rolledDebuff = targetDebuffs[adventure.generateRandomNumber(targetDebuffs.length, "battle")];
-			resultLines.push(...removeModifier([user], { name: rolledDebuff, stacks: "all" }));
+			resultLines.concat(generateModifierResultLines(removeModifier([user], { name: rolledDebuff, stacks: "all" })));
 		}
 		addProtection([user], 100);
 		return resultLines;
@@ -50,8 +52,10 @@ module.exports = new EnemyTemplate("Elkemist",
 			damage *= 2;
 		}
 		changeStagger(targets, "elementMatchFoe");
-		return dealDamage(targets, user, damage, false, user.element, adventure)
-			.concat(addModifier([user], { name: "Progress", stacks: 15 + adventure.generateRandomNumber(16, "battle") }));
+		const resultLines = dealDamage(targets, user, damage, false, user.element, adventure);
+		const wrappedProgressReceipt = addModifier([user], { name: "Progress", stacks: 15 + adventure.generateRandomNumber(16, "battle") });
+		progressCheck(user, wrappedProgressReceipt, resultLines);
+		return resultLines;
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,
@@ -75,37 +79,55 @@ module.exports = new EnemyTemplate("Elkemist",
 }).addAction({
 	name: "Bubble",
 	element: "Untyped",
-	description: "Converts all foe buffs to Fire Weakness and gain Progress per buff removed",
+	description: `Converts all foe buffs to @e{Fire Weakness} and gain @e{Progress} per buff removed`,
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
 		let progressGained = adventure.generateRandomNumber(16, "battle");
-		const affectedDelvers = new Set();
 		if (isCrit) {
 			progressGained += 10;
 		}
+		const removalReceipts = [];
 		for (const target of targets) {
 			for (let modifier in target.modifiers) {
 				if (isBuff(modifier)) {
 					const buffStackCount = target.modifiers[modifier];
-					const existingRetainStacks = target.getModifierStacks("Retain");
-					removeModifier([target], { name: modifier, stacks: "all" });
-					if (existingRetainStacks < 1) {
+					const receipt = removeModifier([target], { name: modifier, stacks: "all" })[0];
+					removalReceipts.push(receipt);
+					if (receipt.succeeded.size > 0) {
 						progressGained += 5;
 						addModifier([target], { name: "Fire Weakness", stacks: buffStackCount });
-						if (!affectedDelvers.has(target.name)) {
-							affectedDelvers.add(target.name);
-						}
 					}
 				}
 			}
 		}
-		const resultLines = addModifier([user], { name: "Progress", stacks: progressGained });
-		if (affectedDelvers.size > 0) {
-			resultLines.push(`Buffs on ${listifyEN([...affectedDelvers], false)} are transmuted to ${getApplicationEmojiMarkdown("Fire Weakness")}.`);
-		}
+		const wrappedProgressReceipt = addModifier([user], { name: "Progress", stacks: progressGained });
+		progressCheck(user, wrappedProgressReceipt, resultLines);
+		combineModifierReceipts(removalReceipts).forEach(receipt => {
+			if (receipt.succeeded.size > 0) {
+				resultLines.push(`Buffs on ${listifyEN([...receipt.combatantNames])} are transmuted into ${getApplicationEmojiMarkdown("Fire Weakness")}.`);
+			}
+			if (receipt.failed.size > 0) {
+				resultLines.push(`Buffs on ${listifyEN([...receipt.combatantNames])} were retained.`);
+			}
+		})
 		return resultLines;
 	},
 	selector: selectAllFoes,
 	needsLivingTargets: false,
 	next: "random"
 }).setFlavorText({ name: "Progress", value: `Each time the Elkemist reaches 100 @e{Progress}, it'll gain a large amount of @e{Power Up}. Stun the Elkemist to reduce its @e{Progress}.` });
+
+/**
+ * @param {Enemy} elkemist
+ * @param {ModifierReceipt[]} wrappedProgressReceipt
+ * @param {string[]} resultLines
+ */
+function progressCheck(elkemist, wrappedProgressReceipt, resultLines) {
+	if (elkemist.getModifierStacks("Progress") >= 100) {
+		elkemist.modifiers.Progress = 0;
+		addModifier([elkemist], { name: "Power Up", stacks: 100, force: false });
+		resultLines.push(`Eureka! ${elkemist.name}'s ${getApplicationEmojiMarkdown("Progress")} yields ${getApplicationEmojiMarkdown("Power Up")}!`);
+	} else {
+		resultLines.push(...generateModifierResultLines(wrappedProgressReceipt));
+	}
+}

--- a/source/enemies/firearrowfrog.js
+++ b/source/enemies/firearrowfrog.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectRandomFoe, selectSelf } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/elementUtil.js");
 
 module.exports = new EnemyTemplate("Fire-Arrow Frog",
@@ -18,7 +18,8 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
 		let damage = user.getPower() + 20;
-		return dealDamage(targets, user, damage, false, user.element, adventure).concat(addModifier(targets, { name: "Poison", stacks: isCrit ? 6 : 3 }));
+		const resultLines = dealDamage(targets, user, damage, false, user.element, adventure);
+		return resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: isCrit ? 6 : 3 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,
@@ -34,7 +35,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 			stacks *= 3;
 		}
 		changeStagger([user], "elementMatchAlly");
-		return addModifier([user], { name: "Evade", stacks }).length > 0;
+		return generateModifierResultLines(addModifier([user], { name: "Evade", stacks }));
 	},
 	selector: selectSelf,
 	needsLivingTargets: false,
@@ -48,7 +49,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 		if (isCrit) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		return addModifier(targets, { name: "Slow", stacks: isCrit ? 3 : 2 });
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: isCrit ? 3 : 2 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,

--- a/source/enemies/geodetortoise.js
+++ b/source/enemies/geodetortoise.js
@@ -34,15 +34,15 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 	description: `Gain protection and @e{Power Up}`,
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
-		const addedPowerUp = user.getModifierStacks("Oblivious") < 1;
+		let addedPowerUp = false;
 		addProtection([user], 25);
 		if (isCrit) {
-			addModifier([user], { name: "Power Up", stacks: 50 });
+			addedPowerUp = addModifier([user], { name: "Power Up", stacks: 50 }).some(receipt => receipt.succeeded.size > 0);
 			changeStagger([user], "elementMatchAlly");
 		} else {
-			addModifier([user], { name: "Power Up", stacks: 25 });
+			addedPowerUp = addModifier([user], { name: "Power Up", stacks: 25 }).some(receipt => receipt.succeeded.size > 0);
 		}
-		return [`${user.name} gains protection${addedPowerUp ? ` and ${getApplicationEmojiMarkdown("Power Up")}` : ""}.`];
+		return [`${user.name} gains protection${addedPowerUp ? ` and ${getApplicationEmojiMarkdown("Power Up")}` : ` but was oblivious to ${getApplicationEmojiMarkdown("Power Up")}`}.`];
 	},
 	selector: selectSelf,
 	needsLivingTargets: false,

--- a/source/enemies/mechabeedrone.js
+++ b/source/enemies/mechabeedrone.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, addModifier, changeStagger } = require("../util/combatantUtil.js");
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require("../util/combatantUtil.js");
 const { selectRandomFoe, selectSelf, selectNone, selectAllFoes } = require("../shared/actionComponents.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 const { getEmoji } = require("../util/elementUtil.js");
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 	effect: (targets, user, isCrit, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, "elementMatchFoe");
-		return dealDamage(targets, user, damage, false, user.element, adventure).concat(addModifier(targets, { name: "Poison", stacks: isCrit ? 4 : 2 }));
+		return dealDamage(targets, user, damage, false, user.element, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: isCrit ? 4 : 2 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,
@@ -28,15 +28,15 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 }).addAction({
 	name: "Barrel Roll",
 	element: "Untyped",
-	description: "Gain Evade, gain Agility on Critical Hit",
+	description: "Gain @e{Evade}, gain @e{Agility} on Critical Hit",
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
-		const resultLines = addModifier([user], { name: "Evade", stacks: 2 });
+		const receipts = addModifier([user], { name: "Evade", stacks: 2 });
 		if (isCrit) {
-			resultLines.push(...addModifier([user], { name: "Agility", stacks: 1 }));
+			receipts.push(...addModifier([user], { name: "Agility", stacks: 1 }));
 		}
 		changeStagger([user], "elementMatchAlly");
-		return resultLines;
+		return generateModifierResultLines(receipts);
 	},
 	selector: selectSelf,
 	needsLivingTargets: false,

--- a/source/enemies/mechabeesoldier.js
+++ b/source/enemies/mechabeesoldier.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, addModifier, changeStagger } = require("../util/combatantUtil.js");
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require("../util/combatantUtil.js");
 const { selectRandomFoe, selectSelf, selectAllFoes } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/elementUtil.js");
 
@@ -19,7 +19,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 	effect: (targets, user, isCrit, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, "elementMatchFoe");
-		return dealDamage(targets, user, damage, false, user.element, adventure).concat(...addModifier(targets, { name: "Poison", stacks: isCrit ? 4 : 2 }));
+		return dealDamage(targets, user, damage, false, user.element, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: isCrit ? 4 : 2 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,
@@ -27,15 +27,15 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 }).addAction({
 	name: "Barrel Roll",
 	element: "Untyped",
-	description: "Gain Evade, gain Agility on Critical Hit",
+	description: "Gain @e{Evade}, gain @e{Agility} on Critical Hit",
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
-		const resultLines = addModifier([user], { name: "Evade", stacks: 2 });
+		const receipts = addModifier([user], { name: "Evade", stacks: 2 });
 		if (isCrit) {
-			resultLines.push(...addModifier([user], { name: "Agility", stacks: 1 }));
+			receipts.push(...addModifier([user], { name: "Agility", stacks: 1 }));
 		}
 		changeStagger([user], "elementMatchAlly");
-		return resultLines;
+		return generateModifierResultLines(receipts);
 	},
 	selector: selectSelf,
 	needsLivingTargets: false,
@@ -43,12 +43,12 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 }).addAction({
 	name: "Neurotoxin Strike",
 	element: "Earth",
-	description: `Inflict ${getEmoji("Earth")} damage and Paralysis on a single foe`,
+	description: `Inflict ${getEmoji("Earth")} damage and @e{Paralysis} on a single foe`,
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
 		let damage = user.getPower() + 40;
 		changeStagger(targets, "elementMatchFoe");
-		return dealDamage(targets, user, damage, false, user.element, adventure).concat(addModifier(targets, { name: "Paralysis", stacks: isCrit ? 5 : 3 }));
+		return dealDamage(targets, user, damage, false, user.element, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Paralysis", stacks: isCrit ? 5 : 3 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: true,

--- a/source/enemies/mechaqueenbee.js
+++ b/source/enemies/mechaqueenbee.js
@@ -1,8 +1,7 @@
 const { EnemyTemplate } = require("../classes/index.js");
 const { selectRandomFoe, selectNone, selectAllFoes, selectRandomOtherAlly, selectAllAllies } = require("../shared/actionComponents.js");
-const { addModifier, changeStagger, addProtection } = require("../util/combatantUtil.js");
+const { addModifier, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
-const { joinAsStatement } = require("../util/textUtil.js");
 
 const drone = require("./mechabeedrone.js")
 
@@ -63,11 +62,8 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 	effect: (targets, user, isCrit, adventure) => {
 		const filteredTargets = targets.filter(target => target.hp > 0 && target.name !== user.name);
 		addProtection([user], isCrit ? 60 : 30);
-		return [
-			`${user.name} gains protection.`,
-			...addModifier(filteredTargets, { name: "Quicken", stacks: 3 }),
-			...addModifier(filteredTargets, { name: "Power Up", stacks: 3 })
-		];
+		const receipts = addModifier(filteredTargets, { name: "Quicken", stacks: 3 }).concat(addModifier(filteredTargets, { name: "Power Up", stacks: 3 }));
+		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	},
 	selector: selectAllAllies,
 	needsLivingTargets: false,
@@ -110,7 +106,7 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
 		changeStagger(targets, "elementMatchFoe");
-		return addModifier(targets, { name: "Poison", stacks: isCrit ? 5 : 3 });;
+		return generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: isCrit ? 5 : 3 }));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,

--- a/source/enemies/mechaqueenmech.js
+++ b/source/enemies/mechaqueenmech.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes/index.js");
 const { selectRandomFoe, selectNone, selectAllFoes, selectRandomOtherAlly, selectAllAllies } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, addProtection, combineModifierReceipts } = require("../util/combatantUtil.js");
+const { addModifier, dealDamage, changeStagger, addProtection, combineModifierReceipts, generateModifierResultLines } = require("../util/combatantUtil.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 
 const drone = require("./mechabeedrone.js")

--- a/source/enemies/mechaqueenmech.js
+++ b/source/enemies/mechaqueenmech.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes/index.js");
 const { selectRandomFoe, selectNone, selectAllFoes, selectRandomOtherAlly, selectAllAllies } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, addProtection } = require("../util/combatantUtil.js");
+const { addModifier, dealDamage, changeStagger, addProtection, combineModifierReceipts } = require("../util/combatantUtil.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 
 const drone = require("./mechabeedrone.js")
@@ -41,11 +41,8 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 	effect: (targets, user, isCrit, adventure) => {
 		const filteredTargets = targets.filter(target => target.hp > 0 && target.name !== user.name);
 		addProtection([user], isCrit ? 60 : 30);
-		return [
-			`${user.name} gains protection.`,
-			...addModifier(filteredTargets, { name: "Quicken", stacks: 3 }),
-			...addModifier(filteredTargets, { name: "Power Up", stacks: 3 })
-		];
+		const receipts = addModifier(filteredTargets, { name: "Quicken", stacks: 3 }).concat(addModifier(filteredTargets, { name: "Power Up", stacks: 3 }));
+		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	},
 	selector: selectAllAllies,
 	needsLivingTargets: false,

--- a/source/enemies/meteorknight.js
+++ b/source/enemies/meteorknight.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, addModifier, changeStagger, addProtection } = require("../util/combatantUtil.js");
+const { dealDamage, addModifier, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil.js");
 const { selectRandomFoe, selectAllCombatants } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/elementUtil.js");
 const { joinAsStatement } = require("../util/textUtil.js");
@@ -53,7 +53,7 @@ module.exports = new EnemyTemplate("Meteor Knight",
 	description: `Grant @e{Power Up} to all combatants (friend and foe); Protects non-delvers on crit`,
 	priority: 0,
 	effect: (targets, user, isCrit, adventure) => {
-		const resultLines = addModifier(targets, { name: "Power Up", stacks: 20 });
+		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Power Up", stacks: 20 })));
 		if (isCrit) {
 			const livingEnemies = adventure.room.enemies.filter(c => c.hp > 0);
 			addProtection(livingEnemies, 50);

--- a/source/enemies/ooze.js
+++ b/source/enemies/ooze.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 	"@{adventureOpposite}",
@@ -19,7 +19,7 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 		if (isCrit) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		return addModifier(targets, { name: "Slow", stacks: 3 });
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: 3 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,

--- a/source/enemies/royalslime.js
+++ b/source/enemies/royalslime.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectSelf, selectAllFoes } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { elementsList } = require("../util/elementUtil");
 
 module.exports = new EnemyTemplate("Royal Slime",
@@ -19,12 +19,12 @@ module.exports = new EnemyTemplate("Royal Slime",
 	effect: (targets, user, isCrit, adventure) => {
 		const elementPool = elementsList(["Untyped", user.element]);
 		user.element = elementPool[adventure.generateRandomNumber(elementPool.length, "battle")];
-		const addedAbsorb = user.getModifierStacks("Oblivious") < 1;
+		let addedAbsorb = false;
 		if (isCrit) {
-			addModifier([user], { name: `${user.element} Absorb`, stacks: 5 });
+			addedAbsorb = addModifier([user], { name: `${user.element} Absorb`, stacks: 5 }).some(receipt => receipt.succeeded.size > 0);
 			changeStagger([user], "elementMatchAlly");
 		} else {
-			addModifier([user], { name: `${user.element} Absorb`, stacks: 3 });
+			addedAbsorb = addModifier([user], { name: `${user.element} Absorb`, stacks: 3 }).some(receipt => receipt.succeeded.size > 0);
 		}
 		if (addedAbsorb) {
 			return [`${user.name}'s elemental alignment has changed.`];
@@ -76,7 +76,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 		if (isCrit) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		return addModifier(targets, { name: "Slow", stacks: isCrit ? 3 : 2 });
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: isCrit ? 3 : 2 })));
 	},
 	selector: selectAllFoes,
 	needsLivingTargets: false,

--- a/source/enemies/slime.js
+++ b/source/enemies/slime.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new EnemyTemplate("@{adventure} Slime",
 	"@{adventure}",
@@ -35,7 +35,7 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 		if (isCrit) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		return addModifier(targets, { name: "Slow", stacks: isCrit ? 3 : 2 });
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: isCrit ? 3 : 2 })));
 	},
 	selector: selectRandomFoe,
 	needsLivingTargets: false,

--- a/source/enemies/treasureelemental.js
+++ b/source/enemies/treasureelemental.js
@@ -1,6 +1,6 @@
 const { EnemyTemplate } = require("../classes");
 const { selectAllFoes, selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, addProtection } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/elementUtil.js");
 
 module.exports = new EnemyTemplate("Treasure Elemental",
@@ -56,7 +56,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			if (isCrit) {
 				stacks *= 2;
 			}
-			return addModifier(targets, { name: "Slow", stacks });
+			return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks })));
 		},
 		selector: selectAllFoes,
 		needsLivingTargets: false,

--- a/source/gear/_appease.js
+++ b/source/gear/_appease.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { removeModifier } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { removeModifier, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Appease",
 	[["use", "Shrug off all insults"]],
@@ -8,17 +7,10 @@ module.exports = new GearTemplate("Appease",
 	"Untyped",
 	0,
 	(targets, user, isCrit, adventure) => {
-		const curedInsults = [];
+		const receipts = [];
 		for (const insult of ["Boring", "Lacking Rhythm", "Smelly", "Stupid", "Ugly"]) {
-			if (insult in user.modifiers) {
-				curedInsults.push(getApplicationEmojiMarkdown(insult));
-			}
-			removeModifier([user], { name: insult, stacks: "all", force: true });
+			receipts.push(...removeModifier([user], { name: insult, stacks: "all", force: true }));
 		}
-		if (curedInsults.length > 0) {
-			return [`${user.name} shrugs off ${curedInsults.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false });

--- a/source/gear/_greed.js
+++ b/source/gear/_greed.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier } = require('../util/combatantUtil.js');
+const { addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Greed",
 	[["use", "Add @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to all Treasure Elementals with priority"]],
@@ -9,7 +9,7 @@ module.exports = new GearTemplate("Greed",
 	(targets, user, isCrit, adventure) => {
 		const { modifiers: [midas, powerUp] } = module.exports;
 		const affectedTargets = targets.filter(target => target.archetype === "Treasure Elemental");
-		return addModifier(affectedTargets, powerUp).concat(addModifier(affectedTargets, midas));
+		return generateModifierResultLines(combineModifierReceipts(addModifier(affectedTargets, powerUp).concat(addModifier(affectedTargets, midas))));
 	}
 ).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
 	.setModifiers({ name: "Curse of Midas", stacks: 1 }, { name: "Power Up", stacks: 20 });

--- a/source/gear/barrier-base.js
+++ b/source/gear/barrier-base.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Barrier",
 	[
@@ -19,22 +18,7 @@ module.exports = new GearTemplate("Barrier",
 		if (isCrit) {
 			pendingVigilance.stacks *= critMultiplier;
 		}
-		const addedModifiers = [];
-		const addedVigilance = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], pendingVigilance);
-		if (addedVigilance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Vigilance"));
-		}
-		const addedEvade = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], evade);
-		if (addedEvade) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-		}
-		if (addedModifiers.length > 0) {
-			return [`${user.name} gains ${addedModifiers.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingVigilance).concat(addModifier([user], evade))))
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setUpgrades("Cleansing Barrier", "Devoted Barrier", "Vigilant Barrier")

--- a/source/gear/barrier-cleansing.js
+++ b/source/gear/barrier-cleansing.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { removeModifier, addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { removeModifier, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Cleansing Barrier",
 	[
@@ -20,27 +19,13 @@ module.exports = new GearTemplate("Cleansing Barrier",
 		if (isCrit) {
 			pendingVigilance.stacks *= critMultiplier;
 		}
-		const addedModifiers = [];
-		const addedVigilance = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], pendingVigilance);
-		if (addedVigilance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Vigilance"));
-		}
-		const addedEvade = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], evade);
-		if (addedEvade) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-		}
-		const resultLines = [];
-		if (addedModifiers.length > 0) {
-			resultLines.push(`${user.name} gains ${addedModifiers.join("")}.`);
-		}
+		const receipts = addModifier([user], pendingVigilance).concat(addModifier([user], evade));
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => isDebuff(modifier));
 		if (userDebuffs.length > 0) {
 			const rolledDebuff = userDebuffs[adventure.generateRandomNumber(userDebuffs.length, "battle")];
-			resultLines.push(...removeModifier([user], { name: rolledDebuff, stacks: "all" }));
+			receipts.push(...removeModifier([user], { name: rolledDebuff, stacks: "all" }));
 		}
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Devoted Barrier", "Vigilant Barrier")

--- a/source/gear/barrier-devoted.js
+++ b/source/gear/barrier-devoted.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
-const { joinAsStatement } = require('../util/textUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Devoted Barrier",
 	[
@@ -20,22 +18,7 @@ module.exports = new GearTemplate("Devoted Barrier",
 		if (isCrit) {
 			pendingVigilance.stacks *= critMultiplier;
 		}
-		const addedModifiers = [];
-		const addedVigilance = targets[0].getModifierStacks("Oblivious") < 1;
-		addModifier(targets, vigilance);
-		if (addedVigilance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Vigilance"));
-		}
-		const addedEvade = targets[0].getModifierStacks("Oblivious") < 1;
-		addModifier(targets, evade);
-		if (addedEvade) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-		}
-		if (addedModifiers.length > 0) {
-			return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", `${addedModifiers.join("")}.`)];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, vigilance).concat(addModifier(targets, evade))));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Cleansing Barrier", "Vigilant Barrier")

--- a/source/gear/barrier-vigilant.js
+++ b/source/gear/barrier-vigilant.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Vigilant Barrier",
 	[
@@ -19,22 +18,7 @@ module.exports = new GearTemplate("Vigilant Barrier",
 		if (isCrit) {
 			pendingVigilance.stacks *= critMultiplier;
 		}
-		const addedModifiers = [];
-		const addedVigilance = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], pendingVigilance);
-		if (addedVigilance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Vigilance"));
-		}
-		const addedEvade = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], evade);
-		if (addedEvade) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-		}
-		if (addedModifiers.length > 0) {
-			return [`${user.name} gains ${addedModifiers.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingVigilance).concat(addModifier([user], evade))));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Cleansing Barrier", "Devoted Barrier")

--- a/source/gear/battleaxe-base.js
+++ b/source/gear/battleaxe-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Battleaxe",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Battleaxe",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier([user], exposed));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Furious Battleaxe", "Reactive Battleaxe", "Thirsting Battleaxe")

--- a/source/gear/battleaxe-furious.js
+++ b/source/gear/battleaxe-furious.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Furious Battleaxe",
 	[
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Furious Battleaxe",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier([user], exposed));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Reactive Battleaxe", "Thirsting Battleaxe")

--- a/source/gear/battleaxe-reactive.js
+++ b/source/gear/battleaxe-reactive.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes/index.js');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reactive Battleaxe",
 	[
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Reactive Battleaxe",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier([user], exposed));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Furious Battleaxe", "Thirsting Battleaxe")

--- a/source/gear/battleaxe-thirsting.js
+++ b/source/gear/battleaxe-thirsting.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, gainHealth, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { addModifier, dealDamage, gainHealth, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Thirsting Battleaxe",
 	[
@@ -27,7 +26,7 @@ module.exports = new GearTemplate("Thirsting Battleaxe",
 			}
 		})
 		resultLines.push(gainHealth(user, healing * killCount, adventure));
-		return resultLines.concat(addModifier([user], exposed));
+		return resultLines.concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Furious Battleaxe", "Reactive Battleaxe")

--- a/source/gear/bloodaegis-charging.js
+++ b/source/gear/bloodaegis-charging.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { addModifier, payHP, changeStagger, addProtection } = require('../util/combatantUtil.js');
+const { addModifier, payHP, changeStagger, addProtection, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Charging Blood Aegis",
 	[
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Charging Blood Aegis",
 			pendingProtection *= critMultiplier;
 		}
 		addProtection([user], pendingProtection);
-		resultLines.push(...addModifier([user], powerUp));
+		resultLines.push(...generateModifierResultLines(addModifier([user], powerUp)));
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;

--- a/source/gear/bloodaegis-toxic.js
+++ b/source/gear/bloodaegis-toxic.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes/index.js');
-const { payHP, changeStagger, addProtection, addModifier } = require('../util/combatantUtil.js');
+const { payHP, changeStagger, addProtection, addModifier, generateModifierResultLines } = require('../util/combatantUtil.js');
 const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
 
 module.exports = new GearTemplate("Toxic Blood Aegis",
@@ -35,11 +35,10 @@ module.exports = new GearTemplate("Toxic Blood Aegis",
 		});
 		if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-			const addedPoison = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], poison);
+			const addedPoison = addModifier([target], poison).some(receipt => receipt.succeeded.size > 0);
 			resultLines.push(`${target.name} falls for the provocation${addedPoison ? ` and gains ${getApplicationEmojiMarkdown("Poison")}` : ""}.`);
 		} else {
-			resultLines.push(...addModifier([target], poison));
+			resultLines.push(...generateModifierResultLines(addModifier([target], poison)));
 		}
 		return resultLines;
 	}

--- a/source/gear/bow-evasive.js
+++ b/source/gear/bow-evasive.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Evasive Bow",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Evasive Bow",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier([user], evade));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], evade)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Thief's Bow", "Unstoppable Bow")

--- a/source/gear/buckler-base.js
+++ b/source/gear/buckler-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger, addProtection } = require('../util/combatantUtil');
+const { addModifier, changeStagger, addProtection, generateModifierResultLines } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Buckler",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Buckler",
 			pendingProtection *= critMultiplier;
 		}
 		addProtection(targets, pendingProtection);
-		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...addModifier([user], powerUp)];
+		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier([user], powerUp))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Devoted Buckler", "Guarding Buckler", "Reinforced Buckler")

--- a/source/gear/buckler-devoted.js
+++ b/source/gear/buckler-devoted.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger, addProtection } = require('../util/combatantUtil');
+const { addModifier, changeStagger, addProtection, generateModifierResultLines } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Devoted Buckler",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Devoted Buckler",
 			pendingProtection *= critMultiplier;
 		}
 		addProtection(targets, pendingProtection);
-		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...addModifier(targets, powerUp)];
+		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier(targets, powerUp))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Guarding Buckler", "Reinforced Buckler")

--- a/source/gear/buckler-guarding.js
+++ b/source/gear/buckler-guarding.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger, addProtection } = require('../util/combatantUtil');
+const { addModifier, changeStagger, addProtection, generateModifierResultLines } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Guarding Buckler",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Guarding Buckler",
 			pendingProtection *= critMultiplier;
 		}
 		addProtection(targets, pendingProtection);
-		return [joinAsStatement(false, [user, ...targets].map(combatant => combatant.name), "gains", "gain", "protection."), ...addModifier([user], powerUp)];
+		return [joinAsStatement(false, [user, ...targets].map(combatant => combatant.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier([user], powerUp))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Devoted Buckler", "Reinforced Buckler")

--- a/source/gear/buckler-reinforced.js
+++ b/source/gear/buckler-reinforced.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger, addProtection } = require('../util/combatantUtil');
+const { addModifier, changeStagger, addProtection, generateModifierResultLines } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Reinforced Buckler",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Reinforced Buckler",
 			pendingProtection *= critMultiplier;
 		}
 		addProtection([user, ...targets], pendingProtection);
-		return [joinAsStatement(false, [user, ...targets].map(combatant => combatant.name), "gains", "gain", "protection."), ...addModifier([user], powerUp)];
+		return [joinAsStatement(false, [user, ...targets].map(combatant => combatant.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier([user], powerUp))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Devoted Buckler", "Guarding Buckler")

--- a/source/gear/cauldronstir-corrosive.js
+++ b/source/gear/cauldronstir-corrosive.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Protection Potion",
@@ -35,7 +35,7 @@ module.exports = new GearTemplate("Corrosive Cauldron Stir",
 			resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 		}
 
-		return resultLines.concat(addModifier(targets, powerdown));
+		return resultLines.concat(generateModifierResultLines(addModifier(targets, powerdown)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Sabotaging Cauldron Stir", "Toxic Cauldron Stir")

--- a/source/gear/cauldronstir-sabotaging.js
+++ b/source/gear/cauldronstir-sabotaging.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Protection Potion",
@@ -38,7 +38,7 @@ module.exports = new GearTemplate("Sabotaging Cauldron Stir",
 			const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
 			const weaknessPool = elementsList(ineligibleWeaknesses);
 			if (weaknessPool.length > 0) {
-				resultLines.push(...addModifier(targets, { name: `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`, stacks: weakness.stacks }));
+				resultLines.push(...generateModifierResultLines(addModifier(targets, { name: `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`, stacks: weakness.stacks })));
 			}
 		}
 		return resultLines;

--- a/source/gear/cauldronstir-toxic.js
+++ b/source/gear/cauldronstir-toxic.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 const rollablePotions = [
 	"Protection Potion",
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Toxic Cauldron Stir",
 			adventure.room.addResource(rolledPotion, "item", "loot", 1);
 			resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 		}
-		return resultLines.concat(addModifier(targets, poison));
+		return resultLines.concat(generateModifierResultLines(addModifier(targets, poison)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Corrosive Cauldron Stir", "Sabotaging Cauldron Stir")

--- a/source/gear/censer-base.js
+++ b/source/gear/censer-base.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary.js');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Censer",
 	[
@@ -22,7 +21,7 @@ module.exports = new GearTemplate("Censer",
 		}
 		const resultLines = dealDamage([target], user, pendingDamage, false, element, adventure);
 		if (isCrit && target.hp > 0) {
-			resultLines.push(...addModifier([target], slow));
+			resultLines.push(...generateModifierResultLines(addModifier([target], slow)));
 		}
 		return resultLines;
 	}

--- a/source/gear/censer-staggering.js
+++ b/source/gear/censer-staggering.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes/index.js');
 const { isDebuff } = require('../modifiers/_modifierDictionary.js');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Staggering Censer",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Staggering Censer",
 		changeStagger([target], stagger);
 		const resultLines = dealDamage([target], user, pendingDamage, false, element, adventure);
 		if (isCrit && target.hp > 0) {
-			resultLines.push(...addModifier([target], slow));
+			resultLines.push(...generateModifierResultLines(addModifier([target], slow)));
 		}
 		return resultLines;
 	}

--- a/source/gear/censer-thick.js
+++ b/source/gear/censer-thick.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require("../classes");
 const { isDebuff } = require("../modifiers/_modifierDictionary");
-const { dealDamage, addModifier, changeStagger } = require("../util/combatantUtil");
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Thick Censer",
 	[
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Thick Censer",
 		}
 		const resultLines = dealDamage([target], user, pendingDamage, false, element, adventure);
 		if (isCrit && target.hp > 0) {
-			resultLines.push(...addModifier([target], slow));
+			resultLines.push(...generateModifierResultLines(addModifier([target], slow)));
 		}
 		return resultLines;
 	}

--- a/source/gear/censer-tormenting.js
+++ b/source/gear/censer-tormenting.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require("../classes");
 const { isDebuff } = require("../modifiers/_modifierDictionary");
-const { dealDamage, addModifier, changeStagger } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Tormenting Censer",
 	[
@@ -22,21 +21,16 @@ module.exports = new GearTemplate("Tormenting Censer",
 		}
 		const resultLines = dealDamage([target], user, pendingDamage, false, element, adventure);
 		if (target.hp > 0) {
-			const debuffs = [];
+			const receipts = [];
 			if (isCrit) {
-				const addedSlow = target.getModifierStacks("Oblivious") < 1;
-				addModifier([target], slow);
-				if (addedSlow) {
-					debuffs.push(getApplicationEmojiMarkdown("Slow"));
-				}
+				receipts.push(...addModifier([target], slow));
 			}
 			for (const modifier in target.modifiers) {
 				if (isDebuff(modifier)) {
-					addModifier([target], { name: modifier, stacks: 1 });
-					debuffs.push(getApplicationEmojiMarkdown(modifier));
+					receipts.push(...addModifier([target], { name: modifier, stacks: 1 }));
 				}
 			}
-			resultLines.push(`${target.name} gains ${debuffs.join("")}.`);
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 		}
 		return resultLines;
 	}

--- a/source/gear/certainvictory-base.js
+++ b/source/gear/certainvictory-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, payHP, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Certain Victory",
 	[
@@ -18,11 +18,10 @@ module.exports = new GearTemplate("Certain Victory",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return [
-			...dealDamage(targets, user, pendingDamage, false, element, adventure),
-			...addModifier([user], powerUp),
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(
+			...generateModifierResultLines(addModifier([user], powerUp)),
 			payHP(user, user.getModifierStacks("Power Up"), adventure)
-		];
+		);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Hunter's Certain Victory", "Lethal Certain Victory", "Reckless Certain Victory")

--- a/source/gear/certainvictory-hunters.js
+++ b/source/gear/certainvictory-hunters.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, payHP, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Hunter's Certain Victory",
 	[
@@ -23,8 +23,7 @@ module.exports = new GearTemplate("Hunter's Certain Victory",
 		if (target.hp < 1) {
 			pendingPowerUp.stacks += huntersPowerUp.stacks;
 		}
-		resultLines.push(...addModifier([user], powerUp).length, payHP(user, user.getModifierStacks("Power Up"), adventure));
-		return resultLines;
+		return resultLines.concat(...generateModifierResultLines(addModifier([user], powerUp)), payHP(user, user.getModifierStacks("Power Up"), adventure));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Lethal Certain Victory", "Reckless Certain Victory")

--- a/source/gear/certainvictory-lethal.js
+++ b/source/gear/certainvictory-lethal.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, payHP, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Lethal Certain Victory",
 	[
@@ -18,11 +18,10 @@ module.exports = new GearTemplate("Lethal Certain Victory",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return [
-			...dealDamage(targets, user, pendingDamage, false, element, adventure),
-			...addModifier([user], powerUp),
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(
+			...generateModifierResultLines(addModifier([user], powerUp)),
 			payHP(user, user.getModifierStacks("Power Up"), adventure)
-		];
+		);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Hunter's Certain Victory", "Reckless Certain Victory")

--- a/source/gear/certainvictory-reckless.js
+++ b/source/gear/certainvictory-reckless.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { dealDamage, addModifier, payHP, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Reckless Certain Victory",
 	[
@@ -20,22 +19,8 @@ module.exports = new GearTemplate("Reckless Certain Victory",
 			pendingDamage *= critMultiplier;
 		}
 		const resultLines = dealDamage(targets, user, pendingDamage, false, element, adventure);
-		const addedModifiers = [];
-		const addedPowerUp = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], powerUp);
-		if (addedPowerUp) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Power Up"));
-		}
-		const addedExposed = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], exposed);
-		if (addedExposed) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Exposed"));
-		}
-		if (addedModifiers.length > 0) {
-			resultLines.push(`${user.name} gains ${addedModifiers.join("")}.`);
-		}
-		resultLines.push(payHP(user, user.getModifierStacks("Power Up"), adventure));
-		return resultLines;
+		const receipts = addModifier([user], powerUp).concat(addModifier([user], exposed));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts), payHP(user, user.getModifierStacks("Power Up"), adventure)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Hunter's Certain Victory", "Lethal Certain Victory")

--- a/source/gear/cloak-accelerating.js
+++ b/source/gear/cloak-accelerating.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { accuratePassive } = require('./descriptions/passives.js');
 
 module.exports = new GearTemplate("Accelerating Cloak",
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Accelerating Cloak",
 			pendingEvade.stacks += bonus;
 			pendingQuicken.stacks += bonus;
 		}
-		return addModifier([user], pendingEvade).concat(addModifier([user], pendingQuicken));
+		return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingEvade).concat(addModifier([user], pendingQuicken))));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Accurate Cloak", "Evasive Cloak")

--- a/source/gear/cloak-accurate.js
+++ b/source/gear/cloak-accurate.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 const { accuratePassive } = require('./descriptions/passives.js');
 
 module.exports = new GearTemplate("Accurate Cloak",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Accurate Cloak",
 		if (isCrit) {
 			pendingEvade.stacks += bonus;
 		}
-		return addModifier([user], pendingEvade);
+		return generateModifierResultLines(addModifier([user], pendingEvade));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Accelerating Cloak", "Evasive Cloak")

--- a/source/gear/cloak-base.js
+++ b/source/gear/cloak-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 const { accuratePassive } = require('./descriptions/passives.js');
 
 module.exports = new GearTemplate("Cloak",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Cloak",
 		if (isCrit) {
 			pendingEvade.stacks += bonus;
 		}
-		return addModifier([user], pendingEvade);
+		return generateModifierResultLines(addModifier([user], pendingEvade));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setUpgrades("Accelerating Cloak", "Accurate Cloak", "Evasive Cloak")

--- a/source/gear/cloak-evasive.js
+++ b/source/gear/cloak-evasive.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 const { accuratePassive } = require('./descriptions/passives.js');
 
 module.exports = new GearTemplate("Evasive Cloak",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Evasive Cloak",
 		if (isCrit) {
 			pendingEvade.stacks += bonus;
 		}
-		return addModifier([user], pendingEvade);
+		return generateModifierResultLines(addModifier([user], pendingEvade));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Accelerating Cloak", "Accurate Cloak")

--- a/source/gear/corrosion-base.js
+++ b/source/gear/corrosion-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger } = require("../util/combatantUtil");
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { joinAsStatement } = require("../util/textUtil");
 
 module.exports = new GearTemplate("Corrosion",
@@ -15,7 +15,7 @@ module.exports = new GearTemplate("Corrosion",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		const resultLines = addModifier(targets, powerDown);
+		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier(targets, powerDown)));
 		if (isCrit) {
 			changeStagger(targets, bonus);
 			resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));

--- a/source/gear/corrosion-fatesealing.js
+++ b/source/gear/corrosion-fatesealing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger } = require("../util/combatantUtil");
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { joinAsStatement } = require("../util/textUtil");
 
 module.exports = new GearTemplate("Fate-Sealing Corrosion",
@@ -15,13 +15,14 @@ module.exports = new GearTemplate("Fate-Sealing Corrosion",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		const resultLines = addModifier(targets, powerDown);
+		const resultLines = [];
+		const receipts = addModifier(targets, powerDown);
 		if (isCrit) {
 			changeStagger(targets, bonus);
-			resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."),
-				...addModifier(targets, retain));
+			resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));
+			receipts.push(...addModifier(targets, retain));
 		}
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Harmful Corrosion", "Shattering Corrosion")

--- a/source/gear/corrosion-harmful.js
+++ b/source/gear/corrosion-harmful.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { joinAsStatement } = require("../util/textUtil");
 
 module.exports = new GearTemplate("Harmful Corrosion",
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Harmful Corrosion",
 			changeStagger(targets, bonus);
 			resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));
 		}
-		return resultLines.concat(addModifier(targets, powerDown));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, powerDown))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Fate-Sealing Corrosion", "Shattering Corrosion")

--- a/source/gear/corrosion-shattering.js
+++ b/source/gear/corrosion-shattering.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger } = require("../util/combatantUtil");
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { joinAsStatement } = require("../util/textUtil");
 
 module.exports = new GearTemplate("Shattering Corrosion",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Shattering Corrosion",
 			changeStagger(targets, bonus);
 			resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));
 		}
-		return resultLines.concat(addModifier(targets, powerDown), addModifier(targets, frail));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, powerDown).concat(addModifier(targets, frail)))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Fate-Sealing Corrosion", "Harmful Corrosion")

--- a/source/gear/daggers-slowing.js
+++ b/source/gear/daggers-slowing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Slowing Daggers",
 	[
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Slowing Daggers",
 			if (user.element === element) {
 				changeStagger(stillLivingTargets, "elementMatchFoe");
 			}
-			resultLines.push(...addModifier(stillLivingTargets, slow));
+			resultLines.push(...generateModifierResultLines(addModifier(stillLivingTargets, slow)));
 		}
 		return resultLines;
 	}

--- a/source/gear/feverbreak-base.js
+++ b/source/gear/feverbreak-base.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, removeModifier, changeStagger } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { dealDamage, removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Fever Break",
 	[
@@ -17,27 +16,17 @@ module.exports = new GearTemplate("Fever Break",
 		}
 		const funnelCount = adventure.getArtifactCount("Spiral Funnel");
 		const resultLines = [];
+		const receipts = [];
 		for (const target of targets) {
 			const poisons = target.getModifierStacks("Poison");
 			const frails = target.getModifierStacks("Frail");
 			const pendingDamage = (10 + 5 * funnelCount) * (poisons ** 2 + poisons) / 2 + (20 + 5 * funnelCount) * frails;
 			resultLines.push(...dealDamage([target], user, pendingDamage, false, element, adventure));
 			if (!isCrit) {
-				const removedDebuffs = [];
-				const curedPoison = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Poison", stacks: "all" });
-				if (curedPoison) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Poison"));
-				}
-				const curedFrail = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Frail", stacks: "all" });
-				if (curedFrail) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Frail"));
-				}
-				resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`);
+				receipts.push(...removeModifier(targets, { name: "Poison", stacks: "all" }).concat(removeModifier(targets, { name: "Frail", stacks: "all" })));
 			}
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Organic Fever Break", "Surpassing Fever Break", "Urgent Fever Break")

--- a/source/gear/feverbreak-organic.js
+++ b/source/gear/feverbreak-organic.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, removeModifier, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
 const { organicPassive } = require('./descriptions/passives');
 
 module.exports = new GearTemplate("Organic Fever Break",
@@ -18,27 +18,17 @@ module.exports = new GearTemplate("Organic Fever Break",
 		}
 		const funnelCount = adventure.getArtifactCount("Spiral Funnel");
 		const resultLines = [];
+		const receipts = [];
 		for (const target of targets) {
 			const poisons = target.getModifierStacks("Poison");
 			const frails = target.getModifierStacks("Frail");
 			const pendingDamage = (10 + 5 * funnelCount) * (poisons ** 2 + poisons) / 2 + (20 + 5 * funnelCount) * frails;
 			resultLines.push(...dealDamage([target], user, pendingDamage, false, element, adventure));
 			if (!isCrit) {
-				const removedDebuffs = [];
-				const curedPoison = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Poison", stacks: "all" });
-				if (curedPoison) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Poison"));
-				}
-				const curedFrail = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Frail", stacks: "all" });
-				if (curedFrail) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Frail"));
-				}
-				resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`);
+				receipts.push(...removeModifier(targets, { name: "Poison", stacks: "all" }).concat(removeModifier(targets, { name: "Frail", stacks: "all" })));
 			}
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Surpassing Fever Break", "Urgent Fever Break")

--- a/source/gear/feverbreak-surpassing.js
+++ b/source/gear/feverbreak-surpassing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, removeModifier, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, removeModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 const { surpassingPassive } = require('./descriptions/passives');
 
 module.exports = new GearTemplate("Surpassing Fever Break",
@@ -18,27 +18,17 @@ module.exports = new GearTemplate("Surpassing Fever Break",
 		}
 		const funnelCount = adventure.getArtifactCount("Spiral Funnel");
 		const resultLines = [];
+		const receipts = [];
 		for (const target of targets) {
 			const poisons = target.getModifierStacks("Poison");
 			const frails = target.getModifierStacks("Frail");
 			const pendingDamage = (10 + 5 * funnelCount) * (poisons ** 2 + poisons) / 2 + (20 + 5 * funnelCount) * frails;
 			resultLines.push(...dealDamage([target], user, pendingDamage, false, element, adventure));
 			if (!isCrit) {
-				const removedDebuffs = [];
-				const curedPoison = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Poison", stacks: "all" });
-				if (curedPoison) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Poison"));
-				}
-				const curedFrail = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Frail", stacks: "all" });
-				if (curedFrail) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Frail"));
-				}
-				resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`);
+				receipts.push(...removeModifier(targets, { name: "Poison", stacks: "all" }).concat(removeModifier(targets, { name: "Frail", stacks: "all" })))
 			}
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Organic Fever Break", "Urgent Fever Break")

--- a/source/gear/feverbreak-urgent.js
+++ b/source/gear/feverbreak-urgent.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, removeModifier, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Urgent Fever Break",
 	[
@@ -16,27 +16,17 @@ module.exports = new GearTemplate("Urgent Fever Break",
 		}
 		const funnelCount = adventure.getArtifactCount("Spiral Funnel");
 		const resultLines = [];
+		const receipts = [];
 		for (const target of targets) {
 			const poisons = target.getModifierStacks("Poison");
 			const frails = target.getModifierStacks("Frail");
 			const pendingDamage = (10 + 5 * funnelCount) * (poisons ** 2 + poisons) / 2 + (20 + 5 * funnelCount) * frails;
 			resultLines.push(...dealDamage([target], user, pendingDamage, false, element, adventure));
 			if (!isCrit) {
-				const removedDebuffs = [];
-				const curedPoison = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Poison", stacks: "all" });
-				if (curedPoison) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Poison"));
-				}
-				const curedFrail = targets[0].getModifierStacks("Retain") < 1;
-				removeModifier(targets, { name: "Frail", stacks: "all" });
-				if (curedFrail) {
-					removedDebuffs.push(getApplicationEmojiMarkdown("Frail"));
-				}
-				resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`);
+				receipts.push(...removeModifier(targets, { name: "Poison", stacks: "all" }), ...removeModifier(targets, { name: "Frail", stacks: "all" }));
 			}
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Organic Fever Break", "Surpassing Fever Break")

--- a/source/gear/firecracker-midass.js
+++ b/source/gear/firecracker-midass.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes/index.js');
 const { SAFE_DELIMITER } = require('../constants.js');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil.js');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Midas's Firecracker",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Midas's Firecracker",
 			if (user.element === element) {
 				changeStagger(stillLivingTargets, "elementMatchFoe");
 			}
-			resultLines.push(...addModifier(stillLivingTargets, curse));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(stillLivingTargets, curse))));
 		}
 		return resultLines;
 	}

--- a/source/gear/firecracker-toxic.js
+++ b/source/gear/firecracker-toxic.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants.js');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Firecracker",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Toxic Firecracker",
 			if (user.element === element) {
 				changeStagger(stillLivingTargets, "elementMatchFoe");
 			}
-			resultLines.push(...addModifier(stillLivingTargets, poison));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(stillLivingTargets, poison))));
 		}
 		return resultLines;
 	}

--- a/source/gear/floatingmiststance-agile.js
+++ b/source/gear/floatingmiststance-agile.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, combineModifierReceipts, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Agile Floating Mist Stance",
 	[
@@ -16,31 +14,11 @@ module.exports = new GearTemplate("Agile Floating Mist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, floatingMistStance);
-		const addedModifiers = [];
-		if (didAddStance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Floating Mist Stance"));
-		}
-		const addedAgility = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], agility);
-		if (addedAgility) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Agility"));
-		}
+		const receipts = enterStance(user, floatingMistStance).concat(addModifier([user], agility));
 		if (isCrit) {
-			const addedEvade = user.getModifierStacks("Oblivious") < 1;
-			addModifier([user], displayEvade);
-			if (addedEvade) {
-				addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-			}
+			receipts.push(...addModifier([user], displayEvade));
 		}
-		const userEffects = [];
-		if (addedModifiers.length > 0) {
-			userEffects.push(`gains ${addedModifiers.join("")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-		return [`${user.name} ${listifyEN(userEffects, false)}.`];
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Devoted Floating Mist Stance", "Soothing Floating Mist Stance")

--- a/source/gear/floatingmiststance-base.js
+++ b/source/gear/floatingmiststance-base.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Floating Mist Stance",
 	[
@@ -16,27 +14,11 @@ module.exports = new GearTemplate("Floating Mist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, floatingMistStance);
-		const addedModifiers = [];
-		if (didAddStance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Floating Mist Stance"));
-		}
+		const receipts = enterStance(user, floatingMistStance);
 		if (isCrit) {
-			const addedEvade = user.getModifierStacks("Oblivious") < 1;
-			addModifier([user], displayEvade);
-			if (addedEvade) {
-				addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-			}
+			receipts.push(...addModifier([user], displayEvade));
 		}
-
-		const userEffects = [];
-		if (addedModifiers.length > 0) {
-			userEffects.push(`gains ${addedModifiers.join("")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-		return [`${user.name} ${listifyEN(userEffects, false)}.`];
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setUpgrades("Agile Floating Mist Stance", "Devoted Floating Mist Stance", "Soothing Floating Mist Stance")

--- a/source/gear/floatingmiststance-devoted.js
+++ b/source/gear/floatingmiststance-devoted.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Devoted Floating Mist Stance",
 	[
@@ -16,27 +14,11 @@ module.exports = new GearTemplate("Devoted Floating Mist Stance",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(target, floatingMistStance);
-		const addedModifiers = [];
-		if (didAddStance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Floating Mist Stance"));
-		}
+		const receipts = enterStance(target, floatingMistStance);
 		if (isCrit) {
-			const addedEvade = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], displayEvade);
-			if (addedEvade) {
-				addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-			}
+			receipts.push(...addModifier([target], displayEvade));
 		}
-
-		const targetEffects = [];
-		if (addedModifiers.length > 0) {
-			targetEffects.push(`gains ${addedModifiers.join("")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			targetEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-		return [`${target.name} ${listifyEN(targetEffects, false)}.`];
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Agile Floating Mist Stance", "Soothing Floating Mist Stance")

--- a/source/gear/floatingmiststance-soothing.js
+++ b/source/gear/floatingmiststance-soothing.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Soothing Floating Mist Stance",
 	[
@@ -16,32 +14,11 @@ module.exports = new GearTemplate("Soothing Floating Mist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, floatingMistStance);
-		const addedModifiers = [];
-		if (didAddStance) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Floating Mist Stance"));
-		}
-		const addedAgility = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], regen);
-		if (addedAgility) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Regen"));
-		}
+		const receipts = enterStance(user, floatingMistStance).concat(addModifier([user], regen));
 		if (isCrit) {
-			const addedEvade = user.getModifierStacks("Oblivious") < 1;
-			addModifier([user], displayEvade);
-			if (addedEvade) {
-				addedModifiers.push(getApplicationEmojiMarkdown("Evade"));
-			}
+			receipts.push(...addModifier([user], displayEvade));
 		}
-
-		const userEffects = [];
-		if (addedModifiers.length > 0) {
-			userEffects.push(`gains ${addedModifiers.join("")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-		return [`${user.name} ${listifyEN(userEffects, false)}.`];
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Agile Floating Mist Stance", "Devoted Floating Mist Stance")

--- a/source/gear/goadfutility-base.js
+++ b/source/gear/goadfutility-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Goad Futility",
 	[
@@ -14,7 +14,8 @@ module.exports = new GearTemplate("Goad Futility",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const resultLines = addModifier([user], oblivious);
+		const resultLines = [];
+		const receipts = addModifier([user], oblivious);
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;
@@ -28,9 +29,9 @@ module.exports = new GearTemplate("Goad Futility",
 			resultLines.push(`${target.name} falls for the provocation.`);
 		}
 		if (isCrit) {
-			resultLines.push(...addModifier([target], unlucky));
+			receipts.push(...addModifier([target], unlucky));
 		}
-		return resultLines;
+		return generateModifierResultLines(receipts).concat(resultLines);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Flanking Goad Futility", "Poised Goad Futility", "Shattering Goad Futility")

--- a/source/gear/goadfutility-flanking.js
+++ b/source/gear/goadfutility-flanking.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Flanking Goad Futility",
 	[
@@ -14,7 +14,8 @@ module.exports = new GearTemplate("Flanking Goad Futility",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const resultLines = addModifier([user], oblivious);
+		const resultLines = [];
+		const receipts = addModifier([user], oblivious);
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;
@@ -27,11 +28,11 @@ module.exports = new GearTemplate("Flanking Goad Futility",
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
 			resultLines.push(`${target.name} falls for the provocation.`);
 		}
-		resultLines.push(...addModifier([target], exposed));
+		receipts.push(...addModifier([target], exposed));
 		if (isCrit) {
-			resultLines.push(...addModifier([target], unlucky));
+			receipts.push(...addModifier([target], unlucky));
 		}
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Poised Goad Futility", "Shattering Goad Futility")

--- a/source/gear/goadfutility-poised.js
+++ b/source/gear/goadfutility-poised.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Poised Goad Futility",
 	[
@@ -15,7 +15,8 @@ module.exports = new GearTemplate("Poised Goad Futility",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const resultLines = addModifier([user], oblivious);
+		const resultLines = [];
+		const receipts = addModifier([user], oblivious);
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;
@@ -29,9 +30,9 @@ module.exports = new GearTemplate("Poised Goad Futility",
 			resultLines.push(`${target.name} falls for the provocation.`);
 		}
 		if (isCrit) {
-			resultLines.push(...addModifier([target], unlucky));
+			receipts.push(...addModifier([target], unlucky));
 		}
-		return resultLines;
+		return generateModifierResultLines(receipts).concat(resultLines);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Flanking Goad Futility", "Shattering Goad Futility")

--- a/source/gear/goadfutility-shattering.js
+++ b/source/gear/goadfutility-shattering.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Shattering Goad Futility",
 	[
@@ -14,7 +14,8 @@ module.exports = new GearTemplate("Shattering Goad Futility",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const resultLines = addModifier([user], oblivious);
+		const resultLines = [];
+		const receipts = addModifier([user], oblivious);
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;
@@ -27,11 +28,11 @@ module.exports = new GearTemplate("Shattering Goad Futility",
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
 			resultLines.push(`${target.name} falls for the provocation.`);
 		}
-		resultLines.push(...addModifier([target], frail));
+		receipts.push(...addModifier([target], frail));
 		if (isCrit) {
-			resultLines.push(...addModifier([target], unlucky));
+			receipts.push(...addModifier([target], unlucky));
 		}
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Flanking Goad Futility", "Poised Goad Futility")

--- a/source/gear/heatmirage-base.js
+++ b/source/gear/heatmirage-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Heat Mirage",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Heat Mirage",
 		if (isCrit) {
 			pendingEvade.stacks *= critMultiplier;
 		}
-		const resultLines = addModifier([user], pendingEvade);
+		const resultLines = generateModifierResultLines(addModifier([user], pendingEvade));
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;

--- a/source/gear/heatmirage-evasive.js
+++ b/source/gear/heatmirage-evasive.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Evasive Heat Mirage",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Evasive Heat Mirage",
 		if (isCrit) {
 			pendingEvade.stacks *= critMultiplier;
 		}
-		const resultLines = addModifier([user], pendingEvade);
+		const resultLines = generateModifierResultLines(addModifier([user], pendingEvade));
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;

--- a/source/gear/heatmirage-vigilant.js
+++ b/source/gear/heatmirage-vigilant.js
@@ -1,6 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Vigilant Heat Mirage",
 	[
@@ -19,21 +18,8 @@ module.exports = new GearTemplate("Vigilant Heat Mirage",
 		if (isCrit) {
 			pendingEvade.stacks *= critMultiplier;
 		}
-		const userResults = [];
-		const addedEvade = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], pendingEvade);
-		if (addedEvade) {
-			userResults.push(getApplicationEmojiMarkdown("Evade"));
-		}
-		const addedVigilance = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], vigilance);
-		if (addedVigilance) {
-			userResults.push(getApplicationEmojiMarkdown("Vigilance"));
-		}
-		const resultLines = [];
-		if (userResults.length > 0) {
-			resultLines.push(`${user.name} gains ${userResults.join("")}.`);
-		}
+		const receipts = addModifier([user], pendingEvade).concat(addModifier([user], vigilance));
+		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 		const targetMove = adventure.room.moves.find(move => {
 			const moveUser = adventure.getCombatant(move.userReference);
 			return moveUser.name === target.name && moveUser.title === target.title;

--- a/source/gear/icebolt-awesome.js
+++ b/source/gear/icebolt-awesome.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Awesome Ice Bolt",
 	[
@@ -20,9 +20,8 @@ module.exports = new GearTemplate("Awesome Ice Bolt",
 			pendingDamage *= critMultiplier;
 			stunnedDamage *= critMultiplier;
 		}
-		const resultLines = [];
-		targets.forEach(target => resultLines.push(...dealDamage([target], user, target.isStunned ? stunnedDamage : pendingDamage, false, element, adventure)));
-		return resultLines.concat(addModifier(targets, slow));
+		const resultLines = targets.reduce((array, target) => array.concat(dealDamage([target], user, target.isStunned ? stunnedDamage : pendingDamage, false, element, adventure)), []);
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Distracting Ice Bolt", "Unlucky Ice Bolt")

--- a/source/gear/icebolt-base.js
+++ b/source/gear/icebolt-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Ice Bolt",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Ice Bolt",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier(targets, slow));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Awesome Ice Bolt", "Distracting Ice Bolt", "Unlucky Ice Bolt")

--- a/source/gear/icebolt-distracting.js
+++ b/source/gear/icebolt-distracting.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Distracting Ice Bolt",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Distracting Ice Bolt",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier(targets, slow), addModifier(targets, distracted));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow).concat(addModifier(targets, distracted)))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Awesome Ice Bolt", "Unlucky Ice Bolt")

--- a/source/gear/icebolt-unlucky.js
+++ b/source/gear/icebolt-unlucky.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Unlucky Ice Bolt",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Unlucky Ice Bolt",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier(targets, slow), addModifier(targets, unlucky));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow).concat(addModifier(targets, unlucky)))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Awesome Ice Bolt", "Distracting Ice Bolt")

--- a/source/gear/infiniteregeneration-base.js
+++ b/source/gear/infiniteregeneration-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, payHP, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Infinite Regeneration",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Infinite Regeneration",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
-		return [paymentSentence, ...addModifier(targets, regen)];
+		return [paymentSentence, ...generateModifierResultLines(addModifier(targets, regen))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Discounted Infinite Regeneration", "Fate-Sealing Infinite Regeneration", "Purifying Infinite Regeneration")

--- a/source/gear/infiniteregeneration-discounted.js
+++ b/source/gear/infiniteregeneration-discounted.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, payHP, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Discounted Infinite Regeneration",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Discounted Infinite Regeneration",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
-		return [paymentSentence, ...addModifier(targets, regen)];
+		return [paymentSentence, ...generateModifierResultLines(addModifier(targets, regen))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Fate-Sealing Infinite Regeneration", "Purifying Infinite Regeneration")

--- a/source/gear/infiniteregeneration-fatesealing.js
+++ b/source/gear/infiniteregeneration-fatesealing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, payHP, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, payHP, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Fate-Sealing Infinite Regeneration",
 	[
@@ -17,15 +17,15 @@ module.exports = new GearTemplate("Fate-Sealing Infinite Regeneration",
 			return paymentSentence;
 		}
 		const resultLines = [paymentSentence];
+		const receipts = addModifier(targets, regen);
 		if (isCrit) {
 			pendingHPCost /= critMultiplier;
-			resultLines.push(...addModifier(targets, stasis));
+			receipts.push(...addModifier(targets, stasis));
 		}
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
-		resultLines.push(...addModifier(targets, regen));
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Discounted Infinite Regeneration", "Purifying Infinite Regeneration")

--- a/source/gear/infiniteregeneration-purifying.js
+++ b/source/gear/infiniteregeneration-purifying.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes/index.js');
 const { isDebuff } = require('../modifiers/_modifierDictionary.js');
-const { addModifier, payHP, changeStagger, removeModifier } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { addModifier, payHP, changeStagger, removeModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Purifying Infinite Regeneration",
 	[
@@ -24,21 +23,16 @@ module.exports = new GearTemplate("Purifying Infinite Regeneration",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
-		const resultLines = [paymentSentence, ...addModifier(targets, regen)];
+		const resultLines = [paymentSentence];
+		const receipts = addModifier(targets, regen);
 		for (const target of targets) {
-			const curedDebuffs = [];
 			Object.keys(target.modifiers).forEach(modifier => {
 				if (isDebuff(modifier)) {
-					const didRemoveDebuff = target.getModifierStacks("Retain") < 1;
-					removeModifier([target], { name: modifier, stacks: "all" });
-					if (didRemoveDebuff) {
-						curedDebuffs.push(getApplicationEmojiMarkdown(modifier));
-					}
+					receipts.push(...removeModifier([target], { name: modifier, stacks: "all" })) ;
 				}
 			})
-			resultLines.push(`${target.name} is cured of ${curedDebuffs.join("")}.`);
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Discounted Infinite Regeneration", "Fate-Sealing Infinite Regeneration")

--- a/source/gear/inspiration-base.js
+++ b/source/gear/inspiration-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Inspiration",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Inspiration",
 		if (isCrit) {
 			pendingPowerUp.stacks += bonus;
 		}
-		return addModifier(targets, pendingPowerUp);
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp)));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Guarding Inspiration", "Soothing Inspiration", "Sweeping Inspiration")

--- a/source/gear/inspiration-guarding.js
+++ b/source/gear/inspiration-guarding.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger, addProtection } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { joinAsStatement } = require('../util/textUtil.js');
 
 module.exports = new GearTemplate("Guarding Inspiration",
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Guarding Inspiration",
 			pendingPowerUp.stacks += bonus;
 		}
 		addProtection(targets, protection);
-		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...addModifier(targets, pendingPowerUp)];
+		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp)))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Soothing Inspiration", "Sweeping Inspiration")

--- a/source/gear/inspiration-soothing.js
+++ b/source/gear/inspiration-soothing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Soothing Inspiration",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Soothing Inspiration",
 		if (isCrit) {
 			pendingPowerUp.stacks += bonus;
 		}
-		return addModifier(targets, pendingPowerUp).concat(addModifier(targets, regen));
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp).concat(addModifier(targets, regen))));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Guarding Inspiration", "Sweeping Inspiration")

--- a/source/gear/inspiration-sweeping.js
+++ b/source/gear/inspiration-sweeping.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Sweeping Inspiration",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Sweeping Inspiration",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
-		return addModifier(targets, pendingPowerUp);
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp)));
 	}
 ).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Guarding Inspiration", "Soothing Inspiration")

--- a/source/gear/ironfiststance-accurate.js
+++ b/source/gear/ironfiststance-accurate.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { accuratePassive } = require("./descriptions/passives");
 
 module.exports = new GearTemplate("Accurate Iron Fist Stance",
@@ -18,26 +16,13 @@ module.exports = new GearTemplate("Accurate Iron Fist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, ironFistStance);
-		const userEffects = [];
-		if (didAddStance) {
-			userEffects.push(`gains ${getApplicationEmojiMarkdown("Iron Fist Stance")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-
-		const resultLines = [];
-		if (userEffects.length > 0) {
-			resultLines.push(`${user.name} ${listifyEN(userEffects, false)}.`);
-		}
-
+		const receipts = enterStance(user, ironFistStance);
 		if (isCrit) {
 			const foeTeam = user.team === "delver" ? adventure.room.enemies.filter(foe => foe.hp > 0) : adventure.delvers;
-			resultLines.push(...addModifier(foeTeam, frail));
+			receipts.push(...addModifier(foeTeam, frail));
 		}
 
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Lucky Iron Fist Stance", "Organic Iron Fist Stance")

--- a/source/gear/ironfiststance-base.js
+++ b/source/gear/ironfiststance-base.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Iron Fist Stance",
 	[
@@ -16,26 +14,13 @@ module.exports = new GearTemplate("Iron Fist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, ironFistStance);
-		const userEffects = [];
-		if (didAddStance) {
-			userEffects.push(`gains ${getApplicationEmojiMarkdown("Iron Fist Stance")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-
-		const resultLines = [];
-		if (userEffects.length > 0) {
-			resultLines.push(`${user.name} ${listifyEN(userEffects, false)}.`);
-		}
-
+		const receipts = enterStance(user, ironFistStance);
 		if (isCrit) {
 			const foeTeam = user.team === "delver" ? adventure.room.enemies.filter(foe => foe.hp > 0) : adventure.delvers;
-			resultLines.push(...addModifier(foeTeam, frail));
+			receipts.push(...addModifier(foeTeam, frail));
 		}
 
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setUpgrades("Accurate Iron Fist Stance", "Lucky Iron Fist Stance", "Organic Iron Fist Stance")

--- a/source/gear/ironfiststance-lucky.js
+++ b/source/gear/ironfiststance-lucky.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
-const { listifyEN } = require("../util/textUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Lucky Iron Fist Stance",
 	[
@@ -16,36 +14,14 @@ module.exports = new GearTemplate("Lucky Iron Fist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, ironFistStance);
-		const addedBuffs = [];
-		if (didAddStance) {
-			addedBuffs.push(getApplicationEmojiMarkdown("Iron Fist Stance"));
-		}
-		const addedLucky = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], lucky);
-		if (addedLucky) {
-			addedBuffs.push(getApplicationEmojiMarkdown("Lucky"));
-		}
-
-		const userEffects = [];
-		if (addedBuffs.length > 0) {
-			userEffects.push(`gains ${addedBuffs.join("")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-
-		const resultLines = [];
-		if (userEffects.length > 0) {
-			resultLines.push(`${user.name} ${listifyEN(userEffects, false)}.`);
-		}
-
+		const receipts = enterStance(user, ironFistStance);
+		receipts.push(...addModifier([user], lucky));
 		if (isCrit) {
 			const foeTeam = user.team === "delver" ? adventure.room.enemies.filter(foe => foe.hp > 0) : adventure.delvers;
-			resultLines.push(...addModifier(foeTeam, frail));
+			receipts.push(...addModifier(foeTeam, frail));
 		}
 
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Accurate Iron Fist Stance", "Organic Iron Fist Stance")

--- a/source/gear/ironfiststance-organic.js
+++ b/source/gear/ironfiststance-organic.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { addModifier, changeStagger, enterStance } = require("../util/combatantUtil");
+const { addModifier, changeStagger, enterStance, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 const { organicPassive } = require("./descriptions/passives");
 
 module.exports = new GearTemplate("Organic Iron Fist Stance",
@@ -16,26 +16,13 @@ module.exports = new GearTemplate("Organic Iron Fist Stance",
 		if (user.element === element) {
 			changeStagger([user], "elementMatchAlly");
 		}
-		const { didAddStance, stancesRemoved } = enterStance(user, ironFistStance);
-		const userEffects = [];
-		if (didAddStance) {
-			userEffects.push(`gains ${getApplicationEmojiMarkdown("Iron Fist Stance")}`);
-		}
-		if (stancesRemoved.length > 0) {
-			userEffects.push(`exits ${stancesRemoved.map(stance => getApplicationEmojiMarkdown(stance)).join("")}`);
-		}
-
-		const resultLines = [];
-		if (userEffects.length > 0) {
-			resultLines.push(`${user.name} ${listifyEN(userEffects, false)}.`);
-		}
-
+		const receipts = enterStance(user, ironFistStance);
 		if (isCrit) {
 			const foeTeam = user.team === "delver" ? adventure.room.enemies.filter(foe => foe.hp > 0) : adventure.delvers;
-			resultLines.push(...addModifier(foeTeam, frail));
+			receipts.push(...addModifier(foeTeam, frail));
 		}
 
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
 	.setSidegrades("Organic Iron Fist Stance", "Lucky Iron Fist Stance")

--- a/source/gear/lance-accelerating.js
+++ b/source/gear/lance-accelerating.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Accelerating Lance",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Accelerating Lance",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier([user], quicken));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], quicken)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Shattering Lance", "Unstoppable Lance")

--- a/source/gear/lance-shattering.js
+++ b/source/gear/lance-shattering.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Shattering Lance",
 	[
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Shattering Lance",
 		const resultLines = dealDamage(targets, user, pendingDamage, false, element, adventure);
 		const stillLivingTargets = targets.filter(target => target.hp > 0);
 		if (stillLivingTargets.length > 0) {
-			resultLines.push(...addModifier(stillLivingTargets, frail));
+			resultLines.push(...generateModifierResultLines(addModifier(stillLivingTargets, frail)));
 		}
 		return resultLines;
 	}

--- a/source/gear/lifedrain-flanking.js
+++ b/source/gear/lifedrain-flanking.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, gainHealth, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, dealDamage, gainHealth, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Flanking Life Drain",
 	[
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Flanking Life Drain",
 		resultLines.push(gainHealth(user, pendingHealing, adventure));
 		const stillLivingTargets = targets.filter(target => target.hp > 0);
 		if (stillLivingTargets.length > 0) {
-			resultLines.push(...addModifier(stillLivingTargets, exposed));
+			resultLines.push(...generateModifierResultLines(addModifier(stillLivingTargets, exposed)));
 		}
 
 		return resultLines;

--- a/source/gear/medicine-base.js
+++ b/source/gear/medicine-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Medicine",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Medicine",
 		if (isCrit) {
 			pendingRegen.stacks *= critMultiplier;
 		}
-		return addModifier(targets, pendingRegen);
+		return generateModifierResultLines(addModifier(targets, pendingRegen));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Bouncing Medicine", "Cleansing Medicine", "Soothing Medicine")

--- a/source/gear/medicine-bouncing.js
+++ b/source/gear/medicine-bouncing.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Bouncing Medicine",
 	[
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Bouncing Medicine",
 		if (isCrit) {
 			pendingRegen.stacks *= critMultiplier;
 		}
-		return addModifier(targets, pendingRegen);
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingRegen)));
 	}
 ).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "ally", needsLivingTargets: true })
 	.setSidegrades("Cleansing Medicine", "Soothing Medicine")

--- a/source/gear/medicine-cleansing.js
+++ b/source/gear/medicine-cleansing.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Cleansing Medicine",
 	[
@@ -19,16 +19,16 @@ module.exports = new GearTemplate("Cleansing Medicine",
 		if (isCrit) {
 			pendingRegen.stacks *= critMultiplier;
 		}
-		const resultLines = addModifier(targets, pendingRegen);
+		const receipts = addModifier(targets, pendingRegen);
 		for (const target of targets) {
 			const debuffs = Object.keys(target.modifiers).filter(modifier => isDebuff(modifier));
 			if (debuffs.length > 0) {
 				const rolledDebuff = debuffs[adventure.generateRandomNumber(debuffs.length, "battle")];
-				resultLines.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
+				receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 			}
 		}
 
-		return resultLines;
+		return generateModifierResultLines(receipts);
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Bouncing Medicine", "Soothing Medicine")

--- a/source/gear/medicine-soothing.js
+++ b/source/gear/medicine-soothing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Soothing Medicine",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Soothing Medicine",
 		if (isCrit) {
 			pendingRegen.stacks *= critMultiplier;
 		}
-		return addModifier(targets, pendingRegen);
+		return generateModifierResultLines(addModifier(targets, pendingRegen));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Bouncing Medicine", "Cleansing Medicine")

--- a/source/gear/midasstaff-accelerating.js
+++ b/source/gear/midasstaff-accelerating.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accelerating Midas Staff",
 	[
@@ -23,29 +22,8 @@ module.exports = new GearTemplate("Accelerating Midas Staff",
 				changeStagger([target], "elementMatchFoe");
 			}
 		}
-		const addedCurse = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], pendingCurse);
-		const addedQuicken = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], quicken);
-		const resultLines = [];
-		if (target.name === user.name) {
-			const userEffects = [];
-			if (addedCurse) {
-				userEffects.push(getApplicationEmojiMarkdown("Curse of Midas"));
-			}
-			if (addedQuicken) {
-				userEffects.push(getApplicationEmojiMarkdown("Quicken"));
-			}
-			resultLines.push(`${user.name} gains ${userEffects.join("")}.`);
-		} else {
-			if (addedCurse) {
-				resultLines.push(`${target.name} gains ${getApplicationEmojiMarkdown("Curse of Midas")}.`);
-			}
-			if (addedQuicken) {
-				resultLines.push(`${user.name} gains ${getApplicationEmojiMarkdown("Quickened")}.`);
-			}
-		}
-		return resultLines;
+		const receipts = addModifier([target], pendingCurse).concat(addModifier([user], quicken));
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
 	.setSidegrades("Discounted Midas Staff", "Soothing Midas Staff")

--- a/source/gear/midasstaff-base.js
+++ b/source/gear/midasstaff-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Midas Staff",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Midas Staff",
 				changeStagger([target], "elementMatchFoe");
 			}
 		}
-		return addModifier([target], pendingCurse);
+		return generateModifierResultLines(addModifier([target], pendingCurse));
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
 	.setUpgrades("Accelerating Midas Staff", "Discounted Midas Staff", "Soothing Midas Staff")

--- a/source/gear/midasstaff-discounted.js
+++ b/source/gear/midasstaff-discounted.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Discounted Midas Staff",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Discounted Midas Staff",
 				changeStagger([target], "elementMatchFoe");
 			}
 		}
-		return addModifier([target], pendingCurse);
+		return generateModifierResultLines(addModifier([target], pendingCurse));
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
 	.setSidegrades("Accelerating Midas Staff", "Soothing Midas Staff")

--- a/source/gear/midasstaff-soothing.js
+++ b/source/gear/midasstaff-soothing.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Soothing Midas Staff",
 	[
@@ -23,22 +22,8 @@ module.exports = new GearTemplate("Soothing Midas Staff",
 				changeStagger([target], "elementMatchFoe");
 			}
 		}
-		const addedCurse = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], pendingCurse);
-		const addedModifiers = [];
-		if (addedCurse) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Curse of Midas"));
-		}
-		const addedRegen = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], regen);
-		if (addedRegen) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Regen"));
-		}
-		if (addedModifiers.length > 0) {
-			return [`${target.name} gains ${addedModifiers.join("")}.`];
-		} else {
-			return [];
-		}
+		const receipts = addModifier([target], pendingCurse).concat(addModifier([target], regen));
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
 	.setSidegrades("Accelerating Midas Staff", "Discounted Midas Staff")

--- a/source/gear/morningstar-hunters.js
+++ b/source/gear/morningstar-hunters.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Hunter's Morning Star",
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Hunter's Morning Star",
 		const resultLines = dealDamage(targets, user, pendingDamage, false, element, adventure);
 		const stillLivingTargets = targets.filter(target => target.hp > 0);
 		if (stillLivingTargets.length < targets.length) {
-			resultLines.push(...addModifier([user], powerUp));
+			resultLines.push(...generateModifierResultLines(addModifier([user], powerUp)));
 		}
 		resultLines.push(joinAsStatement(false, stillLivingTargets.map(target => target.name), "was", "were", "Staggered."))
 		return resultLines;

--- a/source/gear/omamori-base.js
+++ b/source/gear/omamori-base.js
@@ -1,7 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
-const { listifyEN } = require('../util/textUtil');
+const { changeStagger, addProtection, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Omamori",
 	[
@@ -21,13 +19,7 @@ module.exports = new GearTemplate("Omamori",
 			pendingLucky.stacks *= critMultiplier;
 		}
 		addProtection([user], protection);
-		const gainedEffects = ["protection"];
-		const addedLucky = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], pendingLucky);
-		if (addedLucky) {
-			gainedEffects.push(getApplicationEmojiMarkdown("Lucky"));
-		}
-		return [`${user.name} gains ${listifyEN(gainedEffects)}.`];
+		return [`${user.name} gains protection.`].concat(generateModifierResultLines(addModifier([user], pendingLucky)));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Centering Omamori", "Cleansing Omamori", "Devoted Omamori")

--- a/source/gear/omamori-centering.js
+++ b/source/gear/omamori-centering.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { changeStagger, addProtection, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 const { listifyEN } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Centering Omamori",
@@ -23,20 +22,11 @@ module.exports = new GearTemplate("Centering Omamori",
 			pendingLucky.stacks *= critMultiplier;
 		}
 		addProtection([user], protection);
-		const gainedEffects = ["protection"];
-		const addedLucky = user.getModifierStacks("Oblivious") < 1;
-		addModifier([user], pendingLucky);
-		if (addedLucky) {
-			gainedEffects.push(getApplicationEmojiMarkdown("Lucky"));
-		}
-		const userEffects = [];
-		if (gainedEffects.length > 0) {
-			userEffects.push(`gains ${listifyEN(gainedEffects)}`);
-		}
+		const userEffects = ["gains protection"];
 		if (hadStagger) {
 			userEffects.push("shrugs off some Stagger");
 		}
-		return [`${user.name} ${listifyEN(userEffects)}.`];
+		return [`${user.name} ${listifyEN(userEffects)}.`].concat(generateModifierResultLines(addModifier([user], pendingLucky)));
 	}
 ).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Cleansing Omamori", "Devoted Omamori")

--- a/source/gear/omamori-devoted.js
+++ b/source/gear/omamori-devoted.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
-const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
-const { listifyEN, joinAsStatement } = require('../util/textUtil');
+const { changeStagger, addProtection, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
+const { joinAsStatement } = require('../util/textUtil');
 
 module.exports = new GearTemplate("Devoted Omamori",
 	[
@@ -21,13 +20,7 @@ module.exports = new GearTemplate("Devoted Omamori",
 			pendingLucky.stacks *= critMultiplier;
 		}
 		addProtection(targets, protection);
-		const gainedEffects = ["protection"];
-		const addedLucky = targets[0].getModifierStacks("Oblivious") < 1;
-		addModifier(targets, pendingLucky);
-		if (addedLucky) {
-			gainedEffects.push(getApplicationEmojiMarkdown("Lucky"));
-		}
-		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", `${listifyEN(gainedEffects)}.`)];
+		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection.")].concat(generateModifierResultLines(addModifier(targets, pendingLucky)));
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Centering Omamori", "Cleansing Omamori")

--- a/source/gear/pistol-base.js
+++ b/source/gear/pistol-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Pistol",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Pistol",
 		if (targets.some(target => getCombatantWeaknesses(target).includes(element))) {
 			const allyTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 			const ally = allyTeam[adventure.generateRandomNumber(allyTeam.length, "battle")];
-			resultLines.push(...addModifier([ally], powerUp));
+			resultLines.push(...generateModifierResultLines(addModifier([ally], powerUp)));
 		}
 		return resultLines;
 	}

--- a/source/gear/pistol-double.js
+++ b/source/gear/pistol-double.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Double Pistol",
 	[
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Double Pistol",
 			for (let i = 0; i < 2; i++) {
 				selectedAllies.push(allyTeam[adventure.generateRandomNumber(allyTeam.length, "battle")]);
 			}
-			resultLines.push(...addModifier(selectedAllies, powerUp));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(selectedAllies, powerUp))));
 		}
 		return resultLines;
 	}

--- a/source/gear/pistol-duelists.js
+++ b/source/gear/pistol-duelists.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require("../classes");
-const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger } = require("../util/combatantUtil");
+const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new GearTemplate("Duelist's Pistol",
 	[
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Duelist's Pistol",
 		if (getCombatantWeaknesses(target).includes(element)) {
 			const allyTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 			const ally = allyTeam[adventure.generateRandomNumber(allyTeam.length, "battle")];
-			resultLines.push(...addModifier([ally], powerUp));
+			resultLines.push(...generateModifierResultLines(addModifier([ally], powerUp)));
 		}
 		return resultLines;
 	}

--- a/source/gear/pistol-flanking.js
+++ b/source/gear/pistol-flanking.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Flanking Pistol",
 	[
@@ -19,12 +19,13 @@ module.exports = new GearTemplate("Flanking Pistol",
 			changeStagger(targets, "elementMatchFoe");
 		}
 		const resultLines = dealDamage(targets, user, pendingDamage, false, element, adventure);
+		const receipts = addModifier(targets, exposed);
 		if (targets.some(target => getCombatantWeaknesses(target).includes(element))) {
 			const allyTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 			const ally = allyTeam[adventure.generateRandomNumber(allyTeam.length, "battle")];
-			resultLines.push(...addModifier([ally], powerUp));
+			receipts.push(...addModifier([ally], powerUp));
 		}
-		return resultLines.concat(addModifier(targets, exposed));
+		return resultLines.concat(generateModifierResultLines(receipts));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Double Pistol", "Duelist's Pistol")

--- a/source/gear/poisontorrent-base.js
+++ b/source/gear/poisontorrent-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Poison Torrent",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Poison Torrent",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		return addModifier(targets, pendingPoison);
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPoison)));
 	}
 ).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Distracting Poison Torrent", "Harmful Poison Torrent", "Staggering Poison Torrent")

--- a/source/gear/poisontorrent-distracting.js
+++ b/source/gear/poisontorrent-distracting.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Distracting Poison Torrent",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Distracting Poison Torrent",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchFoe");
 		}
-		return addModifier(targets, pendingPoison).concat(addModifier(targets, distracted));
+		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPoison).concat(addModifier(targets, distracted))));
 	}
 ).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Harmful Poison Torrent", "Staggering Poison Torrent")

--- a/source/gear/poisontorrent-harmful.js
+++ b/source/gear/poisontorrent-harmful.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Harmful Poison Torrent",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Harmful Poison Torrent",
 			if (user.element === element) {
 				changeStagger(stillLivingTargets, "elementMatchFoe");
 			}
-			resultLines.push(...addModifier(stillLivingTargets, pendingPoison));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(stillLivingTargets, pendingPoison))));
 		}
 		return resultLines;
 	}

--- a/source/gear/poisontorrent-staggering.js
+++ b/source/gear/poisontorrent-staggering.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Staggering Poison Torrent",
 	[
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Staggering Poison Torrent",
 			changeStagger(targets, "elementMatchFoe");
 		}
 		changeStagger(targets, stagger);
-		return ["All foes were Staggered.", ...addModifier(targets, pendingPoison)];
+		return ["All foes were Staggered.", ...generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPoison)))];
 	}
 ).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Distracting Poison Torrent", "Harmful Poison Torrent")

--- a/source/gear/powerfromwrath-hunters.js
+++ b/source/gear/powerfromwrath-hunters.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { payHP, dealDamage, changeStagger } = require('../util/combatantUtil');
+const { payHP, dealDamage, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Hunter's Power from Wrath",
 	[
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Hunter's Power from Wrath",
 			resultLines.push(...dealDamage(targets, user, pendingDamage, false, element, adventure));
 			const stillLivingTargets = targets.filter(target => target.hp > 0);
 			if (stillLivingTargets.length < targets.length) {
-				resultLines.push(...addModifier([user], powerUp));
+				resultLines.push(...generateModifierResultLines(addModifier([user], powerUp)));
 			}
 		}
 		return resultLines;

--- a/source/gear/prismaticblast-distracting.js
+++ b/source/gear/prismaticblast-distracting.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Distracting Prismatic Blast",
 	[
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Distracting Prismatic Blast",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier(targets, distracted));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, distracted))));
 	}
 ).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe", needsLivingTargets: true })
 	.setSidegrades("Flanking Prismatic Blast", "Vexing Prismatic Blast")

--- a/source/gear/prismaticblast-flanking.js
+++ b/source/gear/prismaticblast-flanking.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { SAFE_DELIMITER } = require('../constants');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Flanking Prismatic Blast",
 	[
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Flanking Prismatic Blast",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier(targets, exposed));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, exposed))));
 	}
 ).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe", needsLivingTargets: true })
 	.setSidegrades("Distracting Prismatic Blast", "Vexing Prismatic Blast")

--- a/source/gear/refreshingbreeze-accelerating.js
+++ b/source/gear/refreshingbreeze-accelerating.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { removeModifier, changeStagger, addModifier } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { removeModifier, changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Accelerating Refreshing Breeze",
 	[
@@ -13,31 +12,26 @@ module.exports = new GearTemplate("Accelerating Refreshing Breeze",
 	350,
 	(targets, user, isCrit, adventure) => {
 		const { element, modifiers: [quicken] } = module.exports;
-		const resultLines = [];
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
+		const receipts = addModifier(targets, quicken);
 		for (const target of targets) {
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => isDebuff(modifier));
 			if (targetDebuffs.length > 0) {
 				const debuffsToRemove = Math.min(targetDebuffs.length, isCrit ? 2 : 1);
-				const removedDebuffs = [];
 				for (let i = 0; i < debuffsToRemove; i++) {
 					const debuffIndex = adventure.generateRandomNumber(targetDebuffs.length, "battle");
 					const rolledDebuff = targetDebuffs[debuffIndex];
-					const wasRemoved = target.getModifierStacks("Retain") < 1;
-					removeModifier([target], { name: rolledDebuff, stacks: "all" });
-					if (wasRemoved) {
-						removedDebuffs.push(rolledDebuff);
+					const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
+					receipts.push(removalReceipt);
+					if (removalReceipt.succeeded.size > 0) {
 						targetDebuffs.splice(debuffIndex, 1);
 					}
 				}
-				if (removedDebuffs.length > 0) {
-					resultLines.push(`${target.name} is cured of ${removedDebuffs.map(debuff => getApplicationEmojiMarkdown(debuff)).join("")}.`)
-				}
 			}
 		}
-		return resultLines.concat(addModifier(targets, quicken));
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Supportive Refreshing Breeze", "Swift Refreshing Breeze")

--- a/source/gear/refreshingbreeze-base.js
+++ b/source/gear/refreshingbreeze-base.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { removeModifier, changeStagger } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Refreshing Breeze",
 	[
@@ -16,28 +15,23 @@ module.exports = new GearTemplate("Refreshing Breeze",
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
-		const resultLines = [];
+		const receipts = [];
 		targets.forEach(target => {
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => isDebuff(modifier));
 			if (targetDebuffs.length > 0) {
 				const debuffsToRemove = Math.min(targetDebuffs.length, isCrit ? 2 : 1);
-				const removedDebuffs = [];
 				for (let i = 0; i < debuffsToRemove; i++) {
 					const debuffIndex = adventure.generateRandomNumber(targetDebuffs.length, "battle");
 					const rolledDebuff = targetDebuffs[debuffIndex];
-					const wasRemoved = target.getModifierStacks("Retain") < 1;
-					removeModifier([target], { name: rolledDebuff, stacks: "all" });
-					if (wasRemoved) {
-						removedDebuffs.push(getApplicationEmojiMarkdown(rolledDebuff));
+					const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
+					receipts.push(removalReceipt);
+					if (removalReceipt.succeeded.size > 0) {
 						targetDebuffs.splice(debuffIndex, 1);
 					}
 				}
-				if (removedDebuffs.length > 0) {
-					resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`)
-				}
 			}
 		})
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
 	.setUpgrades("Accelerating Refereshing Breeze", "Supportive Refreshing Breeze", "Swift Refreshing Breeze")

--- a/source/gear/refreshingbreeze-supportive.js
+++ b/source/gear/refreshingbreeze-supportive.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { removeModifier, changeStagger } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Supportive Refreshing Breeze",
 	[
@@ -13,32 +12,28 @@ module.exports = new GearTemplate("Supportive Refreshing Breeze",
 	350,
 	(targets, user, isCrit, adventure) => {
 		const { element, stagger } = module.exports;
-		const resultLines = ["All allies shrug off some Stagger."];
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
 		changeStagger(targets, stagger);
+		const resultLines = ["All allies shrug off some Stagger."];
+		const receipts = [];
 		for (const target of targets) {
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => isDebuff(modifier));
 			if (targetDebuffs.length > 0) {
 				const debuffsToRemove = Math.min(targetDebuffs.length, isCrit ? 2 : 1);
-				const removedDebuffs = [];
 				for (let i = 0; i < debuffsToRemove; i++) {
 					const debuffIndex = adventure.generateRandomNumber(targetDebuffs.length, "battle");
 					const rolledDebuff = targetDebuffs[debuffIndex];
-					const wasRemoved = target.getModifierStacks("Retain") < 1;
-					removeModifier([target], { name: rolledDebuff, stacks: "all" });
-					if (wasRemoved) {
-						removedDebuffs.push(getApplicationEmojiMarkdown(rolledDebuff));
+					const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
+					receipts.push(removalReceipt);
+					if (removalReceipt.succeeded.size > 0) {
 						targetDebuffs.splice(debuffIndex, 1);
 					}
 				}
-				if (removedDebuffs.length > 0) {
-					resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`)
-				}
 			}
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Accelerating Refreshing Breeze", "Swift Refreshing Breeze")

--- a/source/gear/refreshingbreeze-swift.js
+++ b/source/gear/refreshingbreeze-swift.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { removeModifier, changeStagger } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
 const { swiftPassive } = require('./descriptions/passives');
 
 module.exports = new GearTemplate("Swift Refreshing Breeze",
@@ -15,31 +14,26 @@ module.exports = new GearTemplate("Swift Refreshing Breeze",
 	350,
 	(targets, user, isCrit, adventure) => {
 		const { element } = module.exports;
-		const resultLines = [];
 		if (user.element === element) {
 			changeStagger(targets, "elementMatchAlly");
 		}
+		const receipts = [];
 		for (const target of targets) {
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => isDebuff(modifier));
 			if (targetDebuffs.length > 0) {
 				const debuffsToRemove = Math.min(targetDebuffs.length, isCrit ? 2 : 1);
-				const removedDebuffs = [];
 				for (let i = 0; i < debuffsToRemove; i++) {
 					const debuffIndex = adventure.generateRandomNumber(targetDebuffs.length, "battle");
 					const rolledDebuff = targetDebuffs[debuffIndex];
-					const wasRemoved = target.getModifierStacks("Retain") < 1;
-					removeModifier([target], { name: rolledDebuff, stacks: "all" });
-					if (wasRemoved) {
-						removedDebuffs.push(getApplicationEmojiMarkdown(rolledDebuff));
+					const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
+					receipts.push(removalReceipt);
+					if (removalReceipt.succeeded.size > 0) {
 						targetDebuffs.splice(debuffIndex, 1);
 					}
 				}
-				if (removedDebuffs.length > 0) {
-					resultLines.push(`${target.name} is cured of ${removedDebuffs.join("")}.`)
-				}
 			}
 		}
-		return resultLines;
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Accelerating Refreshing Breeze", "Supportive Refreshing Breeze")

--- a/source/gear/riskymixture-base.js
+++ b/source/gear/riskymixture-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Risky Mixture",
 	[
@@ -19,9 +19,9 @@ module.exports = new GearTemplate("Risky Mixture",
 			}
 		}
 		if (isCrit) {
-			return addModifier([target], regen);
+			return generateModifierResultLines(addModifier([target], regen));
 		} else {
-			return addModifier([target], poison);
+			return generateModifierResultLines(addModifier([target], poison));
 		}
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })

--- a/source/gear/riskymixture-midass.js
+++ b/source/gear/riskymixture-midass.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Midas's Risky Mixture",
 	[
@@ -19,30 +18,13 @@ module.exports = new GearTemplate("Midas's Risky Mixture",
 				changeStagger([target], "elementMatchFoe");
 			}
 		}
-		const addedModifiers = [];
+		const receipts = addModifier([target], curseOfMidas);
 		if (isCrit) {
-			const addedRegen = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], regen);
-			if (addedRegen) {
-				addedModifiers.push(getApplicationEmojiMarkdown("Regen"));
-			}
+			receipts.unshift(...addModifier([target], regen));
 		} else {
-			const addedPoison = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], poison);
-			if (addedPoison) {
-				addedModifiers.push(getApplicationEmojiMarkdown("Poison"));
-			}
+			receipts.unshift(...addModifier([target], poison));
 		}
-		const addedCurse = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], curseOfMidas);
-		if (addedCurse) {
-			addedModifiers.push(getApplicationEmojiMarkdown("Curse of Midas"));
-		}
-		if (addedModifiers.length > 0) {
-			return [`${target.name} gains ${addedModifiers.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
 	.setSidegrades("Potent Risky Mixture", "Thick Risky Mixture")

--- a/source/gear/riskymixture-potent.js
+++ b/source/gear/riskymixture-potent.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Potent Risky Mixture",
 	[
@@ -19,9 +19,9 @@ module.exports = new GearTemplate("Potent Risky Mixture",
 			}
 		}
 		if (isCrit) {
-			return addModifier([target], regen);
+			return generateModifierResultLines(addModifier([target], regen));
 		} else {
-			return addModifier([target], poison);
+			return generateModifierResultLines(addModifier([target], poison));
 		}
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })

--- a/source/gear/riskymixture-thick.js
+++ b/source/gear/riskymixture-thick.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Thick Risky Mixture",
 	[
@@ -19,9 +19,9 @@ module.exports = new GearTemplate("Thick Risky Mixture",
 			}
 		}
 		if (isCrit) {
-			return addModifier([target], regen);
+			return generateModifierResultLines(addModifier([target], regen));
 		} else {
-			return addModifier([target], poison);
+			return generateModifierResultLines(addModifier([target], poison));
 		}
 	}
 ).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })

--- a/source/gear/sabotagekit-base.js
+++ b/source/gear/sabotagekit-base.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, getCombatantWeaknesses, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { elementsList, getResistances } = require('../util/elementUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
 
 module.exports = new GearTemplate("Sabotage Kit",
 	[
@@ -15,9 +14,6 @@ module.exports = new GearTemplate("Sabotage Kit",
 		const { element, modifiers: [slow, weakness], bonus } = module.exports;
 		const pendingSlow = { ...slow };
 		const pendingWeakness = { stacks: weakness.stacks };
-		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
-		const weaknessPool = elementsList(ineligibleWeaknesses);
-		pendingWeakness.name = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
 		if (isCrit) {
 			pendingSlow.stacks += bonus;
 			pendingWeakness.stacks += bonus;
@@ -25,24 +21,14 @@ module.exports = new GearTemplate("Sabotage Kit",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const debuffs = [];
-		const addedSlow = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], pendingSlow);
-		if (addedSlow) {
-			debuffs.push(getApplicationEmojiMarkdown("Slow"));
-		}
+		const receipts = addModifier([target], pendingSlow);
+		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
+		const weaknessPool = elementsList(ineligibleWeaknesses);
 		if (weaknessPool.length > 0) {
-			const addedWeakness = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], pendingWeakness);
-			if (addedWeakness) {
-				debuffs.push(getApplicationEmojiMarkdown(pendingWeakness.name));
-			}
+			pendingWeakness.name = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
+			receipts.unshift(...addModifier([target], pendingWeakness));
 		}
-		if (debuffs.length > 0) {
-			return [`${target.name} gains ${debuffs.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setUpgrades("Potent Sabotage Kit", "Shattering Sabotage Kit", "Urgent Sabotage Kit")
 	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })

--- a/source/gear/sabotagekit-potent.js
+++ b/source/gear/sabotagekit-potent.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier, getCombatantWeaknesses, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { elementsList, getResistances } = require('../util/elementUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
 
 module.exports = new GearTemplate("Potent Sabotage Kit",
 	[
@@ -15,9 +14,6 @@ module.exports = new GearTemplate("Potent Sabotage Kit",
 		const { element, modifiers: [slow, weakness], bonus } = module.exports;
 		const pendingSlow = { ...slow };
 		const pendingWeakness = { stacks: weakness.stacks };
-		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
-		const weaknessPool = elementsList(ineligibleWeaknesses);
-		pendingWeakness.name = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
 		if (isCrit) {
 			pendingSlow.stacks += bonus;
 			pendingWeakness.stacks += bonus;
@@ -25,24 +21,14 @@ module.exports = new GearTemplate("Potent Sabotage Kit",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const debuffs = [];
-		const addedSlow = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], pendingSlow);
-		if (addedSlow) {
-			debuffs.push(getApplicationEmojiMarkdown("Slow"));
-		}
+		const receipts = addModifier([target], pendingSlow);
+		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
+		const weaknessPool = elementsList(ineligibleWeaknesses);
 		if (weaknessPool.length > 0) {
-			const addedWeakness = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], pendingWeakness);
-			if (addedWeakness) {
-				debuffs.push(getApplicationEmojiMarkdown(pendingWeakness.name));
-			}
+			pendingWeakness.name = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
+			receipts.unshift(...addModifier([target], pendingWeakness));
 		}
-		if (debuffs.length > 0) {
-			return [`${target.name} gains ${debuffs.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setSidegrades("Shattering Sabotage Kit", "Urgent Sabotage Kit")
 	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })

--- a/source/gear/sabotagekit-shattering.js
+++ b/source/gear/sabotagekit-shattering.js
@@ -1,7 +1,6 @@
 const { GearTemplate } = require('../classes/index.js');
-const { addModifier, getCombatantWeaknesses, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, getCombatantWeaknesses, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { elementsList, getResistances } = require('../util/elementUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
 
 module.exports = new GearTemplate("Shattering Sabotage Kit",
 	[
@@ -15,9 +14,6 @@ module.exports = new GearTemplate("Shattering Sabotage Kit",
 		const { element, modifiers: [slow, weakness, frail], bonus } = module.exports;
 		const pendingSlow = { ...slow };
 		const pendingWeakness = { stacks: weakness.stacks };
-		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
-		const weaknessPool = elementsList(ineligibleWeaknesses);
-		pendingWeakness.name = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
 		if (isCrit) {
 			pendingSlow.stacks += bonus;
 			pendingWeakness.stacks += bonus;
@@ -25,29 +21,14 @@ module.exports = new GearTemplate("Shattering Sabotage Kit",
 		if (user.element === element) {
 			changeStagger([target], "elementMatchFoe");
 		}
-		const debuffs = [];
-		const addedSlow = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], pendingSlow);
-		if (addedSlow) {
-			debuffs.push(getApplicationEmojiMarkdown("Slow"));
-		}
+		const receipts = addModifier([target], pendingSlow).concat(addModifier([target], frail));
+		const ineligibleWeaknesses = getResistances(target.element).concat(getCombatantWeaknesses(target));
+		const weaknessPool = elementsList(ineligibleWeaknesses);
 		if (weaknessPool.length > 0) {
-			const addedWeakness = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], pendingWeakness);
-			if (addedWeakness) {
-				debuffs.push(getApplicationEmojiMarkdown(pendingWeakness.name));
-			}
+			pendingWeakness.name = `${weaknessPool[adventure.generateRandomNumber(weaknessPool.length, "battle")]} Weakness`;
+			receipts.unshift(...addModifier([target], pendingWeakness));
 		}
-		const addedFrail = target.getModifierStacks("Oblivious") < 1;
-		addModifier([target], frail);
-		if (addedFrail) {
-			debuffs.push(getApplicationEmojiMarkdown("Frail"));
-		}
-		if (debuffs.length > 0) {
-			return [`${target.name} gains ${debuffs.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setSidegrades("Potent Sabotage Kit", "Urget Sabotage Kit")
 	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })

--- a/source/gear/scutum-lucky.js
+++ b/source/gear/scutum-lucky.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addProtection, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Lucky Scutum",
 	[
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Lucky Scutum",
 			pendingProtection *= critMultiplier;
 		}
 		addProtection([target, user], pendingProtection);
-		return [`${target.name} and ${user.name} gain protection.`, ...addModifier([user], lucky)];
+		return [`${target.name} and ${user.name} gain protection.`, ...generateModifierResultLines(addModifier([user], lucky))];
 	}
 ).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
 	.setSidegrades("Guarding Scutum", "Sweeping Scutum")

--- a/source/gear/scythe-toxic.js
+++ b/source/gear/scythe-toxic.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, dealDamage, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, dealDamage, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Scythe",
 	[
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Toxic Scythe",
 			pendingHPThreshold *= critMultiplier;
 		}
 		if (target.hp > pendingHPThreshold) {
-			return dealDamage([target], user, pendingDamage, false, element, adventure).concat(addModifier([target], poison));
+			return dealDamage([target], user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([target], poison)));
 		} else {
 			target.hp = 0;
 			return [`${target.name} meets the reaper.`];

--- a/source/gear/secondwind-cleansing.js
+++ b/source/gear/secondwind-cleansing.js
@@ -1,6 +1,6 @@
 const { GearTemplate } = require('../classes');
 const { isDebuff } = require('../modifiers/_modifierDictionary');
-const { gainHealth, removeModifier, changeStagger } = require('../util/combatantUtil');
+const { gainHealth, removeModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Cleansing Second Wind",
 	[
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Cleansing Second Wind",
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => isDebuff(modifier));
 		if (userDebuffs.length > 0) {
 			const rolledDebuff = userDebuffs[adventure.generateRandomNumber(userDebuffs.length, "battle")];
-			resultLines.push(...removeModifier([user], { name: rolledDebuff, stacks: "all" }));
+			resultLines.push(...generateModifierResultLines(removeModifier([user], { name: rolledDebuff, stacks: "all" })));
 		}
 		return resultLines;
 	}

--- a/source/gear/secondwind-lucky.js
+++ b/source/gear/secondwind-lucky.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { gainHealth, changeStagger, addModifier } = require('../util/combatantUtil');
+const { gainHealth, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Lucky Second Wind",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Lucky Second Wind",
 		if (isCrit) {
 			pendingHealing *= critMultiplier;
 		}
-		return [gainHealth(user, pendingHealing, adventure), addModifier([user], lucky)];
+		return [gainHealth(user, pendingHealing, adventure), ...generateModifierResultLines(addModifier([user]), lucky)];
 	}
 ).setTargetingTags({ type: "self", team: "none", needsLivingTargets: true })
 	.setSidegrades("Cleansing Second Wind", "Soothing Second Wind")

--- a/source/gear/secondwind-soothing.js
+++ b/source/gear/secondwind-soothing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { gainHealth, changeStagger, addModifier } = require('../util/combatantUtil');
+const { gainHealth, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Soothing Second Wind",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Soothing Second Wind",
 		if (isCrit) {
 			pendingHealing *= critMultiplier;
 		}
-		return [gainHealth(user, pendingHealing, adventure), ...addModifier([user], regen)];
+		return [gainHealth(user, pendingHealing, adventure), ...generateModifierResultLines(addModifier([user], regen))];
 	}
 ).setTargetingTags({ type: "self", team: "none", needsLivingTargets: true })
 	.setSidegrades("Cleansing Second Wind", "Lucky Second Wind")

--- a/source/gear/shortsword-accelerating.js
+++ b/source/gear/shortsword-accelerating.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Accelerating Shortsword",
 	[
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Accelerating Shortsword",
 				changeStagger(targets, "elementMatchFoe");
 			}
 		}
-		return resultLines.concat(addModifier([user, ...stillLivingTargets], exposed), addModifier([user], quicken));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user, ...stillLivingTargets], exposed), addModifier([user], quicken))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Lethal Shortsword", "Toxic Shortsword")

--- a/source/gear/shortsword-base.js
+++ b/source/gear/shortsword-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Shortsword",
 	[
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Shortsword",
 		if (user.element === element) {
 			changeStagger(stillLivingTargets, "elementMatchFoe");
 		}
-		return resultLines.concat(addModifier([user, ...stillLivingTargets], exposed));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user, ...stillLivingTargets], exposed))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setUpgrades("Accelerating Shortsword", "Lethal Shortsword", "Toxic Shortsword")

--- a/source/gear/shortsword-lethal.js
+++ b/source/gear/shortsword-lethal.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes/index.js');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Lethal Shortsword",
 	[
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Lethal Shortsword",
 		if (user.element === element) {
 			changeStagger(stillLivingTargets, "elementMatchFoe");
 		}
-		return resultLines.concat(addModifier([user, ...stillLivingTargets], exposed));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user, ...stillLivingTargets], exposed))));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Accelerating Shortsword", "Toxic Shortsword")

--- a/source/gear/shortsword-toxic.js
+++ b/source/gear/shortsword-toxic.js
@@ -1,6 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Toxic Shortsword",
 	[
@@ -16,27 +15,15 @@ module.exports = new GearTemplate("Toxic Shortsword",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		const resultLines = dealDamage([target], user, pendingDamage, false, element, adventure).concat(addModifier([user], exposed));
-		const targetDebuffs = [];
+		const resultLines = dealDamage([target], user, pendingDamage, false, element, adventure);
+		const receipts = addModifier([user], exposed);
 		if (target.hp > 0) {
 			if (user.element === element) {
 				changeStagger([target], "elementMatchFoe");
 			}
-			const addedPoison = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], poison);
-			if (addedPoison) {
-				targetDebuffs.push(getApplicationEmojiMarkdown("Poison"));
-			}
-			const addedExposedTarget = target.getModifierStacks("Oblivious") < 1;
-			addModifier([target], exposed);
-			if (addedExposedTarget) {
-				targetDebuffs.push(getApplicationEmojiMarkdown("Exposed"));
-			}
-			if (targetDebuffs.length > 0) {
-				resultLines.push(`${target.name} gains ${targetDebuffs.join("")}.`);
-			}
+			receipts.push(...addModifier([target], poison), ...addModifier([target], exposed));
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Accelerating Shortsword", "Lethal Shortsword")

--- a/source/gear/shoulderthrow-base.js
+++ b/source/gear/shoulderthrow-base.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Shoulder Throw",
 	[
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Shoulder Throw",
 			resultLines.push(`${target.name} is redirected into targeting themself.`);
 		}
 		if (isCrit) {
-			resultLines.push(...addModifier([user], evade));
+			resultLines.push(...generateModifierResultLines(addModifier([user], evade)));
 		}
 		return resultLines;
 	}

--- a/source/gear/shoulderthrow-evasive.js
+++ b/source/gear/shoulderthrow-evasive.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Evasive Shoulder Throw",
 	[
@@ -31,7 +31,7 @@ module.exports = new GearTemplate("Evasive Shoulder Throw",
 			targetMove.targets = [{ team: target.team, index: adventure.getCombatantIndex(target) }];
 			resultLines.push(`${target.name} is redirected into targeting themself.`);
 		}
-		return resultLines.concat(addModifier([user], pendingEvade));
+		return resultLines.concat(generateModifierResultLines(addModifier([user], pendingEvade)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Harmful Shoulder Throw", "Staggering Shoulder Throw")

--- a/source/gear/shoulderthrow-harmful.js
+++ b/source/gear/shoulderthrow-harmful.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier, dealDamage } = require('../util/combatantUtil');
+const { changeStagger, addModifier, dealDamage, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Harmful Shoulder Throw",
 	[
@@ -30,7 +30,7 @@ module.exports = new GearTemplate("Harmful Shoulder Throw",
 			}
 		}
 		if (isCrit) {
-			resultLines.push(...addModifier([user], evade));
+			resultLines.push(...generateModifierResultLines(addModifier([user], evade)));
 		}
 		return resultLines;
 	}

--- a/source/gear/shoulderthrow-staggering.js
+++ b/source/gear/shoulderthrow-staggering.js
@@ -1,5 +1,5 @@
 const { GearTemplate, Move } = require('../classes');
-const { changeStagger, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Staggering Shoulder Throw",
 	[
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Staggering Shoulder Throw",
 			resultLines.push(`${target.name} is redirected into targeting themself.`);
 		}
 		if (isCrit) {
-			resultLines.push(...addModifier([user], evade));
+			resultLines.push(...generateModifierResultLines(addModifier([user], evade)));
 		}
 		return resultLines;
 	}

--- a/source/gear/strongattack-flanking.js
+++ b/source/gear/strongattack-flanking.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Flanking Strong Attack",
 	[
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Flanking Strong Attack",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(addModifier(targets, exposed));
+		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier(targets, exposed)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Sharpened Strong Attack", "Staggering Strong Attack")

--- a/source/gear/warcry-charging.js
+++ b/source/gear/warcry-charging.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 const { joinAsStatement } = require('../util/textUtil.js');
 
 module.exports = new GearTemplate("Charging War Cry",
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Charging War Cry",
 			pendingStaggerStacks += bonus;
 		}
 		changeStagger(targetArray, pendingStaggerStacks);
-		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered."), ...addModifier([user], powerup)];
+		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered."), ...generateModifierResultLines(addModifier([user], powerup))];
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
 	.setSidegrades("Slowing War Cry", "Tormenting War Cry")

--- a/source/gear/warcry-slowing.js
+++ b/source/gear/warcry-slowing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { joinAsStatement } = require('../util/textUtil.js');
 
 module.exports = new GearTemplate("Slowing War Cry",
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Slowing War Cry",
 			pendingStaggerStacks += bonus;
 		}
 		changeStagger(targetArray, pendingStaggerStacks);
-		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered."), ...addModifier(targetArray, slow)];
+		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered."), ...generateModifierResultLines(combineModifierReceipts(addModifier(targetArray, slow))) ];
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
 	.setSidegrades("Charging War Cry", "Tormenting War Cry")

--- a/source/gear/warcry-tormenting.js
+++ b/source/gear/warcry-tormenting.js
@@ -1,8 +1,7 @@
 const { GearTemplate } = require('../classes');
-const { addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
 const { joinAsStatement } = require('../util/textUtil.js');
 const { isDebuff } = require('../modifiers/_modifierDictionary.js');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil.js');
 
 module.exports = new GearTemplate("Tormenting War Cry",
 	[
@@ -36,19 +35,15 @@ module.exports = new GearTemplate("Tormenting War Cry",
 		}
 		const resultLines = [joinAsStatement(false, [...targetSet], "was", "were", "Staggered.")];
 		changeStagger(targetArray, pendingStaggerStacks);
+		const receipts = [];
 		for (const target of targetArray) {
-			const debuffs = [];
 			for (const modifier in target.modifiers) {
 				if (isDebuff(modifier)) {
-					addModifier([target], { name: modifier, stacks: 1 });
-					debuffs.push(getApplicationEmojiMarkdown(modifier));
+					receipts.push(...addModifier([target], { name: modifier, stacks: 1 }));
 				}
 			}
-			if (debuffs.length > 0) {
-				resultLines.push(`${target.name} gains ${debuffs.join("")}.`);
-			}
 		}
-		return resultLines;
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
 	.setSidegrades("Charging War Cry", "Slowing War Cry")

--- a/source/gear/warhammer-slowing.js
+++ b/source/gear/warhammer-slowing.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { dealDamage, addModifier, changeStagger } = require('../util/combatantUtil.js');
+const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = require('../util/combatantUtil.js');
 
 module.exports = new GearTemplate("Slowing Warhammer",
 	[
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Slowing Warhammer",
 		if (isCrit) {
 			pendingDamage *= critMultiplier;
 		}
-		return dealDamage([target], user, pendingDamage, false, element, adventure).concat(addModifier([target], slow));
+		return dealDamage([target], user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([target], slow)));
 	}
 ).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
 	.setSidegrades("Reactive Warhammer", "Unstoppable Warhammer")

--- a/source/items/clearpotion.js
+++ b/source/items/clearpotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Clear Potion",
 	"Grants the user 3 @e{Untyped Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Clear Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Untyped Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Untyped Absorb", stacks: 3 }));
 	}
 );

--- a/source/items/earthenpotion.js
+++ b/source/items/earthenpotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Earthen Potion",
 	"Grants the user 3 @e{Earth Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Earthen Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Earth Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Earth Absorb", stacks: 3 }));
 	}
 );

--- a/source/items/fierypotion.js
+++ b/source/items/fierypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Fiery Potion",
 	"Grants the user 3 @e{Fire Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Fiery Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Fire Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Fire Absorb", stacks: 3 }));
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*Not to be confused with __Explosive Potion__. DO NOT apply to enemies.*" });

--- a/source/items/glowingpotion.js
+++ b/source/items/glowingpotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Glowing Potion",
 	"Grants the user 3 @e{Light Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Glowing Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Light Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Light Absorb", stacks: 3 }));
 	}
 );

--- a/source/items/inkypotion.js
+++ b/source/items/inkypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Inky Potion",
 	"Grants the user 3 @e{Darkness Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Inky Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Darkness Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Darkness Absorb", stacks: 3 }));
 	}
 );

--- a/source/items/oblivionsalt.js
+++ b/source/items/oblivionsalt.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Salt of Oblivion",
 	"Grants the user 1 @e{Oblivious}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Salt of Oblivion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Oblivious", stacks: 1 });
+		return generateModifierResultLines(addModifier([user], { name: "Oblivious", stacks: 1 }));
 	}
 );

--- a/source/items/panacea.js
+++ b/source/items/panacea.js
@@ -1,7 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { isDebuff } = require("../modifiers/_modifierDictionary");
-const { removeModifier } = require("../util/combatantUtil");
-const { getApplicationEmojiMarkdown } = require("../util/graphicsUtil");
+const { removeModifier, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Panacea",
 	"Cure the user of up to 2 random debuffs",
@@ -12,24 +11,19 @@ module.exports = new ItemTemplate("Panacea",
 	},
 	false,
 	(targets, user, isCrit, adventure) => {
-		const removedDebuffs = [];
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => isDebuff(modifier));
 		const debuffsToRemove = Math.min(userDebuffs.length, 2);
+		const receipts = [];
 		for (let i = 0; i < debuffsToRemove; i++) {
 			const debuffIndex = adventure.generateRandomNumber(userDebuffs.length, "battle");
 			const rolledDebuff = userDebuffs[debuffIndex];
-			const wasRemoved = user.getModifierStacks("Retain") < 1;
-			removeModifier([user], { name: rolledDebuff, stacks: "all" });
-			if (wasRemoved) {
-				removedDebuffs.push(getApplicationEmojiMarkdown(rolledDebuff));
+			const [removalReceipt] = removeModifier([user], { name: rolledDebuff, stacks: "all" });
+			receipts.push(removalReceipt);
+			if (removalReceipt.succeeded.size > 0) {
 				userDebuffs.splice(debuffIndex, 1);
 			}
 		}
 
-		if (removedDebuffs.length > 1) {
-			return [`${user.name} is cured of ${removedDebuffs.join("")}.`];
-		} else {
-			return [];
-		}
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 );

--- a/source/items/quickpepper.js
+++ b/source/items/quickpepper.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Quick Pepper",
 	"Grants the user 3 @e{Quicken}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Quick Pepper",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Quicken", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Quicken", stacks: 3 }));
 	}
 );

--- a/source/items/regenroot.js
+++ b/source/items/regenroot.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Regen Root",
 	`Grants the user 5 @e{Regen}`,
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Regen Root",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Regen", stacks: 5 });
+		return generateModifierResultLines(addModifier([user], { name: "Regen", stacks: 5 }));
 	}
 );

--- a/source/items/smokebomb.js
+++ b/source/items/smokebomb.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Smoke Bomb",
 	"Grants the user 2 @e{Evade}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Smoke Bomb",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Evade", stacks: 2 });
+		return generateModifierResultLines(addModifier([user], { name: "Evade", stacks: 2 }));
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*\"While the foe suspects you're fleeing\" is the third best time to strike, beat only by \"when they least expect it\" and \"first\".*" });

--- a/source/items/stasisquartz.js
+++ b/source/items/stasisquartz.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Stasis Quartz",
 	"Grants the user 1 @e{Retain}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Stasis Quartz",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Retain", stacks: 1 });
+		return generateModifierResultLines(addModifier([user], { name: "Retain", stacks: 1 }));
 	}
 );

--- a/source/items/strengthspinach.js
+++ b/source/items/strengthspinach.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Strength Spinach",
 	"Grants the user 50 @e{Power Up}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Strength Spinach",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Power Up", stacks: 50 });
+		return generateModifierResultLines(addModifier([user], { name: "Power Up", stacks: 50 }));
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*It does what it says on the tin.*" });

--- a/source/items/waterypotion.js
+++ b/source/items/waterypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Watery Potion",
 	"Grants the user 3 @e{Water Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Watery Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Water Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Water Absorb", stacks: 3 }));
 	}
 ).setFlavorText({ name: "*Additional Note*", value: "Apply directly to the forehead." });

--- a/source/items/windypotion.js
+++ b/source/items/windypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents.js");
-const { addModifier } = require("../util/combatantUtil");
+const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Windy Potion",
 	"Grants the user 3 @e{Wind Absorb}",
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Windy Potion",
 	selectSelf,
 	false,
 	(targets, user, isCrit, adventure) => {
-		return addModifier([user], { name: "Wind Absorb", stacks: 3 });
+		return generateModifierResultLines(addModifier([user], { name: "Wind Absorb", stacks: 3 }));
 	}
 );

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -537,7 +537,7 @@ function resolveMove(move, adventure) {
 			results.push(gainHealth(user, regenStacks * 10, adventure, "Regen"));
 		}
 	}
-	return `${headline}${results.reduce((contextLines, currentLine) => `${contextLines}\n-# ${currentLine}`, "")}\n`;
+	return `${headline}${results.reduce((contextLines, currentLine) => `${contextLines}\n-# ${bold(currentLine)}`, "")}\n`;
 }
 
 /**

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -1,9 +1,9 @@
 const { italic, bold } = require("discord.js");
-const { Combatant, Adventure } = require("../classes");
+const { Combatant, Adventure, ModifierReceipt } = require("../classes");
 const { getInverse, getModifierDescription, isBuff, isDebuff } = require("../modifiers/_modifierDictionary");
 const { getWeaknesses, getResistances, elementsList, getEmoji } = require("./elementUtil.js");
 const { getApplicationEmojiMarkdown } = require("./graphicsUtil.js");
-const { joinAsStatement } = require("./textUtil.js");
+const { listifyEN } = require("./textUtil.js");
 
 /**
  * @param {Combatant} target
@@ -186,9 +186,7 @@ function gainHealth(combatant, healing, adventure, source) {
  * @param {boolean} modifierData.force whether to ignore the Oblivious check
  */
 function addModifier(combatants, { name: modifier, stacks: pendingStacks, force = false }) {
-	const affectedCombatants = [];
-	const obliviousCombatants = [];
-	const resultLines = [];
+	const receipts = [];
 	for (const combatant of combatants) {
 		// Oblivious only blocks buffs and debuffs
 		if (force || !("Oblivious" in combatant.modifiers && (isBuff(modifier) || isDebuff(modifier)))) {
@@ -207,26 +205,13 @@ function addModifier(combatants, { name: modifier, stacks: pendingStacks, force 
 				}
 			}
 
-			// Trigger threshold: Progress
-			if (combatant.getModifierStacks("Progress") >= 100) {
-				combatant.modifiers.Progress = 0;
-				addModifier([combatant], { name: "Power Up", stacks: 100, force: false });
-				resultLines.push(`Eureka! ${combatant.name}'s ${getApplicationEmojiMarkdown("Progress")} yields ${getApplicationEmojiMarkdown("Power Up")}!`);
-			} else {
-				affectedCombatants.push(combatant.name);
-			}
+			receipts.push(new ModifierReceipt(combatant.name, "add", [getApplicationEmojiMarkdown(modifier)], []));
 		} else {
 			removeModifier([combatant], { name: "Oblivious", stacks: 1, force: true });
-			obliviousCombatants.push(combatant.name);
+			receipts.push(new ModifierReceipt(combatant.name, "add", [], [getApplicationEmojiMarkdown(modifier)]));
 		}
 	}
-	if (affectedCombatants.length > 0) {
-		resultLines.push(joinAsStatement(false, affectedCombatants, "gains", "gain", `${getApplicationEmojiMarkdown(modifier)}.`));
-	}
-	if (obliviousCombatants.length > 0) {
-		resultLines.push(joinAsStatement(false, obliviousCombatants, "is", "are", `oblivious to ${getApplicationEmojiMarkdown(modifier)}.`));
-	}
-	return resultLines;
+	return receipts;
 }
 
 /** After decrementing a modifier's stacks, delete the modifier's entry in the object
@@ -237,8 +222,7 @@ function addModifier(combatants, { name: modifier, stacks: pendingStacks, force 
  * @param {boolean} modifierData.force whether to ignore the Retain check (eg buffs/debuffs consuming themselves)
  */
 function removeModifier(combatants, { name: modifier, stacks, force = false }) {
-	const affectedCombatants = [];
-	const retainingCombatants = [];
+	const receipts = [];
 	for (const combatant of combatants) {
 		// Retain only protects buffs and debuffs
 		if (force || !("Retain" in combatant.modifiers && (isBuff(modifier) || isDebuff(modifier)))) {
@@ -249,21 +233,14 @@ function removeModifier(combatants, { name: modifier, stacks, force = false }) {
 				combatant.modifiers[modifier] -= stacks;
 			}
 			if (didHaveModifier) {
-				affectedCombatants.push(combatant.name);
+				receipts.push(new ModifierReceipt(combatant.name, "remove", [getApplicationEmojiMarkdown(modifier)], []));
 			}
 		} else {
 			removeModifier([combatant], { name: "Retain", stacks: 1, force: true });
-			retainingCombatants.push(combatant.name);
+			receipts.push(new ModifierReceipt(combatant.name, "remove", [], [getApplicationEmojiMarkdown(modifier)]))
 		}
 	}
-	const resultLines = [];
-	if (affectedCombatants.length > 0) {
-		resultLines.push(joinAsStatement(false, affectedCombatants, "loses", "lose", `${getApplicationEmojiMarkdown(modifier)}.`));
-	}
-	if (retainingCombatants.length > 0) {
-		resultLines.push(joinAsStatement(false, retainingCombatants, "retains", "retain", `${getApplicationEmojiMarkdown(modifier)}.`));
-	}
-	return resultLines;
+	return receipts;
 }
 
 const ALL_STANCES = ["Iron Fist Stance", "Floating Mist Stance"];
@@ -273,15 +250,98 @@ const ALL_STANCES = ["Iron Fist Stance", "Floating Mist Stance"];
  * @param {{name: "Iron Fist Stance" | "Floating Mist Stance", stacks: number}} stanceModifier
  */
 function enterStance(combatant, stanceModifier) {
-	const stancesRemoved = [];
+	const receipts = [];
 	ALL_STANCES.filter(stanceToCheck => stanceToCheck !== stanceModifier.name).forEach(stanceToRemove => {
 		if (stanceToRemove in combatant.modifiers) {
-			removeModifier([combatant], { name: stanceToRemove, stacks: "all", force: true });
-			stancesRemoved.push(stanceToRemove);
+			receipts.push(...removeModifier([combatant], { name: stanceToRemove, stacks: "all", force: true }));
 		}
 	});
-	addModifier([combatant], stanceModifier);
-	return { didAddStance: combatant.getModifierStacks("Oblivious") < 1, stancesRemoved };
+	return receipts.concat(addModifier([combatant], stanceModifier));
+}
+
+/**  Consolidation convention set by game design as "name then modifier set" to minimize the number of lines required to describe all changes to a specific combatant
+ * @param {ModifierReceipt[]} receipts
+ */
+function combineModifierReceipts(receipts) {
+	// Consolidate by name
+	// eg "Combatant gains X" + "Combatant gains Y" = "Combatant gains XY"
+	for (let i = 1; i < receipts.length; i++) {
+		const heldReceipt = receipts[i];
+		for (let j = i + 1; j < receipts.length; j++) {
+			const checkingReceipt = receipts[j];
+			if (heldReceipt.type === checkingReceipt.type && areSetContentsCongruent(heldReceipt.combatantNames, checkingReceipt.combatantNames)) {
+				heldReceipt.combineModifierSets(checkingReceipt);
+				receipts.splice(j, 1);
+				j--;
+			}
+		}
+	}
+
+	// Consolidate by modifier sets
+	// eg "X gains ModifierSet" + "Y gains ModifierSet" = "X and Y gain ModifierSet"
+	for (let i = 1; i < receipts.length; i++) {
+		const heldReceipt = receipts[i];
+		for (let j = i + 1; j < receipts.length; j++) {
+			const checkingReceipt = receipts[j];
+			if (heldReceipt.type === checkingReceipt.type && areSetContentsCongruent(heldReceipt.succeeded, checkingReceipt.succeeded) && areSetContentsCongruent(heldReceipt.failed, checkingReceipt.failed)) {
+				heldReceipt.combineCombatantNames(checkingReceipt);
+				receipts.splice(j, 1);
+				j--;
+			}
+		}
+	}
+	return receipts;
+}
+
+/**
+ * @param {ModifierReceipt[]} receipts
+ */
+function generateModifierResultLines(receipts) {
+	const resultLines = [];
+	for (const receipt of receipts) {
+		if (receipt.type === "add") {
+			const addedFragments = [];
+			if (receipt.succeeded.size > 0) {
+				if (receipt.combatantNames.size > 1) {
+					addedFragments.push(`gain ${[...receipt.succeeded].join("")}`);
+				} else {
+					addedFragments.push(`gains ${[...receipt.succeeded].join("")}`);
+				}
+			}
+			if (receipt.failed.size > 0) {
+				if (receipt.combatantNames.size > 1) {
+					addedFragments.push(`were oblivious to ${[...receipt.failed].join("")}`);
+				} else {
+					addedFragments.push(`was oblivious to ${[...receipt.failed].join("")}`);
+				}
+			}
+
+			if (addedFragments.length > 0) {
+				resultLines.push(`${listifyEN([...receipt.combatantNames])} ${listifyEN(addedFragments)}.`);
+			}
+		} else {
+			const removedFragments = [];
+			if (receipt.succeeded.size > 0) {
+				if (receipt.combatantNames.size > 1) {
+					removedFragments.push(`loses ${[...receipt.succeeded].join("")}`);
+				} else {
+					removedFragments.push(`lose ${[...receipt.succeeded].join("")}`);
+				}
+			}
+			if (receipt.failed.size > 0) {
+				if (receipt.combatantNames.size > 1) {
+					removedFragments.push(`retain ${[...receipt.failed].join("")}`);
+				} else {
+					removedFragments.push(`retains ${[...receipt.failed].join("")}`);
+				}
+			}
+
+			if (removedFragments.length > 0) {
+				resultLines.push(`${listifyEN([...receipt.combatantNames])} ${listifyEN(removedFragments)}.`);
+			}
+		}
+	}
+	return resultLines;
 }
 
 /** add Stagger, negative values allowed
@@ -346,6 +406,8 @@ module.exports = {
 	addModifier,
 	removeModifier,
 	enterStance,
+	combineModifierReceipts,
+	generateModifierResultLines,
 	changeStagger,
 	addProtection,
 	modifiersToString,

--- a/source/util/mathUtil.js
+++ b/source/util/mathUtil.js
@@ -9,7 +9,24 @@ function anyDieSucceeds(successChance, extraDice) {
 	return 1 - ((1 - successChance) ** (1 + extraDice));
 };
 
+/**
+ * @param {Set} firstSet
+ * @param {Set} secondSet
+ */
+function areSetContentsCongruent(firstSet, secondSet) {
+	if (firstSet.size !== secondSet.size) {
+		return false;
+	}
+
+	for (const element of firstSet) {
+		if (!secondSet.has(element)) {
+			return false;
+		}
+	}
+	return true;
+}
 
 module.exports = {
-	anyDieSucceeds
+	anyDieSucceeds,
+	areSetContentsCongruent
 };


### PR DESCRIPTION
Summary
-------
- added automated modifier statement combining and refactored move effects to use it
- `addModifier()`, `removeModifier()` and `enterStance()` now return `ModifierReceipt[]` instead of their previous returns
- moved Progress logic into Elkemist's actions

Created a new class "ModifierReceipt" to standardize modifier addition or removal attempts, while including enough data for moves with logic based on modifier addition or removal to function and report unsuccessful modifier change attempts (ie Retain and Oblivious). This standardized shape also allowed for the creation of functions to handle them in bulk: `combineModifierReceipts()` for minimizing the number of lines mentioning a specific combatant, and `generateModifierResultLines()` for converting receipts into user-readable text.

Future work should include creating sibling receipt classes for damage, healing, stagger, and protection, as there is still some need for custom result line generation when combining those changes to combatants.

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Successful run through the Debug Dungeon