### PR TITLE
#219: add Event: Door 1 or Door 2?

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,7 @@
 - Protection gained from Boat Parts no longer scales from more copies of Boat Parts
 - Renamed the modifier "Stasis" to "Retain"
 - Added Challenge: "Shoddy Craftsmanship" - For the next 5 rooms, gear you acquire has reduced durability reduced by 25%. Afterwards gain 250 gold.
+- Added new Event room: Door 1 or Door 2?
 ## Prophets of the Labyrinth v0.15.0:
 After the systems focus in v0.14, this update is looping back to give some love to balance and content. One focus is adding more archetype differences so picking party composition is a more interesting decision; a step toward composition varying based on labyrinth choice. Predicts are now unique combinations of information. For example, multiple archetypes can predict HP, but only the Hemomancer can predict both HP and Speed.
 ### Detective

--- a/source/artifacts/_artifactDictionary.js
+++ b/source/artifacts/_artifactDictionary.js
@@ -58,9 +58,24 @@ function rollArtifact(adventure) {
 	return artifactPool[adventure.generateRandomNumber(artifactPool.length, "general")];
 }
 
+/**
+ * @param {Adventure} adventure
+ * @param {string[]} exclusions
+ */
+function rollArtifactWithExclusions(adventure, exclusions = []) {
+	/** @type {string[]} */
+	const artifactPool = adventure.getElementPool().reduce((artifacts, element) => artifacts.concat(ROLL_TABLE[element]), []).filter(artifact => !exclusions.includes(artifact));
+	if (artifactPool.length > 0) {
+		return artifactPool[adventure.generateRandomNumber(artifactPool.length, "general")];
+	} else {
+		return null;
+	}
+}
+
 module.exports = {
 	artifactNames: ARTIFACT_NAMES,
 	getArtifact,
 	getArtifactCounts,
-	rollArtifact
+	rollArtifact,
+	rollArtifactWithExclusions
 };

