### PR TITLE
#435: improve start of delve messaging

### DIFF
--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -2,7 +2,6 @@ const { ButtonWrapper } = require('../classes');
 const { getArchetype } = require('../archetypes/_archetypeDictionary');
 const { buildGearRecord } = require('../gear/_gearDictionary');
 const { getAdventure, nextRoom, fetchRecruitMessage, setAdventure } = require('../orcustrators/adventureOrcustrator');
-const { commandMention } = require('../util/textUtil');
 const { bold } = require('discord.js');
 
 const cursedGearByPurpose = ["Cursed Blade", "Cursed Tome"];
@@ -32,6 +31,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
 				recruitMessage.edit({ components: [] });
 			}).catch(console.error);
+			interaction.update({ components: [] });
 			interaction.message.delete();
 
 			adventure.delvers.forEach(delver => {
@@ -57,12 +57,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				}
 			})
 
-			interaction.reply({ content: `The adventure has begun (and closed to new delvers joining)! You can use ${commandMention("adventure party-stats")} or ${commandMention("adventure inspect-self")} to check adventure status.`, fetchReply: true }).then(message => {
+			interaction.channel.send({ content: `The adventure has begun (and closed to new delvers joining)! You can use ${commandMention("adventure party-stats")} or ${commandMention("adventure inspect-self")} to check adventure status. You can also use ${commandMention("manual")} to look up various information on the game.`, fetchReply: true }).then(message => {
 				message.pin();
-				adventure.state = "ongoing";
-				adventure.messageIds.utility = message.id;
-				nextRoom(adventure.getChallengeIntensity("Into the Deep End") > 0 ? "Artifact Guardian" : "Battle", interaction.channel);
 			});
+			adventure.state = "ongoing";
+			nextRoom(adventure.getChallengeIntensity("Into the Deep End") > 0 ? "Artifact Guardian" : "Battle", interaction.channel);
 		}
 	}
 );

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -37,7 +37,6 @@ class Adventure {
 	static endStates = ["success", "defeat", "giveup"];
 	messageIds = {
 		recruit: "",
-		utility: "",
 		room: "",
 		battleRound: ""
 	};

--- a/source/commands/delve.js
+++ b/source/commands/delve.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ChannelType, InteractionContextType } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ChannelType, InteractionContextType, italic, userMention } = require('discord.js');
 const { PermissionFlagsBits } = require('discord.js');
 const { CommandWrapper, Adventure, Delver } = require('../classes');
 const { setAdventure } = require('../orcustrators/adventureOrcustrator');
@@ -7,58 +7,60 @@ const { prerollBoss, defaultLabyrinths, labyrinthExists, getLabyrinthProperty } 
 const { SAFE_DELIMITER } = require('../constants');
 const { isSponsor } = require('../util/fileUtil');
 const { generateRecruitEmbed, generateAdventureConfigMessage } = require('../util/embedUtil');
