### PR TITLE
#419: use select option descriptions to label resource type for loot, treasure and merchants

### DIFF
--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -32,8 +32,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			fetchRecruitMessage(interaction.channel, adventure.messageIds.recruit).then(recruitMessage => {
 				recruitMessage.edit({ components: [] });
 			}).catch(console.error);
-			interaction.update({ components: [] });
-			interaction.message.delete();
+			interaction.update({ components: [] }).then(() => {
+				interaction.message.delete();
+			});
 
 			adventure.delvers.forEach(delver => {
 				if (delver.startingArtifact) {
@@ -62,7 +63,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				message.pin();
 			});
 			adventure.state = "ongoing";
-			nextRoom(adventure.getChallengeIntensity("Into the Deep End") > 0 ? "Artifact Guardian" : "Battle", interaction.channel);
+			nextRoom(adventure.getChallengeIntensity("Into the Deep End") > 0 ? "Artifact Guardian" : "Treasure", interaction.channel);
 		}
 	}
 );

--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -3,6 +3,7 @@ const { getArchetype } = require('../archetypes/_archetypeDictionary');
 const { buildGearRecord } = require('../gear/_gearDictionary');
 const { getAdventure, nextRoom, fetchRecruitMessage, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { bold } = require('discord.js');
+const { commandMention } = require('../util/textUtil');
 
 const cursedGearByPurpose = ["Cursed Blade", "Cursed Tome"];
 

--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -63,7 +63,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				message.pin();
 			});
 			adventure.state = "ongoing";
