### PR TITLE
#405: Curse of Midas fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 - New Challenge: Cursed Run - One of your starting gear pieces is randomly replaced with cursed gear
 - Fixed delvers being able to end up above max HP when acquiring Cursed Blade
 - Fixed Reckless Certain Victory not reporting its user paying HP
+- Fixed the party stats embed not showing the Final Battle after it had been scouted
+- Fixed Curse of Midas reporting generating fractional gold, not scaling with stacks, and being added to party gold immediately instead of being added to loot
 ## Prophets of the Labyrinth v0.16.0:
 ### Archetypes
 - Changed Detective to Untyped

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -88,9 +88,9 @@ function dealDamage(targets, assailant, damage, isUnblockable, element, adventur
 					target.hp -= pendingDamage;
 					results.push(`${target.name} takes ${pendingDamage} ${getEmoji(element)} damage${blockedDamage > 0 ? ` (${blockedDamage} was blocked)` : ""}${isWeakness ? "!!!" : isResistance ? "." : "!"}${downedCheck(target, adventure)}`);
 					if (pendingDamage > 0 && "Curse of Midas" in target.modifiers) {
-						const midasGold = pendingDamage / 10;
-						adventure.gainGold(Math.floor(midasGold));
-						results.push(`Loot: +${midasGold}g`)
+						const midasGold = Math.floor(pendingDamage / 10 * target.modifiers["Curse of Midas"]);
+						adventure.room.addResource("gold", "gold", "loot", midasGold);
+						results.push(`${getApplicationEmojiMarkdown("Curse of Midas")}: Loot +${midasGold}g`)
 					}
 				} else {
 					removeModifier([target], { name: "Evade", stacks: 1, force: true });


### PR DESCRIPTION
Summary
-------
- fixed Curse of Midas adding gold immediately instead of to loot
- fixed Curse of Midas reporting generating fractional gold
- fixed Curse of Midas not scaling with stacks
- added emoji to Curse of Midas result line

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] hitting the Treasure Elemental no longer produces result lines with fractional gold generation
- [x] using Greed against the Treasure Elemental scales up gold generated
- [x] Curse of Midas adds gold to end of combat loot instead of immediately to party coffers

Issue
-----
Closes #405