### PR TITLE
#409: check Delver for hp exceeding max hp on gear acquisition

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # Prophets of the Labyrinth Change Log
+## Prophets of the Labyrinth v0.17.0:
+- Added context menu option to check a server member's PotL stats (Apps -> PotL Stats)
+- Fixed delvers being able to end up above max HP when acquiring Cursed Blade
 ## Prophets of the Labyrinth v0.16.0:
 ### Archetypes
 - Changed Detective to Untyped

--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -42,6 +42,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				delver.gear = archetypeTemplate.startingGear.map(gearName => {
 					return buildGearRecord(gearName, adventure);
 				});
+				if (delver.hp > delver.getMaxHP()) {
+					delver.hp = delver.getMaxHP();
+				}
 			})
 
 			interaction.reply({ content: `The adventure has begun (and closed to new delvers joining)! You can use ${commandMention("adventure party-stats")} or ${commandMention("adventure inspect-self")} to check adventure status.`, fetchReply: true }).then(message => {

--- a/source/selects/buygear.js
+++ b/source/selects/buygear.js
@@ -32,6 +32,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 			adventure.gold -= cost;
 			adventure.room.decrementResource(name, 1);
 			delver.gear.push(buildGearRecord(name, adventure));
+			if (delver.hp > delver.getMaxHP()) {
+				delver.hp = delver.getMaxHP();
+			}
 			interaction.message.edit(renderRoom(adventure, interaction.channel));
 			interaction.reply({ content: `${interaction.member.displayName} buys a ${name} for ${cost}g.` });
 			setAdventure(adventure);
@@ -60,6 +63,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 					const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
 					const discardedName = delver.gear[gearIndex].name;
 					delver.gear.splice(gearIndex, 1, buildGearRecord(name, adventure));
+					if (delver.hp > delver.getMaxHP()) {
+						delver.hp = delver.getMaxHP();
+					}
 					collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
 						adventure.room.decrementResource(name, 1);
 						adventure.gold -= cost;

--- a/source/selects/loot.js
+++ b/source/selects/loot.js
@@ -62,6 +62,9 @@ module.exports = new SelectWrapper(mainId, 2000,
 							const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
 							const discardedName = delver.gear[gearIndex].name;
 							delver.gear.splice(gearIndex, 1, buildGearRecord(name, adventure));
+							if (delver.hp > delver.getMaxHP()) {
+								delver.hp = delver.getMaxHP();
+							}
 							collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
 								adventure.room.decrementResource(name, 1);
 								return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
@@ -79,6 +82,9 @@ module.exports = new SelectWrapper(mainId, 2000,
 					return;
 				} else {
 					delver.gear.push(buildGearRecord(name, adventure));
+					if (delver.hp > delver.getMaxHP()) {
+						delver.hp = delver.getMaxHP();
+					}
 					if (adventure.room.resources[name].count > 1) {
 						adventure.room.resources[name].count--;
 					} else {

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -60,6 +60,9 @@ module.exports = new SelectWrapper(mainId, 2000,
 							const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
 							const discardedName = delver.gear[gearIndex].name;
 							delver.gear.splice(gearIndex, 1, buildGearRecord(name, adventure));
+							if (delver.hp > delver.getMaxHP()) {
+								delver.hp = delver.getMaxHP();
+							}
 							collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
 								adventure.room.decrementResource("roomAction", 1);
 								adventure.room.decrementResource(name, 1);
@@ -79,6 +82,9 @@ module.exports = new SelectWrapper(mainId, 2000,
 					return;
 				} else {
 					delver.gear.push(buildGearRecord(name, adventure));
+					if (delver.hp > delver.getMaxHP()) {
+						delver.hp = delver.getMaxHP();
+					}
 					if (adventure.room.resources[name].count > 1) {
 						adventure.room.resources[name].count--;
 					} else {


### PR DESCRIPTION
Summary
-------
- check Delver for hp exceeding max hp on gear acquisition

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] starting with Cursed Blade no longer starts adventure with player above max HP

Issue
-----
Closes #409