-			nextRoom(adventure.getChallengeIntensity("Into the Deep End") > 0 ? "Artifact Guardian" : "Treasure", interaction.channel);
+			nextRoom(adventure.getChallengeIntensity("Into the Deep End") > 0 ? "Artifact Guardian" : "Battle", interaction.channel);
 		}
 	}
 );

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -302,7 +302,7 @@ class Room {
 	enemies = null;
 	/** @type {{[enemyName: string]: number} | null} */
 	enemyIdMap = null;
-	/** @type {Record<string, {name: string, type: "gear" | "artifact" | "gold" | "scouting" | "roomAction" | "challenge" | "item", visibility: "loot" | "always" | "internal", count: number, uiGroup?: string, cost?: number}>} */
+	/** @type {Record<string, {name: string, type: "Gear" | "Artifact" | "Currency" | "scouting" | "roomAction" | "challenge" | "Item", visibility: "loot" | "always" | "internal", count: number, uiGroup?: string, cost?: number}>} */
 	resources = {};
 	/** @type {Record<string, string[]>} */
 	history = {};
@@ -317,7 +317,7 @@ class Room {
 
 	/** Initializes a resource in the room's resources if it's not already present
 	 * @param {string} nameInput Note: all names in the combined pool of gear, artifacts, items, and resources must be unique
-	 * @param {"gear" | "artifact" | "gold" | "scouting" | "roomAction" | "challenge" | "item"} typeInput
+	 * @param {"Gear" | "Artifact" | "Currency" | "scouting" | "roomAction" | "challenge" | "Item"} typeInput
 	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
 	 * @param {number} countInput
 	 * @param {string?} uiGroupInput

--- a/source/classes/RoomTemplate.js
+++ b/source/classes/RoomTemplate.js
@@ -43,7 +43,7 @@ class ResourceTemplate {
 	/** This read-only data class that defines resources available for placement in rooms
 	 * @param {string} countExpression
 	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
-	 * @param {"gear" | "artifact" | "gold" | "roomAction" | "challenge" | "item" | string} typeInput categories (eg "item", "gear") are random rolls, specific names allowed
+	 * @param {"Gear" | "Artifact" | "Currency" | "roomAction" | "challenge" | "Item" | string} typeInput categories (eg "item", "gear") are random rolls, specific names allowed
 	 */
 	constructor(countExpression, visibilityInput, typeInput) {
 		if (!countExpression) throw new BuildError("Falsy countExpression");

--- a/source/gear/cauldronstir-base.js
+++ b/source/gear/cauldronstir-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate(gearName,
 		const resultLines = [dealDamage(targets, user, pendingDamage, false, element, adventure)];
 		if (user.crit) {
 			const rolledPotion = rollablePotions[user.roundRns[`${gearName}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
-			adventure.room.addResource(rolledPotion, "item", "loot", 1);
+			adventure.room.addResource(rolledPotion, "Item", "loot", 1);
 			resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 		}
 		return resultLines;

--- a/source/gear/cauldronstir-corrosive.js
+++ b/source/gear/cauldronstir-corrosive.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate(gearName,
 		const resultLines = [dealDamage(targets, user, pendingDamage, false, element, adventure)];
 		if (user.crit) {
 			const rolledPotion = rollablePotions[user.roundRns[`${gearName}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
-			adventure.room.addResource(rolledPotion, "item", "loot", 1);
+			adventure.room.addResource(rolledPotion, "Item", "loot", 1);
 			resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 		}
 

--- a/source/gear/cauldronstir-sabotaging.js
+++ b/source/gear/cauldronstir-sabotaging.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		if (user.crit) {
 			const rolledPotion = rollablePotions[user.roundRns[`${gearName}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
-			adventure.room.addResource(rolledPotion, "item", "loot", 1);
+			adventure.room.addResource(rolledPotion, "Item", "loot", 1);
 			resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 		}
 		for (const target of stillLivingTargets) {

--- a/source/gear/cauldronstir-toxic.js
+++ b/source/gear/cauldronstir-toxic.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate(gearName,
 		const resultLines = [dealDamage(targets, user, pendingDamage, false, element, adventure)];
 		if (user.crit) {
 			const rolledPotion = rollablePotions[user.roundRns[`${gearName}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
-			adventure.room.addResource(rolledPotion, "item", "loot", 1);
+			adventure.room.addResource(rolledPotion, "Item", "loot", 1);
 			resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 		}
 		return resultLines.concat(generateModifierResultLines(addModifier(targets, poison)));

--- a/source/gear/herbbasket-base.js
+++ b/source/gear/herbbasket-base.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate(gearName,
 			changeStagger([user], "elementMatchAlly");
 		}
 		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
-		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "Item", "loot", pendingHerbCount);
 		if (user.crit) {
 			return [`${user.name} gathers a double-batch of ${randomHerb}.`];
 		} else {

--- a/source/gear/herbbasket-organic.js
+++ b/source/gear/herbbasket-organic.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate(gearName,
 			changeStagger([user], "elementMatchAlly");
 		}
 		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
-		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "Item", "loot", pendingHerbCount);
 		if (user.crit) {
 			return [`${user.name} gathers a double-batch of ${randomHerb}.`];
 		} else {

--- a/source/gear/herbbasket-reinforced.js
+++ b/source/gear/herbbasket-reinforced.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		addProtection([user], protection);
 		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
-		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "Item", "loot", pendingHerbCount);
 		if (user.crit) {
 			return [`${user.name} gains protection and gathers a double-batch of ${randomHerb}.`];
 		} else {

--- a/source/gear/herbbasket-urgent.js
+++ b/source/gear/herbbasket-urgent.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate(gearName,
 			changeStagger([user], "elementMatchAlly");
 		}
 		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
-		adventure.room.addResource(randomHerb, "item", "loot", pendingHerbCount);
+		adventure.room.addResource(randomHerb, "Item", "loot", pendingHerbCount);
 		if (user.crit) {
 			return [`${user.name} gathers a double-batch of ${randomHerb}.`];
 		} else {

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -211,7 +211,7 @@ function nextRoom(roomType, thread) {
 					adventure.room.addResource(challengeName, resourceType, visibility, 1);
 				})
 				break;
-			case "gear": {
+			case "Gear": {
 				let tier = unparsedTier;
 				for (let i = 0; i < Math.min(MAX_SELECT_OPTIONS, count); i++) {
 					if (unparsedTier === "?") {
@@ -224,23 +224,23 @@ function nextRoom(roomType, thread) {
 				}
 				break;
 			}
-			case "artifact": {
+			case "Artifact": {
 				const artifact = rollArtifact(adventure);
 				adventure.room.addResource(artifact, resourceType, visibility, count, uiGroup);
 				break;
 			}
-			case "item": {
+			case "Item": {
 				const item = rollItem(adventure);
 				adventure.room.addResource(item, resourceType, visibility, count, uiGroup, Math.ceil(parseExpression(unparsedCostExpression, getItem(item).cost)));
 				break;
 			}
-			case "gold": {
+			case "Currency": {
 				// Randomize loot gold
 				let goldCount = count;
 				if (visibility !== "internal") {
 					goldCount = Math.ceil(count * (90 + adventure.generateRandomNumber(21, "general")) / 100);
 				}
-				adventure.room.addResource(resourceType, resourceType, visibility, goldCount, uiGroup);
+				adventure.room.addResource("Gold", resourceType, visibility, goldCount, uiGroup);
 				break;
 			}
 			default: {
@@ -1031,19 +1031,19 @@ function checkEndCombat(adventure, thread, lastRoundText) {
 		// Gear drops
 		const gearThreshold = 1;
 		const gearMax = 16;
-		if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
+		if (true/*adventure.generateRandomNumber(gearMax, "general") < gearThreshold*/) {
 			const tier = rollGearTier(adventure);
 			const droppedGear = rollGear(tier, adventure);
 			if (droppedGear) {
-				adventure.room.addResource(droppedGear, "gear", "loot", 1);
+				adventure.room.addResource(droppedGear, "Gear", "loot", 1);
 			}
 		}
 
 		// Item drops
 		const itemThreshold = 1;
 		const itemMax = 8;
-		if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
-			adventure.room.addResource(rollItem(adventure), "item", "loot", 1);
+		if (true/*adventure.generateRandomNumber(itemMax, "general") < itemThreshold*/) {
+			adventure.room.addResource(rollItem(adventure), "Item", "loot", 1);
 		}
 
 		return { payload: renderRoom(adventure, thread, lastRoundText), type: "endCombat" };

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1031,7 +1031,7 @@ function checkEndCombat(adventure, thread, lastRoundText) {
 		// Gear drops
 		const gearThreshold = 1;
 		const gearMax = 16;
-		if (true/*adventure.generateRandomNumber(gearMax, "general") < gearThreshold*/) {
+		if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
 			const tier = rollGearTier(adventure);
 			const droppedGear = rollGear(tier, adventure);
 			if (droppedGear) {
@@ -1042,7 +1042,7 @@ function checkEndCombat(adventure, thread, lastRoundText) {
 		// Item drops
 		const itemThreshold = 1;
 		const itemMax = 8;
-		if (true/*adventure.generateRandomNumber(itemMax, "general") < itemThreshold*/) {
+		if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
 			adventure.room.addResource(rollItem(adventure), "Item", "loot", 1);
 		}
 

--- a/source/rooms/artifactguardian-royalslime.js
+++ b/source/rooms/artifactguardian-royalslime.js
@@ -9,8 +9,8 @@ module.exports = new RoomTemplate("A Slimy Throneroom",
 	"Off to the side of the room lays a knocked over thone and crown. As the party approaches it, slime gushes from the ceiling, engulfing the objects. The slime collects stands itself up into a teardrop shape, suspending the throne inside it and the crown atop it, then begins rolling in the direction of the party.",
 	[
 		new ResourceTemplate("3", "internal", "levelsGained"),
-		new ResourceTemplate("1", "loot", "artifact"),
-		new ResourceTemplate(`${enemies[0][1]}*100`, "loot", "gold")
+		new ResourceTemplate("1", "loot", "Artifact"),
+		new ResourceTemplate(`${enemies[0][1]}*100`, "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/artifactguardian-treasureelemental.js
+++ b/source/rooms/artifactguardian-treasureelemental.js
@@ -9,8 +9,8 @@ module.exports = new RoomTemplate("A windfall of treasure!",
 	"Floor to ceiling, gold coins, gems and other valuables are stacked in massive piles. Out of the corner of your eyes, you notice a mass of treasure meld together...",
 	[
 		new ResourceTemplate("3", "internal", "levelsGained"),
-		new ResourceTemplate("1", "loot", "artifact"),
-		new ResourceTemplate("75", "loot", "gold")
+		new ResourceTemplate("1", "loot", "Artifact"),
+		new ResourceTemplate("75", "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder(["greed"])

--- a/source/rooms/battle-bloodtailhawks.js
+++ b/source/rooms/battle-bloodtailhawks.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Hawk Fight",
 	"A flock of birds of prey swoop down looking for a meal.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "gold")
+		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/battle-frogranch.js
+++ b/source/rooms/battle-frogranch.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Frog Ranch",
 	"Two Mechabee Soldiers are interrupted while escorting a set of domesticated Fire-Arrow Frogs to another pasture.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate(`${enemies[1][1]}*25+35`, "loot", "gold")
+		new ResourceTemplate(`${enemies[1][1]}*25+35`, "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/battle-mechabees.js
+++ b/source/rooms/battle-mechabees.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Mechabee Fight",
 	"Some mechabees charge at you. In addition to starting a fight, it prompts you to wonder if mechabees are more mech or more bee.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("25*n+35", "loot", "gold")
+		new ResourceTemplate("25*n+35", "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/battle-meteorknight.js
+++ b/source/rooms/battle-meteorknight.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Meteor Knight Fight",
 	"You are halted by a company of knights. By the time a Earthly Knight has advanced one step towards you, the Meteor Knight has recklessly charged across most of the gap!",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("45*n", "loot", "gold")
+		new ResourceTemplate("45*n", "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/battle-slimes.js
+++ b/source/rooms/battle-slimes.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Slime Fight",
 	"Some slimes and oozes approach...",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("35*n", "loot", "gold")
+		new ResourceTemplate("35*n", "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/battle-tortoises.js
+++ b/source/rooms/battle-tortoises.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Tortoise Fight",
 	"The rocky terrain rises up to reveal a pair of shelled menaces.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("40*n", "loot", "gold")
+		new ResourceTemplate("40*n", "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/battle-wildfirearrowfrogs.js
+++ b/source/rooms/battle-wildfirearrowfrogs.js
@@ -9,7 +9,7 @@ module.exports = new RoomTemplate("Wild Fire-Arrow Frogs",
 	"A blaze of orange and red in the muck outs itself as a warning sign to a blast of heated mud and venom.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "gold")
+		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "Currency")
 	],
 	function (adventure) { return {}; },
 	generateCombatRoomBuilder([])

--- a/source/rooms/event-freegoldonfire.js
+++ b/source/rooms/event-freegoldonfire.js
@@ -8,7 +8,7 @@ module.exports = new RoomTemplate("Free Gold?",
 	"Event",
 	"A large pile of gold sits quietly in the middle of the room, seemingly alone.",
 	[
-		new ResourceTemplate("300", "internal", "gold")
+		new ResourceTemplate("300", "internal", "Currency")
 	],
 	function (adventure) {
 		return {
@@ -25,7 +25,7 @@ module.exports = new RoomTemplate("Free Gold?",
 			getEmoji = "🔥";
 			getLabel = `+${reward}g, ${adventure.room.history.Burned[0]} -${burnDamage} HP`;
 			isGetDisabled = true;
-		} else if (!("gold" in adventure.room.resources)) {
+		} else if (!("Gold" in adventure.room.resources)) {
 			getEmoji = "✔️";
 			getLabel = `+${reward}g`;
 			isGetDisabled = true;

--- a/source/rooms/merchant-gear.js
+++ b/source/rooms/merchant-gear.js
@@ -1,9 +1,8 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { buildGearDescription, getGearProperty } = require("../gear/_gearDictionary");
+const { getGearProperty } = require("../gear/_gearDictionary");
 const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
-const { trimForSelectOptionDescription } = require("../util/textUtil");
 
 const uiGroups = [`gear${SAFE_DELIMITER}?`, `gear${SAFE_DELIMITER}Rare`];
 
@@ -12,8 +11,8 @@ module.exports = new RoomTemplate("Gear Merchant",
 	"Merchant",
 	"A masked figure sits in front of a rack of weapons and other gear. \"Care to trade?\"",
 	[
-		new ResourceTemplate("n+1", "always", "gear").setTier("?").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("2", "always", "gear").setTier("Rare").setUIGroup(uiGroups[1])
+		new ResourceTemplate("n+1", "always", "Gear").setTier("?").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("2", "always", "Gear").setTier("Rare").setUIGroup(uiGroups[1])
 	],
 	function (adventure) { return {}; },
 	function (roomEmbed, adventure) {
@@ -28,7 +27,7 @@ module.exports = new RoomTemplate("Gear Merchant",
 					const maxDurability = getGearProperty(name, "maxDurability");
 					const option = {
 						label: `${cost}g: ${name} (${maxDurability > 0 ? `${maxDurability}  uses` : "passive"})`,
-						description: trimForSelectOptionDescription(buildGearDescription(name, false)),
+						description: "Gear",
 						value: `${name}${SAFE_DELIMITER}${i}`
 					};
 					switch (uiGroup) {

--- a/source/rooms/merchant-gearbuying.js
+++ b/source/rooms/merchant-gearbuying.js
@@ -1,16 +1,15 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { buildGearDescription, getGearProperty } = require("../gear/_gearDictionary");
+const { getGearProperty } = require("../gear/_gearDictionary");
 const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
-const { trimForSelectOptionDescription } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Gear Buying Merchant",
 	"@{adventure}",
 	"Merchant",
 	"A masked figure sits in front of a half-full rack of weapons and other gear. \"Care to trade?\"",
 	[
-		new ResourceTemplate("n+1", "always", "gear").setTier("?")
+		new ResourceTemplate("n+1", "always", "Gear").setTier("?")
 	],
 	function (adventure) { return {}; },
 	function (roomEmbed, adventure) {
@@ -23,7 +22,7 @@ module.exports = new RoomTemplate("Gear Buying Merchant",
 				const maxDurability = getGearProperty(name, "maxDurability");
 				mixedGearOptions.push({
 					label: `${cost}g: ${name} (${maxDurability > 0 ? `${maxDurability}  uses` : "passive"})`,
-					description: trimForSelectOptionDescription(buildGearDescription(name, false)),
+					description: "Gear",
 					value: `${name}${SAFE_DELIMITER}${i}`
 				});
 			}

--- a/source/rooms/merchant-item.js
+++ b/source/rooms/merchant-item.js
@@ -1,11 +1,9 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { getGearProperty, buildGearDescription } = require("../gear/_gearDictionary");
+const { getGearProperty } = require("../gear/_gearDictionary");
 const { getItem } = require("../items/_itemDictionary");
 const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
-const { trimForSelectOptionDescription } = require("../util/textUtil");
-const { injectApplicationEmojiName } = require("../util/graphicsUtil");
 
 const uiGroups = [`gear${SAFE_DELIMITER}?`, "item"];
 
@@ -31,7 +29,7 @@ module.exports = new RoomTemplate("Item Merchant",
 						const maxDurability = getGearProperty(name, "maxDurability");
 						gearOptions.push({
 							label: `${cost}g: ${name} (${maxDurability > 0 ? `${maxDurability}  uses` : "passive"})`,
-							description: trimForSelectOptionDescription(buildGearDescription(name, false)),
+							description: "Gear",
 							value: `${name}${SAFE_DELIMITER}${i}`
 						});
 						break;
@@ -40,7 +38,7 @@ module.exports = new RoomTemplate("Item Merchant",
 						const item = getItem(name);
 						itemOptions.push({
 							label: `${item.cost}g: ${name}`,
-							description: trimForSelectOptionDescription(injectApplicationEmojiName(item.description)),
+							description: "Item",
 							value: `${name}${SAFE_DELIMITER}${i}`
 						})
 						break;

--- a/source/rooms/merchant-overpriced.js
+++ b/source/rooms/merchant-overpriced.js
@@ -1,9 +1,8 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { buildGearDescription, getGearProperty } = require("../gear/_gearDictionary");
+const { getGearProperty } = require("../gear/_gearDictionary");
 const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
-const { trimForSelectOptionDescription } = require("../util/textUtil");
 
 const uiGroups = [`gear${SAFE_DELIMITER}?`, `gear${SAFE_DELIMITER}Rare`];
 
@@ -28,7 +27,7 @@ module.exports = new RoomTemplate("Overpriced Merchant",
 					const maxDurability = getGearProperty(name, "maxDurability");
 					const option = {
 						label: `${cost}g: ${name} (${maxDurability > 0 ? `${maxDurability}  uses` : "passive"})`,
-						description: trimForSelectOptionDescription(buildGearDescription(name, false)),
+						description: "Gear",
 						value: `${name}${SAFE_DELIMITER}${i}`
 					};
 					switch (uiGroup) {

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -1,10 +1,8 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 
-const { getArtifact } = require("../artifacts/_artifactDictionary");
-const { buildGearDescription } = require("../gear/_gearDictionary");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { trimForSelectOptionDescription, listifyEN } = require("../util/textUtil");
+const { listifyEN } = require("../util/textUtil");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
@@ -13,8 +11,8 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("1", "always", "artifact").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "gear").setTier("?").setCostExpression("0")
+		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0")
 	],
 	function (adventure) {
 		return {
@@ -26,18 +24,11 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
-					const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-					option.label = `${name} x ${count}`;
-					switch (type) {
-						case "gear":
-							option.description = trimForSelectOptionDescription(buildGearDescription(name, false));
-							break;
-						case "artifact":
-							option.description = trimForSelectOptionDescription(getArtifact(name).dynamicDescription(count));
-							break;
-					}
-					options.push(option)
+					options.push({
+						label: `${name} x ${count}`,
+						description: type,
+						value: `${name}${SAFE_DELIMITER}${options.length}`
+					});
 				}
 			}
 			const hasOptions = options.length > 0;

--- a/source/rooms/treasure-artifactvsgold.js
+++ b/source/rooms/treasure-artifactvsgold.js
@@ -3,9 +3,8 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { getArtifact } = require("../artifacts/_artifactDictionary");
-const { trimForSelectOptionDescription, listifyEN } = require("../util/textUtil");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { listifyEN } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 	"@{adventure}",
@@ -13,8 +12,8 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gold' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("1", "always", "artifact").setCostExpression("0"),
-		new ResourceTemplate("250*n", "always", "gold").setCostExpression("0")
+		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
+		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0")
 	],
 	function (adventure) {
 		return {
@@ -26,18 +25,11 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
-					const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-					if (name === "gold") {
-						option.label = `${count} Gold`;
-					} else {
-						option.label = `${name} x ${count}`;
-					}
-
-					if (type === "artifact") {
-						option.description = trimForSelectOptionDescription(getArtifact(name).dynamicDescription(count));
-					}
-					options.push(option)
+					options.push({
+						label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+						description: type,
+						value: `${name}${SAFE_DELIMITER}${options.length}`
+					});
 				}
 			}
 			const hasOptions = options.length > 0;

--- a/source/rooms/treasure-artifactvsitems.js
+++ b/source/rooms/treasure-artifactvsitems.js
@@ -2,12 +2,9 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 
-const { getArtifact } = require("../artifacts/_artifactDictionary");
-const { getItem } = require("../items/_itemDictionary");
 const { EMPTY_SELECT_OPTION_SET, SAFE_DELIMITER } = require("../constants");
-const { trimForSelectOptionDescription, listifyEN } = require("../util/textUtil");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
-const { injectApplicationEmojiName } = require("../util/graphicsUtil");
+const { listifyEN } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 	"@{adventure}",
@@ -15,8 +12,8 @@ module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("1", "always", "artifact").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "item").setCostExpression("0")
+		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
 	],
 	function (adventure) {
 		return {
@@ -28,18 +25,11 @@ module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
-					const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-					option.label = `${name} x ${count}`;
-					switch (type) {
-						case "artifact":
-							option.description = trimForSelectOptionDescription(getArtifact(name).dynamicDescription(count));
-							break;
-						case "item":
-							option.description = trimForSelectOptionDescription(injectApplicationEmojiName(getItem(name).description));
-							break;
-					}
-					options.push(option)
+					options.push({
+						label: `${name} x ${count}`,
+						description: type,
+						value: `${name}${SAFE_DELIMITER}${options.length}`
+					});
 				}
 			}
 			const hasOptions = options.length > 0;

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -3,11 +3,8 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { buildGearDescription } = require("../gear/_gearDictionary");
-const { getItem } = require("../items/_itemDictionary");
-const { trimForSelectOptionDescription, listifyEN } = require("../util/textUtil");
+const { listifyEN } = require("../util/textUtil");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
-const { injectApplicationEmojiName } = require("../util/graphicsUtil");
 
 module.exports = new RoomTemplate("Treasure! Gear or Items?",
 	"@{adventure}",
@@ -15,8 +12,8 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gear' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("2", "always", "gear").setTier("?").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "item").setCostExpression("0")
+		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
 	],
 	function (adventure) {
 		return {
@@ -28,18 +25,11 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
-					const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-					option.label = `${name} x ${count}`;
-					switch (type) {
-						case "gear":
-							option.description = trimForSelectOptionDescription(buildGearDescription(name, false));
-							break;
-						case "item":
-							option.description = trimForSelectOptionDescription(injectApplicationEmojiName(getItem(name).description));
-							break;
-					}
-					options.push(option)
+					options.push({
+						label: `${name} x ${count}`,
+						description: type,
+						value: `${name}${SAFE_DELIMITER}${options.length}`
+					});
 				}
 			}
 			const hasOptions = options.length > 0;

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -3,8 +3,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { buildGearDescription } = require("../gear/_gearDictionary");
-const { trimForSelectOptionDescription, listifyEN } = require("../util/textUtil");
+const { listifyEN } = require("../util/textUtil");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Gear?",
@@ -13,8 +12,8 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("250*n", "always", "gold").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "gear").setTier("?").setCostExpression("0")
+		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0")
 	],
 	function (adventure) {
 		return {
@@ -26,18 +25,11 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
-					const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-					if (name === "gold") {
-						option.label = `${count} Gold`;
-					} else {
-						option.label = `${name} x ${count}`;
-					}
-
-					if (type === "gear") {
-						option.description = trimForSelectOptionDescription(buildGearDescription(name, false));
-					}
-					options.push(option)
+					options.push({
+						label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+						description: type,
+						value: `${name}${SAFE_DELIMITER}${options.length}`
+					});
 				}
 			}
 			const hasOptions = options.length > 0;

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -3,10 +3,8 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { getItem } = require("../items/_itemDictionary");
-const { trimForSelectOptionDescription, listifyEN } = require("../util/textUtil");
+const { listifyEN } = require("../util/textUtil");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
-const { injectApplicationEmojiName } = require("../util/graphicsUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Items?",
 	"@{adventure}",
@@ -14,8 +12,8 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
 		new ResourceTemplate("1", "internal", "roomAction"),
-		new ResourceTemplate("250*n", "always", "gold").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "item").setCostExpression("0")
+		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0"),
+		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
 	],
 	function (adventure) {
 		return {
@@ -27,18 +25,11 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
-					const option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-					if (name === "gold") {
-						option.label = `${count} Gold`;
-					} else {
-						option.label = `${name} x ${count}`;
-					}
-
-					if (type === "item") {
-						option.description = trimForSelectOptionDescription(injectApplicationEmojiName(getItem(name).description));
-					}
-					options.push(option)
+					options.push({
+						label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+						description: type,
+						value: `${name}${SAFE_DELIMITER}${options.length}`
+					});
 				}
 			}
 			const hasOptions = options.length > 0;

--- a/source/rooms/workshop-blackbox.js
+++ b/source/rooms/workshop-blackbox.js
@@ -8,7 +8,7 @@ module.exports = new RoomTemplate("Workshop with Black Box",
 	"In this workshop there's a black box with a gear-shaped keyhole on the front. You figure it's designed to trade a piece of your gear for a Rare piece of gear.",
 	[
 		new ResourceTemplate("n", "internal", "roomAction"),
-		new ResourceTemplate("1", "internal", "gear").setTier("Rare").setCostExpression("0")
+		new ResourceTemplate("1", "internal", "Gear").setTier("Rare").setCostExpression("0")
 	],
 	function (adventure) {
 		return {

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -89,7 +89,7 @@ function dealDamage(targets, assailant, damage, isUnblockable, element, adventur
 					results.push(`${target.name} takes ${pendingDamage} ${getEmoji(element)} damage${blockedDamage > 0 ? ` (${blockedDamage} was blocked)` : ""}${isWeakness ? "!!!" : isResistance ? "." : "!"}${downedCheck(target, adventure)}`);
 					if (pendingDamage > 0 && "Curse of Midas" in target.modifiers) {
 						const midasGold = Math.floor(pendingDamage / 10 * target.modifiers["Curse of Midas"]);
-						adventure.room.addResource("gold", "gold", "loot", midasGold);
+						adventure.room.addResource("Gold", "Currency", "loot", midasGold);
 						results.push(`${getApplicationEmojiMarkdown("Curse of Midas")}: Loot +${midasGold}g`)
 					}
 				} else {

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -3,10 +3,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, StringSelect
 const { Adventure } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { getArtifact } = require("../artifacts/_artifactDictionary");
-const { buildGearDescription } = require("../gear/_gearDictionary");
-
-const { ordinalSuffixEN, trimForSelectOptionDescription } = require("./textUtil");
+const { ordinalSuffixEN } = require("./textUtil");
 
 /** Remove components (buttons and selects) from a given message
  * @param {string} messageId - the id of the message to remove components from
@@ -78,20 +75,11 @@ function generateLootRow(adventure) {
 	for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 		if (visibility === "loot") {
 			if (count > 0) {
-				let option = { value: `${name}${SAFE_DELIMITER}${options.length}` };
-
-				if (name === "gold") {
-					option.label = `${count} Gold`;
-				} else {
-					option.label = `${name} x ${count}`;
-				}
-
-				if (type === "gear") {
-					option.description = trimForSelectOptionDescription(buildGearDescription(name, false));
-				} else if (type === "artifact") {
-					option.description = trimForSelectOptionDescription(getArtifact(name).dynamicDescription(count));
-				}
-				options.push(option)
+				options.push({
+					label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+					description: type,
+					value: `${name}${SAFE_DELIMITER}${options.length}`
+				});
 			}
 		}
 	}


### PR DESCRIPTION
Summary
-------
- use select option descriptions to label resource type for loot, treasure and merchants
- fix missing imports

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] viewed loot, treasure and merchant select generation

Issue
-----
Closes #419