--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -13,6 +13,7 @@ for (const file of [
 	"collectartifact.js",
 	"deploy.js",
 	"elementresearch.js",
+	"eventartifact.js",
 	"freerepairkit.js",
 	"gearcapup.js",
 	"getgoldonfire.js",

--- a/source/buttons/eventartifact.js
+++ b/source/buttons/eventartifact.js
@@ -1,0 +1,25 @@
+const { ButtonWrapper } = require('../classes');
+const { ZERO_WIDTH_WHITESPACE } = require('../constants');
+const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
+const { renderRoom } = require('../util/embedUtil');
+
+const mainId = "eventartifact";
+module.exports = new ButtonWrapper(mainId, 3000,
+	(interaction, [artifactsHistoryIndex, cost]) => {
+		const adventure = getAdventure(interaction.channelId);
+		if (!adventure.delvers.some(delver => delver.id === interaction.user.id)) {
+			interaction.reply({ content: "You aren't in this adventure.", ephemeral: true });
+			return;
+		}
+
+		if (adventure.room.history["Option Picked"].length < 1) {
+			adventure.room.history["Option Picked"].push(artifactsHistoryIndex);
+			adventure.gold -= cost;
+			adventure.gainArtifact(adventure.room.history.Artifacts[artifactsHistoryIndex], 1);
+			interaction.update(renderRoom(adventure, interaction.channel));
+			setAdventure(adventure);
+		} else {
+			interaction.update({ content: ZERO_WIDTH_WHITESPACE });
+		}
+	}
+);

--- a/source/labyrinths/castleofthecelestialknights.js
+++ b/source/labyrinths/castleofthecelestialknights.js
@@ -213,7 +213,7 @@ module.exports = new LabyrinthTemplate("Castle of the Celestial Knights",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["Twin Pedestals", "Imp Contract Faire", "Gear Collector", "The Score Beggar", "Apple Pie Wishing Well", "Repair Kit, just hanging out", "Workshop", "Merchant", "Rest Site", "Treasure"],
+		"Event": ["Door 1 or Door 2?", "Twin Pedestals", "Imp Contract Faire", "Gear Collector", "The Score Beggar", "Apple Pie Wishing Well", "Repair Kit, just hanging out", "Workshop", "Merchant", "Rest Site", "Treasure"],
 		"Battle": ["Slime Fight", "Tortoise Fight", "Meteor Knight Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
 		"Final Battle": ["Hall of Mirrors", "Confronting the Top Celestial Knight"],

--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -109,7 +109,7 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["Imp Contract Faire", "The Score Beggar", "Free Gold?", "Apple Pie Wishing Well", "Twin Pedestals", "Gear Collector", "Repair Kit, just hanging out"],
+		"Event": ["Door 1 or Door 2?"],
 		"Battle": ["Frog Ranch", "Wild Fire-Arrow Frogs", "Meteor Knight Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
 		"Final Battle": ["Hall of Mirrors"],

--- a/source/labyrinths/everythingbagel.js
+++ b/source/labyrinths/everythingbagel.js
@@ -285,7 +285,7 @@ module.exports = new LabyrinthTemplate("Everything Bagel",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["Apple Pie Wishing Well", "Free Gold?", "Gear Collector", "Imp Contract Faire", "Repair Kit, just hanging out", "The Score Beggar", "Twin Pedestals", "Workshop", "Merchant", "Rest Site", "Treasure"],
+		"Event": ["Apple Pie Wishing Well", "Door 1 or Door 2?", "Free Gold?", "Gear Collector", "Imp Contract Faire", "Repair Kit, just hanging out", "The Score Beggar", "Twin Pedestals", "Workshop", "Merchant", "Rest Site", "Treasure"],
 		"Battle": ["Hawk Fight", "Frog Ranch", "Wild Fire-Arrow Frogs", "Mechabee Fight", "Slime Fight", "Tortoise Fight", "Meteor Knight Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
 		"Final Battle": ["A Northern Laboratory", "Hall of Mirrors", "The Hexagon: Bee Mode", "The Hexagon: Mech Mode", "Confronting the Top Celestial Knight"],

--- a/source/labyrinths/mechahive.js
+++ b/source/labyrinths/mechahive.js
@@ -213,7 +213,7 @@ module.exports = new LabyrinthTemplate("Mechahive",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["Twin Pedestals", "Imp Contract Faire", "Free Gold?", "The Score Beggar", "Repair Kit, just hanging out", "Workshop", "Merchant", "Rest Site", "Treasure"],
+		"Event": ["Door 1 or Door 2?", "Twin Pedestals", "Imp Contract Faire", "Free Gold?", "The Score Beggar", "Repair Kit, just hanging out", "Workshop", "Merchant", "Rest Site", "Treasure"],
 		"Battle": ["Frog Ranch", "Mechabee Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
 		"Final Battle": ["The Hexagon: Bee Mode", "The Hexagon: Mech Mode"],

--- a/source/labyrinths/zooofchimeras.js
+++ b/source/labyrinths/zooofchimeras.js
@@ -213,7 +213,7 @@ module.exports = new LabyrinthTemplate("Zoo of Chimeras",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["Twin Pedestals", "Imp Contract Faire", "Free Gold?", "Gear Collector", "The Score Beggar", "Apple Pie Wishing Well", "Workshop", "Merchant", "Rest Site", "Treasure"],
+		"Event": ["Door 1 or Door 2?", "Twin Pedestals", "Imp Contract Faire", "Free Gold?", "Gear Collector", "The Score Beggar", "Apple Pie Wishing Well", "Workshop", "Merchant", "Rest Site", "Treasure"],
 		"Battle": ["Hawk Fight", "Wild Fire-Arrow Frogs", "Tortoise Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
 		"Final Battle": ["A Northern Laboratory", "Hall of Mirrors"],

--- a/source/rooms/_roomDictionary.js
+++ b/source/rooms/_roomDictionary.js
@@ -16,6 +16,7 @@ for (const file of [
 	"empty.js",
 	"event-applepiewishingwell.js",
 	"event-artifactdupe.js",
+	"event-door1ordoor2.js",
 	"event-freegoldonfire.js",
 	"event-freerepairkit.js",
 	"event-gearcollector.js",

--- a/source/rooms/event-applepiewishingwell.js
+++ b/source/rooms/event-applepiewishingwell.js
@@ -1,5 +1,5 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 const { EMPTY_SELECT_OPTION_SET } = require("../constants");
 

--- a/source/rooms/event-door1ordoor2.js
+++ b/source/rooms/event-door1ordoor2.js
@@ -1,0 +1,70 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, italic } = require("discord.js");
+const { RoomTemplate } = require("../classes");
+const { rollArtifactWithExclusions } = require("../artifacts/_artifactDictionary");
+const { SAFE_DELIMITER } = require("../constants");
+const { generateRoutingRow } = require("../util/messageComponentUtil");
+
+module.exports = new RoomTemplate("Door 1 or Door 2?",
+	"@{adventureOpposite}",
+	"Event",
+	"There are four doors in this room. Two of them are labelled with numbers \"Door 1\" and \"Door 2\" and have coin insert slots. The other two doors are the entrance and exit.",
+	[],
+	function (adventure) {
+		const ownedArtifacts = Object.keys(adventure.artifacts);
+		const door1Artifact = ownedArtifacts.length > 0 ? ownedArtifacts[adventure.generateRandomNumber(ownedArtifacts.length, "general")] : null;
+		const door2Artifact = rollArtifactWithExclusions(adventure, ownedArtifacts);
+		return {
+			"Artifacts": [door1Artifact, door2Artifact],
+			"Option Picked": []
+		};
+	},
+	function (roomEmbed, adventure) {
+		const partyHasNoArtifacts = adventure.room.history.Artifacts[0] === null;
+		const partyHasAllArtifacts = adventure.room.history.Artifacts[1] === null;
+		const partyHasPicked = adventure.room.history["Option Picked"].length > 0;
+		let door1Cost = 300;
+		const partyCannotAffordDoor1 = adventure.gold < door1Cost;
+		let door2Cost = 150;
+		const partyCannotAffordDoor2 = adventure.gold < door2Cost;
+		let door1Label, door1Emoji, door2Label, door2Emoji;
+		roomEmbed.addFields({ name: "A Sixth Sense", value: `You get the feeling that Door 1 will have a random duplicate of an artifact the party owns, while Door 2 will have a random artifact the party doesn't own.${partyHasNoArtifacts || partyHasAllArtifacts ? ` ${italic(`You also get the feeling there's nothing behind Door ${partyHasNoArtifacts ? "1" : "2"}.`)}` : ""}` });
+		if (!partyHasPicked) {
+			door1Label = `${door1Cost}g: Pick Door 1`;
+			door1Emoji = "❔";
+			door2Label = `${door2Cost}g: Pick Door 2`;
+			door2Emoji = "❔";
+		} else if (adventure.room.history["Option Picked"][0] === "0") {
+			door1Label = `${door1Cost}g: ${adventure.room.history.Artifacts[0]}`;
+			door1Emoji = "✔️";
+			door2Label = "Didn't Pick Door 2";
+			door2Emoji = "✖️";
+		} else {
+			door1Label = "Didn't Pick Door 1";
+			door1Emoji = "✖️";
+			door2Label = `${door2Cost}g: ${adventure.room.history.Artifacts[1]}`;
+			door2Emoji = "✔️";
+		}
+		return {
+			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			components: [
+				new ActionRowBuilder().addComponents(
+					new ButtonBuilder().setCustomId(`eventartifact${SAFE_DELIMITER}0${SAFE_DELIMITER}${door1Cost}`)
+						.setStyle(ButtonStyle.Primary)
+						.setEmoji(door1Emoji)
+						.setLabel(door1Label)
+						.setDisabled(partyHasPicked || partyCannotAffordDoor1 || partyHasNoArtifacts),
+					new ButtonBuilder().setCustomId(`eventartifact${SAFE_DELIMITER}1${SAFE_DELIMITER}${door2Cost}`)
+						.setStyle(ButtonStyle.Primary)
+						.setEmoji(door2Emoji)
+						.setLabel(door2Label)
+						.setDisabled(partyHasPicked || partyCannotAffordDoor2 || partyHasAllArtifacts),
+					new ButtonBuilder().setCustomId("partystats")
+						.setEmoji("📚")
+						.setLabel("Party Stats")
+						.setStyle(ButtonStyle.Secondary)
+				),
+				generateRoutingRow(adventure)
+			]
+		};
+	}
+);


### PR DESCRIPTION
Summary
-------
- add Event: Door 1 or Door 2?

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Door 1 button duplicates an artifact the party has, disables if party has no artifacts
- [x] Door 2 button grants a random artifact the party doesn't have, should disable if party has all artifacts
- [x] buttons disable if party has already picked or doesn't have enough gold to pay

Issue
-----
Closes #219