+const { injectApplicationEmojiMarkdown } = require('../util/graphicsUtil');
 
 const mainId = "delve";
 module.exports = new CommandWrapper(mainId, "Start a new adventure", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
-/** Start a new adventure */
-(interaction) => {
-	if (interaction.channel.type !== ChannelType.GuildText) {
-		interaction.reply({ content: "Please start your adventure in a text channel (threads cannot be made in thread channels).", ephemeral: true });
-		return;
-	}
+	/** Start a new adventure */
+	(interaction) => {
+		if (interaction.channel.type !== ChannelType.GuildText) {
+			interaction.reply({ content: "Please start your adventure in a text channel (threads cannot be made in thread channels).", ephemeral: true });
+			return;
+		}
 
-	const labyrinthName = interaction.options.getString("labyrinth");
-	if (!labyrinthExists(labyrinthName)) {
-		interaction.reply({ content: `There isn't a labyrinth named **${labyrinthName}** (input is case-sensitive).`, ephemeral: true });
-		return;
-	}
+		const labyrinthName = interaction.options.getString("labyrinth");
+		if (!labyrinthExists(labyrinthName)) {
+			interaction.reply({ content: `There isn't a labyrinth named **${labyrinthName}** (input is case-sensitive).`, ephemeral: true });
+			return;
+		}
 
-	const company = getCompany(interaction.guildId);
-	if (!isSponsor(interaction.user.id) && company.adventuring.has(interaction.user.id)) {
-		interaction.reply({ content: "Delving in more than one adventure per server is a premium perk. Use `/support` for more details.", ephemeral: true });
-		return;
-	}
+		const company = getCompany(interaction.guildId);
+		if (!isSponsor(interaction.user.id) && company.adventuring.has(interaction.user.id)) {
+			interaction.reply({ content: "Delving in more than one adventure per server is a premium perk. Use `/support` for more details.", ephemeral: true });
+			return;
+		}
 
-	const labyrinthNameInTitleCaps = getLabyrinthProperty(labyrinthName, "name");
-	const adventure = new Adventure(interaction.options.getString("seed"), interaction.guildId, labyrinthNameInTitleCaps, interaction.user.id);
-	// roll bosses
-	prerollBoss("Final Battle", adventure);
-	prerollBoss("Artifact Guardian", adventure);
+		const labyrinthNameInTitleCaps = getLabyrinthProperty(labyrinthName, "name");
+		const adventure = new Adventure(interaction.options.getString("seed"), interaction.guildId, labyrinthNameInTitleCaps, interaction.user.id);
+		// roll bosses
+		prerollBoss("Final Battle", adventure);
+		prerollBoss("Artifact Guardian", adventure);
 
-	interaction.reply({ embeds: [generateRecruitEmbed(adventure)], fetchReply: true }).then(recruitMessage => {
-		adventure.messageIds.recruit = recruitMessage.id;
-		interaction.channel.threads.create({
-			name: adventure.name,
-			type: ChannelType.PrivateThread,
-			invitable: true
-		}).then(thread => {
-			recruitMessage.edit({
-				components: [new ActionRowBuilder().addComponents(
-					new ButtonBuilder().setCustomId(`join${SAFE_DELIMITER}${thread.guildId}${SAFE_DELIMITER}${thread.id}${SAFE_DELIMITER}recruit`)
-						.setLabel("Join")
-						.setStyle(ButtonStyle.Success)
-				)]
+		interaction.reply({ embeds: [generateRecruitEmbed(adventure)], fetchReply: true }).then(recruitMessage => {
+			adventure.messageIds.recruit = recruitMessage.id;
+			interaction.channel.threads.create({
+				name: adventure.name,
+				type: ChannelType.PrivateThread,
+				invitable: true
+			}).then(thread => {
+				recruitMessage.edit({
+					components: [new ActionRowBuilder().addComponents(
+						new ButtonBuilder().setCustomId(`join${SAFE_DELIMITER}${thread.guildId}${SAFE_DELIMITER}${thread.id}${SAFE_DELIMITER}recruit`)
+							.setLabel("Join")
+							.setStyle(ButtonStyle.Success)
+					)]
+				});
+				adventure.delvers.push(new Delver(interaction.user.id, interaction.member.displayName, thread.id));
+				company.adventuring.add(interaction.user.id);
+				setCompany(company);
+
+				adventure.setId(thread.id);
+				setAdventure(adventure);
+				thread.send(`## ${adventure.name}\n${italic(injectApplicationEmojiMarkdown(getLabyrinthProperty(adventure.labyrinth, "description")))}\nParty Leader: ${userMention(adventure.leaderId)}`);
+				thread.send(generateAdventureConfigMessage());
 			});
-			adventure.delvers.push(new Delver(interaction.user.id, interaction.member.displayName, thread.id));
-			company.adventuring.add(interaction.user.id);
-			setCompany(company);
-
-			adventure.setId(thread.id);
-			setAdventure(adventure);
-			thread.send(generateAdventureConfigMessage(adventure));
-		});
-	}).catch(console.error);
-}
+		}).catch(console.error);
+	}
 ).setOptions(
 	{ type: "String", name: "labyrinth", description: "The value to base the run's random events on", required: true, autocomplete: defaultLabyrinths.map(labyrinthName => ({ name: labyrinthName, value: labyrinthName })) },
 	{ type: "String", name: "seed", description: "The value to base the run's random events on", required: false }

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1086,11 +1086,6 @@ function completeAdventure(adventure, thread, endState, descriptionOverride) {
 	})
 	clearComponents(adventure.messageIds.battleRound, messageManager);
 	clearComponents(adventure.messageIds.room, messageManager);
-	[adventure.messageIds.utility].forEach(id => {
-		if (id) {
-			messageManager.delete(id).catch(console.error);
-		}
-	})
 
 	adventure.state = endState;
 	setAdventure(adventure);

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -6,13 +6,12 @@ const { DISCORD_ICON_URL, POTL_ICON_URL, SAFE_DELIMITER, MAX_BUTTONS_PER_ROW, MA
 
 const { getChallenge, getStartingChallenges } = require("../challenges/_challengeDictionary");
 const { getGearProperty, buildGearDescription } = require("../gear/_gearDictionary");
-const { getLabyrinthProperty } = require("../labyrinths/_labyrinthDictionary");
 const { isBuff, isDebuff } = require("../modifiers/_modifierDictionary");
 const { getRoom } = require("../rooms/_roomDictionary");
 
 const { getEmoji, getColor } = require("./elementUtil");
 const { ordinalSuffixEN, generateTextBar, getNumberEmoji, trimForSelectOptionDescription, listifyEN } = require("./textUtil");
-const { getApplicationEmojiMarkdown, injectApplicationEmojiMarkdown } = require("./graphicsUtil");
+const { getApplicationEmojiMarkdown } = require("./graphicsUtil");
 
 const { getCompany, setCompany } = require("../orcustrators/companyOrcustrator");
 const { getPlayer, setPlayer } = require("../orcustrators/playerOrcustrator");
@@ -109,14 +108,13 @@ function generateRecruitEmbed(adventure) {
 		.addFields(fields);
 }
 
-/** @param {Adventure} adventure */
-function generateAdventureConfigMessage(adventure) {
+function generateAdventureConfigMessage() {
 	const options = getStartingChallenges().map(challengeName => {
 		const challenge = getChallenge(challengeName);
 		return { label: challengeName, description: trimForSelectOptionDescription(challenge.dynamicDescription(challenge.intensity, challenge.duration, challenge.reward)), value: challengeName };
 	})
 	return {
-		content: `**${adventure.labyrinth}**\n*${injectApplicationEmojiMarkdown(getLabyrinthProperty(adventure.labyrinth, "description"))}*\nParty Leader: <@${adventure.leaderId}>\n\nThe adventure will begin when everyone clicks the "Ready!" button. Each player must select an archetype and can optionally select a starting artifact.`,
+		content: "Each player must select an archetype and can optionally select a starting artifact. The adventure will begin when everyone clicks the \"Ready!\" button.",
 		components: [
 			new ActionRowBuilder().addComponents(
 				new ButtonBuilder().setCustomId("ready")


### PR DESCRIPTION
Summary
-------
- separate labyrinth description from config message so labyrinth description survives after config message is deleted
- mention /manual in "adventure is starting message"
- skip deleting utility message on adventure completion (no longer has buttons to clean up)
- "adventure is starting" message no longer references the previously deleted message

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] started adventures to see how they looked

Issue
-----
Closes #435