### PR TITLE
#410: remove custom handling for Known Issues section in version embed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,10 @@
 # Prophets of the Labyrinth Change Log
 ## Prophets of the Labyrinth v0.16.0:
 ### Archetypes
-- Changed Detective to Untyped, increased duration of Sabotage Kit (and upgrades) weakness by 1, changed predict to weaknesses and random outcomes (no longer modifiers)
-   - The case where the Detective innately had elemental advantage against an enemy was too much more powerful than the case where the advantage was earned. Changing to Untyped both removes the innate elemental advantage case, but also makes adding Pistol triggering weakness to enemies always possible (no enemies resist Untyped).
-   - In the effort to make random outcomes stable for bouncing moves, the system became compatible with being able to have random outcomes be recorded by predicts
+- Changed Detective to Untyped
+   - The Detective was too much more powerful in battles where they innately had elemental advantage than those where the advantage was earned. Changing to Untyped both removes the possibility for innate elemental advantage and makes adding Pistol weakness to enemies always possible (no enemies resist Untyped).
+- Changed Detective predict to weaknesses and random outcomes (no longer modifiers)
+- Increased duration of Sabotage Kit (and upgrades) weakness by 1
 - Changed Martial Artist Predict to Stagger and Enemy's next move
    - Now that predicts are unique info combinations, the Martial Artist is no longer stuck predicting speed (which hasn't been helpful in informing Stun strategies since the mechanics were made independent) in order to be able to predict Stagger. Predicting the move in the next round (note: not the upcoming round, but the one after that) is helpful for deciding if that move is worth attempting to avoid by pushing for Stun.
 ### Gear

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -335,21 +335,12 @@ async function generateVersionEmbed() {
 	}
 	let knownIssuesEnd = dividerRegEx.exec(data).index;
 
-	const embed = embedTemplate()
+	return embedTemplate()
 		.setTitle(data.slice(titleStart + 3, changesStartRegEx.lastIndex))
-		.setURL('https://discord.gg/JxqE9EpKt9')
+		.setDescription(data.slice(changesStartRegEx.lastIndex, knownIssuesEnd).slice(0, MAX_EMBED_DESCRIPTION_LENGTH)).setURL('https://discord.gg/JxqE9EpKt9')
 		.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/734099622846398565/newspaper.png')
-		.setTimestamp();
-
-	if (knownIssuesStart && knownIssuesStart < knownIssuesEnd) {
-		// Known Issues section found
-		embed.setDescription(data.slice(changesStartRegEx.lastIndex, knownIssuesStart).slice(0, MAX_EMBED_DESCRIPTION_LENGTH))
-			.addFields({ name: "Known Issues", value: data.slice(knownIssuesStart + 16, knownIssuesEnd) });
-	} else {
-		// Known Issues section not found
-		embed.setDescription(data.slice(changesStartRegEx.lastIndex, knownIssuesEnd).slice(0, MAX_EMBED_DESCRIPTION_LENGTH));
-	}
-	return embed.addFields({ name: "Become a Sponsor", value: "Chip in for server costs or get premium features by sponsoring [PotL on GitHub](https://github.com/Imaginary-Horizons-Productions/Prophets-of-the-Labyrinth)" });
+		.setTimestamp()
+		.addFields({ name: "Become a Sponsor", value: "Chip in for server costs or get premium features by sponsoring [PotL on GitHub](https://github.com/Imaginary-Horizons-Productions/Prophets-of-the-Labyrinth)" });
 }
 
 /**

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -325,14 +325,8 @@ async function generateVersionEmbed() {
 	const data = await fs.promises.readFile('./ChangeLog.md', { encoding: 'utf8' });
 	const dividerRegEx = /## .+ v\d+.\d+.\d+/g;
 	const changesStartRegEx = /\.\d+:/g;
-	const knownIssuesStartRegEx = /### Known Issues/g;
 	let titleStart = dividerRegEx.exec(data).index;
 	changesStartRegEx.exec(data);
-	let knownIssuesStart;
-	let knownIssueStartResult = knownIssuesStartRegEx.exec(data);
-	if (knownIssueStartResult) {
-		knownIssuesStart = knownIssueStartResult.index;
-	}
 	let knownIssuesEnd = dividerRegEx.exec(data).index;
 
 	return embedTemplate()


### PR DESCRIPTION
Summary
-------
- remove custom handling for Known Issues section in version embed

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] /version includes the Known Issues section

Issue
-----
Closes #410