### PR TITLE
#397: add "Inspect Self" buttons to Rest Sites

### DIFF
--- a/source/rooms/event-door1ordoor2.js
+++ b/source/rooms/event-door1ordoor2.js
@@ -2,7 +2,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, italic } = require("discor
 const { RoomTemplate } = require("../classes");
 const { rollArtifactWithExclusions } = require("../artifacts/_artifactDictionary");
 const { SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, partyStatsButton } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Door 1 or Door 2?",
 	"@{adventureOpposite}",
@@ -58,10 +58,7 @@ module.exports = new RoomTemplate("Door 1 or Door 2?",
 						.setEmoji(door2Emoji)
 						.setLabel(door2Label)
 						.setDisabled(partyHasPicked || partyCannotAffordDoor2 || partyHasAllArtifacts),
-					new ButtonBuilder().setCustomId("partystats")
-						.setEmoji("📚")
-						.setLabel("Party Stats")
-						.setStyle(ButtonStyle.Secondary)
+					partyStatsButton
 				),
 				generateRoutingRow(adventure)
 			]

--- a/source/rooms/restsite-challenger.js
+++ b/source/rooms/restsite-challenger.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, inspectSelfButton } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 	"@{adventure}",
@@ -50,6 +50,7 @@ module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [
 				new ActionRowBuilder().addComponents(
+					inspectSelfButton,
 					new ButtonBuilder().setCustomId(`rest${SAFE_DELIMITER}${healPercent}`)
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(restEmoji)

--- a/source/rooms/restsite-trainingdummy.js
+++ b/source/rooms/restsite-trainingdummy.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, inspectSelfButton } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Rest Site: Training Dummy",
 	"@{adventure}",
@@ -45,6 +45,7 @@ module.exports = new RoomTemplate("Rest Site: Training Dummy",
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 			components: [
 				new ActionRowBuilder().addComponents(
+					inspectSelfButton,
 					new ButtonBuilder().setCustomId(`rest${SAFE_DELIMITER}${healPercent}`)
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(restEmoji)

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -41,14 +41,8 @@ function generateCombatRoomBuilder(extraButtons) {
 		const isCombatVictory = adventure.room.enemies?.every(enemy => enemy.hp === 0);
 		if (!isCombatVictory) {
 			const buttons = [
-				new ButtonBuilder().setCustomId("partystats")
-					.setEmoji("📚")
-					.setLabel("Party Stats")
-					.setStyle(ButtonStyle.Secondary),
-				new ButtonBuilder().setCustomId("inspectself")
-					.setEmoji("🔎")
-					.setLabel("Inspect Self")
-					.setStyle(ButtonStyle.Secondary),
+				module.exports.partyStatsButton,
+				module.exports.inspectSelfButton,
 				new ButtonBuilder().setCustomId("readymove")
 					.setEmoji("⚔")
 					.setLabel("Ready a Move")
@@ -145,6 +139,14 @@ function generateMerchantScoutingRow(adventure) {
 
 module.exports = {
 	clearComponents,
+	partyStatsButton: new ButtonBuilder().setCustomId("partystats")
+		.setEmoji("📚")
+		.setLabel("Party Stats")
+		.setStyle(ButtonStyle.Secondary),
+	inspectSelfButton: new ButtonBuilder().setCustomId("inspectself")
+		.setEmoji("🔎")
+		.setLabel("Inspect Self")
+		.setStyle(ButtonStyle.Secondary),
 	generateCombatRoomBuilder,
 	generateLootRow,
 	generateRoutingRow,


### PR DESCRIPTION
Summary
-------
- add inspect self button to rest sites
- create exports for inspect self and party stats buttons

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] inspect self button shows in rest sites
- [x] inspect self and party stats still work in combat rounds post-refactor

Issue
-----
Closes #397