### PR TITLE
#433: add more instructions to Room Actions field

### DIFF
--- a/source/buttons/blackbox.js
+++ b/source/buttons/blackbox.js
@@ -55,7 +55,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				}
 
 				const gearIndex = collectedInteraction.values[0];
-				const blackBoxResource = Object.values(adventure.room.resources).find(resource => resource.type === "gear");
+				const blackBoxResource = Object.values(adventure.room.resources).find(resource => resource.type === "Gear");
 				delete adventure.room.resources[blackBoxResource.name];
 				const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
 				const tradedGearName = delver.gear[gearIndex].name;

--- a/source/buttons/challenges.js
+++ b/source/buttons/challenges.js
@@ -35,7 +35,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const adventure = getAdventure(collectedInteraction.channelId);
 				const [_, startingDepth] = collectedInteraction.customId.split(SAFE_DELIMITER);
 				const challengeName = collectedInteraction.values[0];
-				if (startingDepth !== adventure?.depth.toString() || !adventure?.room.hasResource("roomAction")) {
+				if (startingDepth !== adventure?.depth.toString() || !adventure?.room.actions > 0) {
 					return;
 				}
 
@@ -47,7 +47,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				} else {
 					adventure.challenges[challengeName] = new Challenge(intensity, reward, duration);
 				}
-				adventure.room.decrementResource("roomAction", 1);
+				adventure.room.actions--;
 				adventure.room.history["New challenges"].push(challengeName);
 				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
 					roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));

--- a/source/buttons/gearcapup.js
+++ b/source/buttons/gearcapup.js
@@ -5,7 +5,7 @@ const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "gearcapup";
 module.exports = new ButtonWrapper(mainId, 3000,
-	/** Consumes a roomAction to raise Adventure's gear capacity */
+	/** Consumes a room action to raise Adventure's gear capacity */
 	(interaction, args) => {
 		const adventure = getAdventure(interaction.channelId);
 		if (!adventure?.delvers.some(delver => delver.id === interaction.user.id)) {
@@ -14,14 +14,14 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const actionCost = 1;
-		if (adventure.room.resources.roomAction.count < actionCost) {
+		if (adventure.room.actions < actionCost) {
 			interaction.reply({ content: "The workshop's supplies have been exhausted.", ephemeral: true });
 			return;
 		}
 
 		if (adventure.gearCapacity < MAX_MESSAGE_ACTION_ROWS) {
 			adventure.gearCapacity++;
-			adventure.room.decrementResource("roomAction", actionCost);
+			adventure.room.actions -= actionCost;
 			adventure.room.history["Cap boosters"].push(interaction.member.displayName);
 			setAdventure(adventure);
 			interaction.channel.send(`The party's gear capacity has been boosted to ${adventure.gearCapacity}.`);

--- a/source/buttons/pillagepedestals.js
+++ b/source/buttons/pillagepedestals.js
@@ -13,8 +13,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		if (adventure.room.hasResource("roomAction")) {
-			adventure.room.decrementResource("roomAction", "all");
+		if (adventure.room.actions > 0) {
+			adventure.room.actions = 0;
 			adventure.gainGold(350);
 			interaction.update(renderRoom(adventure, interaction.channel));
 			setAdventure(adventure);

--- a/source/buttons/repair.js
+++ b/source/buttons/repair.js
@@ -16,7 +16,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		if (!adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions < 1) {
 			interaction.reply({ content: "The workshop's supplies have been exhausted.", ephemeral: true });
 			return;
 		}
@@ -53,7 +53,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			collector.on("collect", collectedInteraction => {
 				const adventure = getAdventure(collectedInteraction.channelId);
 				const [_, startedDepth] = collectedInteraction.customId.split(SAFE_DELIMITER);
-				if (startedDepth !== adventure.depth.toString() || !adventure.room.hasResource("roomAction")) {
+				if (startedDepth !== adventure.depth.toString() || adventure.room.actions < 1) {
 					return;
 				}
 
@@ -61,7 +61,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const [gearName, index, value] = collectedInteraction.values[0].split(SAFE_DELIMITER);
 				delver.gear[Number(index)].durability += Number(value);
 				adventure.room.history.Repairers.push(delver.name);
-				adventure.room.decrementResource("roomAction", 1);
+				adventure.room.actions--;
 				setAdventure(adventure);
 				collectedInteraction.channel.send({ content: `**${collectedInteraction.member.displayName}** repaired ${value} durability on their ${gearName}.` });
 				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {

--- a/source/buttons/rest.js
+++ b/source/buttons/rest.js
@@ -15,12 +15,12 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const actionCost = 1;
-		if (!adventure.room.hasResource("roomAction", actionCost)) {
+		if (adventure.room.actions < actionCost) {
 			interaction.reply({ content: "No more actions can be taken in this room.", ephemeral: true });
 			return;
 		}
 
-		adventure.room.decrementResource("roomAction", actionCost);
+		adventure.room.actions -= actionCost;
 		adventure.room.history.Rested.push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
 			interaction.followUp(gainHealth(delver, Math.ceil(delver.getMaxHP() * (parseInt(healPercent) / 100.0)), adventure));

--- a/source/buttons/routevote.js
+++ b/source/buttons/routevote.js
@@ -56,7 +56,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						.setAuthor(embed.author)
 						.setTitle(embed.title)
 						.setDescription(embed.description)
-						.addFields(embed.fields.filter(field => !(["Room Actions", "Decide the next room"].includes(field.name))))
+						.addFields(embed.fields.filter(field => field.name !== "Decide the next room" && !field.name.startsWith("Room Actions")))
 						.setFooter(embed.footer)
 				})
 				interaction.message.edit({ embeds: updatedEmbeds, components: uiRows });

--- a/source/buttons/selltogearcollector.js
+++ b/source/buttons/selltogearcollector.js
@@ -43,11 +43,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					const [_, startedDepth] = collectedIntearction.customId.split(SAFE_DELIMITER);
 					const adventure = getAdventure(collectedIntearction.channelId);
 					const actionCost = 1;
-					if (startedDepth !== adventure.depth.toString() || !adventure.room.hasResource("roomAction", actionCost)) {
+					if (startedDepth !== adventure.depth.toString() || adventure.room.actions < actionCost) {
 						return;
 					}
 
-					adventure.room.decrementResource("roomAction", actionCost);
+					adventure.room.actions -= actionCost;
 					const [saleIndex] = collectedIntearction.values;
 					const delver = adventure.delvers.find(delver => delver.id === collectedIntearction.user.id);
 					const gearName = delver.gear[saleIndex].name;

--- a/source/buttons/tinker.js
+++ b/source/buttons/tinker.js
@@ -18,7 +18,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		if (adventure.room.resources.roomAction.count < 1) {
+		if (adventure.room.actions < 1) {
 			interaction.reply({ content: "The workshop's supplies have been exhausted.", ephemeral: true });
 			return;
 		}
@@ -55,7 +55,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			collector.on("collect", collectedInteraction => {
 				const [_, startedDepth] = collectedInteraction.customId.split(SAFE_DELIMITER);
 				const adventure = getAdventure(collectedInteraction.channelId);
-				if (!adventure.room.hasResource("roomAction") || startedDepth !== adventure.depth.toString()) {
+				if (adventure.room.actions < 1 || startedDepth !== adventure.depth.toString()) {
 					return;
 				}
 
@@ -67,7 +67,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const sidegradeName = sidegrades[adventure.generateRandomNumber(sidegrades.length, "general")];
 				transformGear(delver, index, gearName, sidegradeName);
 				adventure.room.history.Tinkerers.push(delver.name);
-				adventure.room.decrementResource("roomAction", 1);
+				adventure.room.actions--;
 				collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}**'s *${gearName}* has been tinkered to **${sidegradeName}**!`);
 				setAdventure(adventure);
 				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {

--- a/source/buttons/trainingdummy.js
+++ b/source/buttons/trainingdummy.js
@@ -15,13 +15,13 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const actionCost = 1;
-		if (!adventure.room.hasResource("roomAction", actionCost)) {
+		if (adventure.room.actions < actionCost) {
 			interaction.reply({ content: "You don't have time to use the training dummy.", ephemeral: true });
 			return;
 		}
 
 		levelUp(delver, 1, adventure);
-		adventure.room.decrementResource("roomAction", actionCost);
+		adventure.room.actions -= actionCost;
 		adventure.room.history.Trained.push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
 			interaction.followUp(`${delver.name} leveled up!`);

--- a/source/buttons/upgrade.js
+++ b/source/buttons/upgrade.js
@@ -18,7 +18,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		if (!adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions < 1) {
 			interaction.reply({ content: "The workshop's supplies have been exhausted.", ephemeral: true });
 			return;
 		}
@@ -55,7 +55,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			collector.on("collect", collectedInteraction => {
 				const adventure = getAdventure(collectedInteraction.channelId);
 				const [_, startingDepth] = collectedInteraction.customId.split(SAFE_DELIMITER);
-				if (!adventure?.room.hasResource("roomAction") || startingDepth !== adventure.depth.toString()) {
+				if (adventure.room.actions < 1 || startingDepth !== adventure.depth.toString()) {
 					return;
 				}
 
@@ -67,7 +67,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const upgradeName = upgradePool[adventure.generateRandomNumber(upgradePool.length, "general")];
 				transformGear(delver, index, gearName, upgradeName);
 				adventure.room.history.Upgraders.push(delver.name);
-				adventure.room.decrementResource("roomAction", 1);
+				adventure.room.actions--;
 				setAdventure(adventure);
 				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
 					return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -280,13 +280,11 @@ class Room {
 	/** This read-write instance class describes a room in an adventure
 	 * @param {string} titleInput
 	 * @param {CombatantElement} elementEnum
-	 * @param {Record<string, string[]>} initialHistoryMap
 	 * @param {[enemyName: string, countExpression: string][]} enemyList
 	 */
-	constructor(titleInput, elementEnum, initialHistoryMap, enemyList) {
+	constructor(titleInput, elementEnum, enemyList) {
 		this.title = titleInput;
 		this.element = elementEnum;
-		this.history = initialHistoryMap;
 		if (enemyList && enemyList.length > 0) {
 			this.round = -1;
 			this.moves = [];
@@ -302,7 +300,8 @@ class Room {
 	enemies = null;
 	/** @type {{[enemyName: string]: number} | null} */
 	enemyIdMap = null;
-	/** @type {Record<string, {name: string, type: "Gear" | "Artifact" | "Currency" | "scouting" | "roomAction" | "challenge" | "Item", visibility: "loot" | "always" | "internal", count: number, uiGroup?: string, cost?: number}>} */
+	actions = 0;
+	/** @type {Record<string, {name: string, type: "Gear" | "Artifact" | "Currency" | "challenge" | "Item", visibility: "loot" | "always" | "internal", count: number, uiGroup?: string, cost?: number}>} */
 	resources = {};
 	/** @type {Record<string, string[]>} */
 	history = {};
@@ -317,7 +316,7 @@ class Room {
 
 	/** Initializes a resource in the room's resources if it's not already present
 	 * @param {string} nameInput Note: all names in the combined pool of gear, artifacts, items, and resources must be unique
-	 * @param {"Gear" | "Artifact" | "Currency" | "scouting" | "roomAction" | "challenge" | "Item"} typeInput
+	 * @param {"Gear" | "Artifact" | "Currency" | "challenge" | "Item"} typeInput
 	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
 	 * @param {number} countInput
 	 * @param {string?} uiGroupInput

--- a/source/classes/RoomTemplate.js
+++ b/source/classes/RoomTemplate.js
@@ -6,27 +6,24 @@ class RoomTemplate {
 	/** This read-only data class defines stats for a room
 	 * @param {string} titleText room titles double as the id, so must be unique
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Untyped" | "@{adventure}" | "@{adventureOpposite}" | "@{adventureWeakness}"} elementEnum
-	 * @param {"Event" | "Battle" | "Merchant" | "Rest Site" | "Final Battle" | "Workshop" | "Artifact Guardian" | "Treasure" | "Empty"} primaryCategoryEnum
 	 * @param {string} descriptionInput
 	 * @param {ResourceTemplate[]} resourceArray
-	 * @param {(adventure: Adventure) => Record<string, string[]>} buildHistoryFunction
+	 * @param {(adventure: Adventure) => Record<string, string[]>} initializeFunction
 	 * @param {(roomEmbed: EmbedBuilder, adventure: Adventure) => {embeds: EmbedBuilder[], components: ActionRowBuilder[]}} buildRoomFunction
 	 */
-	constructor(titleText, elementEnum, primaryCategoryEnum, descriptionInput, resourceArray, buildHistoryFunction, buildRoomFunction) {
+	constructor(titleText, elementEnum, descriptionInput, resourceArray, initializeFunction, buildRoomFunction) {
 		if (!titleText) throw new BuildError("Falsy titleText");
 		if (!elementEnum) throw new BuildError("Falsy elementEnum");
-		if (!primaryCategoryEnum) throw new BuildError("Falsy primaryCategoryEnum");
 		if (!descriptionInput) throw new BuildError("Falsy descriptionInput");
 		if (!resourceArray) throw new BuildError("Falsy resourceArray");
-		if (!buildHistoryFunction) throw new BuildError("Falsy buildHistoryFunction");
+		if (!initializeFunction) throw new BuildError("Falsy buildHistoryFunction");
 		if (!buildRoomFunction) throw new BuildError("Falsy buildRoomFunction");
 
 		this.title = titleText;
 		this.element = elementEnum;
-		this.primaryCategory = primaryCategoryEnum;
 		this.description = descriptionInput;
 		this.resourceList = resourceArray;
-		this.buildHistory = buildHistoryFunction;
+		this.init = initializeFunction;
 		this.buildRoom = buildRoomFunction;
 	}
 	/** @type {[enemyName: string, countExpression: string][]} */
@@ -43,7 +40,7 @@ class ResourceTemplate {
 	/** This read-only data class that defines resources available for placement in rooms
 	 * @param {string} countExpression
 	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
-	 * @param {"Gear" | "Artifact" | "Currency" | "roomAction" | "challenge" | "Item" | string} typeInput categories (eg "item", "gear") are random rolls, specific names allowed
+	 * @param {"Gear" | "Artifact" | "Currency" | "challenge" | "Item" | string} typeInput categories (eg "Item", "Gear") are random rolls, specific names allowed
 	 */
 	constructor(countExpression, visibilityInput, typeInput) {
 		if (!countExpression) throw new BuildError("Falsy countExpression");

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -190,7 +190,8 @@ function nextRoom(roomType, thread) {
 
 	// Generate current room
 	const roomTemplate = rollRoom(roomType, adventure);
-	adventure.room = new Room(roomTemplate.title, roomTemplate.element, roomTemplate.buildHistory(adventure), roomTemplate.enemyList);
+	adventure.room = new Room(roomTemplate.title, roomTemplate.element, roomTemplate.enemyList);
+	roomTemplate.init(adventure);
 	if (adventure.room.element === "@{adventure}") {
 		adventure.room.element = adventure.element;
 	} else if (adventure.room.element === "@{adventureWeakness}") {
@@ -244,13 +245,7 @@ function nextRoom(roomType, thread) {
 				break;
 			}
 			default: {
-				let resourceCount = count;
-				const hammerCount = adventure.getArtifactCount("Best-in-Class Hammer");
-				if (roomTemplate.primaryCategory === "Workshop" && resourceType === "roomAction" && hammerCount > 0) {
-					resourceCount += hammerCount;
-					adventure.updateArtifactStat("Best-in-Class Hammer", "Extra Room Actions", hammerCount);
-				}
-				adventure.room.addResource(resourceType, resourceType, visibility, resourceCount, uiGroup);
+				adventure.room.addResource(resourceType, resourceType, visibility, count, uiGroup);
 			}
 		}
 	}

--- a/source/rooms/_room_blueprint.js
+++ b/source/rooms/_room_blueprint.js
@@ -4,12 +4,15 @@ const enemies = [["name", "countExpression"], ["name", "countExpression"]];
 
 module.exports = new RoomTemplate("name",
 	"element",
-	"primary category",
 	"description",
 	[
 		new ResourceTemplate("countExpression", "visibility", "type")
 	],
-	function (adventure) { return {}; },
+	function (adventure) {
+		adventure.room.actions = 0;
+
+		adventure.room.history = {};
+	},
 	function (roomEmbed, adventure) {
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],

--- a/source/rooms/artifactguardian-royalslime.js
+++ b/source/rooms/artifactguardian-royalslime.js
@@ -5,13 +5,12 @@ const enemies = [["Royal Slime", "0.5*n"]];
 
 module.exports = new RoomTemplate("A Slimy Throneroom",
 	"@{adventure}",
-	"Artifact Guardian",
 	"Off to the side of the room lays a knocked over thone and crown. As the party approaches it, slime gushes from the ceiling, engulfing the objects. The slime collects stands itself up into a teardrop shape, suspending the throne inside it and the crown atop it, then begins rolling in the direction of the party.",
 	[
 		new ResourceTemplate("3", "internal", "levelsGained"),
 		new ResourceTemplate("1", "loot", "Artifact"),
 		new ResourceTemplate(`${enemies[0][1]}*100`, "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/artifactguardian-treasureelemental.js
+++ b/source/rooms/artifactguardian-treasureelemental.js
@@ -5,13 +5,12 @@ const enemies = [["Treasure Elemental", "1"]];
 
 module.exports = new RoomTemplate("A windfall of treasure!",
 	"Earth",
-	"Artifact Guardian",
 	"Floor to ceiling, gold coins, gems and other valuables are stacked in massive piles. Out of the corner of your eyes, you notice a mass of treasure meld together...",
 	[
 		new ResourceTemplate("3", "internal", "levelsGained"),
 		new ResourceTemplate("1", "loot", "Artifact"),
 		new ResourceTemplate("75", "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder(["greed"])
 ).setEnemies(enemies);

--- a/source/rooms/battle-bloodtailhawks.js
+++ b/source/rooms/battle-bloodtailhawks.js
@@ -5,12 +5,11 @@ const enemies = [["Bloodtail Hawk", "1.5*n"]];
 
 module.exports = new RoomTemplate("Hawk Fight",
 	"Wind",
-	"Battle",
 	"A flock of birds of prey swoop down looking for a meal.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-frogranch.js
+++ b/source/rooms/battle-frogranch.js
@@ -5,12 +5,11 @@ const enemies = [["Mechabee Soldier", "1"], ["Fire-Arrow Frog", "0.5*n"], ["Mech
 
 module.exports = new RoomTemplate("Frog Ranch",
 	"Earth",
-	"Battle",
 	"Two Mechabee Soldiers are interrupted while escorting a set of domesticated Fire-Arrow Frogs to another pasture.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate(`${enemies[1][1]}*25+35`, "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-mechabees.js
+++ b/source/rooms/battle-mechabees.js
@@ -5,12 +5,11 @@ const enemies = [["Mechabee Drone", "n*0.25"], ["Mechabee Soldier", "1"], ["Mech
 
 module.exports = new RoomTemplate("Mechabee Fight",
 	"Earth",
-	"Battle",
 	"Some mechabees charge at you. In addition to starting a fight, it prompts you to wonder if mechabees are more mech or more bee.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("25*n+35", "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-meteorknight.js
+++ b/source/rooms/battle-meteorknight.js
@@ -5,12 +5,11 @@ const enemies = [["Earthly Knight", "0.5*n"], ["Meteor Knight", "1"], ["Asteroid
 
 module.exports = new RoomTemplate("Meteor Knight Fight",
 	"Fire",
-	"Battle",
 	"You are halted by a company of knights. By the time a Earthly Knight has advanced one step towards you, the Meteor Knight has recklessly charged across most of the gap!",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("45*n", "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-slimes.js
+++ b/source/rooms/battle-slimes.js
@@ -5,12 +5,11 @@ const enemies = [["@{adventure} Slime", "0.5*n"], ["@{adventureOpposite} Ooze", 
 
 module.exports = new RoomTemplate("Slime Fight",
 	"@{adventure}",
-	"Battle",
 	"Some slimes and oozes approach...",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("35*n", "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-tortoises.js
+++ b/source/rooms/battle-tortoises.js
@@ -5,12 +5,11 @@ const enemies = [["Geode Tortoise", "2"]];
 
 module.exports = new RoomTemplate("Tortoise Fight",
 	"Earth",
-	"Battle",
 	"The rocky terrain rises up to reveal a pair of shelled menaces.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate("40*n", "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-wildfirearrowfrogs.js
+++ b/source/rooms/battle-wildfirearrowfrogs.js
@@ -5,12 +5,11 @@ const enemies = [["Fire-Arrow Frog", "n"]];
 
 module.exports = new RoomTemplate("Wild Fire-Arrow Frogs",
 	"Fire",
-	"Battle",
 	"A blaze of orange and red in the muck outs itself as a warning sign to a blast of heated mud and venom.",
 	[
 		new ResourceTemplate("1", "internal", "levelsGained"),
 		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "Currency")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/empty.js
+++ b/source/rooms/empty.js
@@ -4,10 +4,9 @@ const { SAFE_DELIMITER } = require("../constants");
 
 module.exports = new RoomTemplate("Empty Room",
 	"Untyped",
-	"Empty",
 	"This room is empty. Lucky you?",
 	[],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	function (roomEmbed, adventure) {
 		return {
 			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],

--- a/source/rooms/event-applepiewishingwell.js
+++ b/source/rooms/event-applepiewishingwell.js
@@ -5,11 +5,10 @@ const { EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 module.exports = new RoomTemplate("Apple Pie Wishing Well",
 	"Light",
-	"Event",
 	"In the center of the room sits a wishing well with a glowing crystal core. Pinned to a post in front of the well are instructions indicating that tossing an item into the well will float it back as a delicious apple pie.",
 	[],
 	function (adventure) {
-		return {
+		adventure.room.history = {
 			"Items tossed": [],
 			"Core thief": []
 		};

--- a/source/rooms/event-artifactdupe.js
+++ b/source/rooms/event-artifactdupe.js
@@ -1,5 +1,5 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { getArtifact } = require("../artifacts/_artifactDictionary");
 const { trimForSelectOptionDescription } = require("../util/textUtil");
 const { EMPTY_SELECT_OPTION_SET } = require("../constants");
@@ -7,19 +7,18 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Twin Pedestals",
 	"@{adventure}",
-	"Event",
 	"There are two identical pedestals in this room. If you place an artifact on one, it'll duplicate onto the other.",
-	[
-		new ResourceTemplate("1", "internal", "roomAction")
-	],
+	[],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Duped artifact": []
 		};
 	},
 	function (roomEmbed, adventure) {
 		let duperLabel, duperOptions, isDuperDisabled, pillageLabel, pillageEmoji, isPillageDisabled;
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			duperOptions = Object.keys(adventure.artifacts).map(artifact => {
 				const count = adventure.getArtifactCount(artifact);
 				return {

--- a/source/rooms/event-door1ordoor2.js
+++ b/source/rooms/event-door1ordoor2.js
@@ -6,14 +6,13 @@ const { generateRoutingRow, partyStatsButton } = require("../util/messageCompone
 
 module.exports = new RoomTemplate("Door 1 or Door 2?",
 	"@{adventureOpposite}",
-	"Event",
 	"There are four doors in this room. Two of them are labelled with numbers \"Door 1\" and \"Door 2\" and have coin insert slots. The other two doors are the entrance and exit.",
 	[],
 	function (adventure) {
 		const ownedArtifacts = Object.keys(adventure.artifacts);
 		const door1Artifact = ownedArtifacts.length > 0 ? ownedArtifacts[adventure.generateRandomNumber(ownedArtifacts.length, "general")] : null;
 		const door2Artifact = rollArtifactWithExclusions(adventure, ownedArtifacts);
-		return {
+		adventure.room.history = {
 			"Artifacts": [door1Artifact, door2Artifact],
 			"Option Picked": []
 		};

--- a/source/rooms/event-freegoldonfire.js
+++ b/source/rooms/event-freegoldonfire.js
@@ -5,13 +5,12 @@ const { SAFE_DELIMITER } = require("../constants");
 
 module.exports = new RoomTemplate("Free Gold?",
 	"Fire",
-	"Event",
 	"A large pile of gold sits quietly in the middle of the room, seemingly alone.",
 	[
 		new ResourceTemplate("300", "internal", "Currency")
 	],
 	function (adventure) {
-		return {
+		adventure.room.history = {
 			"Burned": []
 		};
 	},

--- a/source/rooms/event-freerepairkit.js
+++ b/source/rooms/event-freerepairkit.js
@@ -4,13 +4,12 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Repair Kit, just hanging out",
 	"Earth",
-	"Event",
 	"There's a Repair Kit hanging in the middle of the room tied to the ceiling by a rope.",
 	[
 		new ResourceTemplate("1", "internal", "Repair Kit")
 	],
 	function (adventure) {
-		return {
+		adventure.room.history = {
 			"Upgrades": []
 		};
 	},

--- a/source/rooms/event-gearcollector.js
+++ b/source/rooms/event-gearcollector.js
@@ -1,18 +1,19 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 const { getNumberEmoji } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Gear Collector",
 	"@{adventure}",
-	"Event",
 	"The Gear Collector excitedly approaches you offering gold to help complete their collection.",
-	[
-		new ResourceTemplate("0.5*n", "internal", "roomAction")
-	],
-	function (adventure) { return {}; },
+	[],
+	function (adventure) {
+		adventure.room.actions = Math.ceil(adventure.delvers.length / 2);
+
+		adventure.room.history = {};
+	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			return {
 				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
 				components: [

--- a/source/rooms/event-impcontractfaire.js
+++ b/source/rooms/event-impcontractfaire.js
@@ -5,11 +5,10 @@ const { getEmoji } = require("../util/elementUtil");
 
 module.exports = new RoomTemplate("Imp Contract Faire",
 	"@{adventureWeakness}",
-	"Event",
 	"The next room contains several stalls with imps hawking suspicious contracts. One imp offers a lucrative opportunity (*given you allow your element to be changed to @{roomElement}). Another offers a sketcy procedure for improving party health.",
 	[],
 	function (adventure) {
-		return {
+		adventure.room.history = {
 			"HP Donor": []
 		};
 	},

--- a/source/rooms/event-scorebeggar.js
+++ b/source/rooms/event-scorebeggar.js
@@ -5,11 +5,12 @@ const { SAFE_DELIMITER } = require("../constants");
 
 module.exports = new RoomTemplate("The Score Beggar",
 	"Water",
-	"Event",
 	"In the center of the room sits a desolate beggar.\n\"Score... more score... I need it! I'll give you this.\"\nThe beggar motions to a flask of questionable liquid.",
 	[],
 	function (adventure) {
-		return { "Traded for Flask": [] }
+		adventure.room.history = {
+			"Traded for Flask": []
+		};
 	},
 	function (roomEmbed, adventure) {
 		const tradeButtons = new ActionRowBuilder();

--- a/source/rooms/finalbattle-elkemist.js
+++ b/source/rooms/finalbattle-elkemist.js
@@ -5,11 +5,10 @@ const enemies = [["Elkemist", "1"]];
 
 module.exports = new RoomTemplate("A Northern Laboratory",
 	"Water",
-	"Final Battle",
 	"Flasks, beakers, vials and a myriad unknown substances line the innumerable tables and shelves of this room. An elk wanders from table to whiteboard to shelf, muttering various alchemical formuae to itself and taking absolutely no notice of the party.",
 	[
 		new ResourceTemplate("5", "internal", "levelsGained")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-mechaqueenbee.js
+++ b/source/rooms/finalbattle-mechaqueenbee.js
@@ -5,11 +5,10 @@ const enemies = [["Mecha Queen: Mech Mode", "1"], ["Mechabee Drone", "n"]];
 
 module.exports = new RoomTemplate("The Hexagon: Mech Mode",
 	"Darkness",
-	"Final Battle",
 	"Myriad six-sided holograms flicker on as you enter the room displaying formations, statistics, and supply information. An alarm blares, and some mechabees (and their queen!) charge you. It dawns on you: they are in fact, more mech than bee.",
 	[
 		new ResourceTemplate("5", "internal", "levelsGained")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-mechaqueenmech.js
+++ b/source/rooms/finalbattle-mechaqueenmech.js
@@ -5,11 +5,10 @@ const enemies = [["Mecha Queen: Bee Mode", "1"], ["Mechabee Drone", "n"]];
 
 module.exports = new RoomTemplate("The Hexagon: Bee Mode",
 	"Earth",
-	"Final Battle",
 	"Myriad six-sided holograms flicker on as you enter the room displaying formations, statistics, and supply information. An alarm blares, and some mechabees (and their queen!) charge you. It dawns on you: they are in fact, more bee than mech.",
 	[
 		new ResourceTemplate("5", "internal", "levelsGained")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-mirrors.js
+++ b/source/rooms/finalbattle-mirrors.js
@@ -5,11 +5,10 @@ const enemies = [["@{clone}", "n"]];
 
 module.exports = new RoomTemplate("Hall of Mirrors",
 	"Untyped",
-	"Final Battle",
 	"A long hall of wavy mirrors sits silently between the party and the door... until a bunch of shadows step out of the mirror and attack the party!",
 	[
 		new ResourceTemplate("5", "internal", "levelsGained")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-starryknight.js
+++ b/source/rooms/finalbattle-starryknight.js
@@ -5,11 +5,10 @@ const enemies = [["Starry Knight", "1"]];
 
 module.exports = new RoomTemplate("Confronting the Top Celestial Knight",
 	"Light",
-	"Final Battle",
 	"Sitting by fireside, the Starry Knight looks up at the party, interrupted amidst perusing the memoirs of his own accolades. 'Oh, I didn't see you there! You're just in time to be added to the list of my glorious victories in combat!'",
 	[
 		new ResourceTemplate("5", "internal", "levelsGained")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	generateCombatRoomBuilder(["appease"])
 ).setEnemies(enemies);

--- a/source/rooms/merchant-gear.js
+++ b/source/rooms/merchant-gear.js
@@ -8,13 +8,12 @@ const uiGroups = [`gear${SAFE_DELIMITER}?`, `gear${SAFE_DELIMITER}Rare`];
 
 module.exports = new RoomTemplate("Gear Merchant",
 	"@{adventure}",
-	"Merchant",
 	"A masked figure sits in front of a rack of weapons and other gear. \"Care to trade?\"",
 	[
 		new ResourceTemplate("n+1", "always", "Gear").setTier("?").setUIGroup(uiGroups[0]),
 		new ResourceTemplate("2", "always", "Gear").setTier("Rare").setUIGroup(uiGroups[1])
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	function (roomEmbed, adventure) {
 		const mixedGearOptions = [];
 		const rareGearOptions = [];

--- a/source/rooms/merchant-gearbuying.js
+++ b/source/rooms/merchant-gearbuying.js
@@ -6,12 +6,11 @@ const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/mes
 
 module.exports = new RoomTemplate("Gear Buying Merchant",
 	"@{adventure}",
-	"Merchant",
 	"A masked figure sits in front of a half-full rack of weapons and other gear. \"Care to trade?\"",
 	[
 		new ResourceTemplate("n+1", "always", "Gear").setTier("?")
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	function (roomEmbed, adventure) {
 		const mixedGearOptions = [];
 

--- a/source/rooms/merchant-item.js
+++ b/source/rooms/merchant-item.js
@@ -9,13 +9,12 @@ const uiGroups = [`gear${SAFE_DELIMITER}?`, "item"];
 
 module.exports = new RoomTemplate("Item Merchant",
 	"@{adventure}",
-	"Merchant",
 	"A masked figure sits in front of a a line up of flasks and vials. \"Care to trade?\"",
 	[
-		new ResourceTemplate("n+1", "always", "gear").setTier("?").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("n+1", "always", "item").setUIGroup(uiGroups[1])
+		new ResourceTemplate("n+1", "always", "Gear").setTier("?").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("n+1", "always", "Item").setUIGroup(uiGroups[1])
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	function (roomEmbed, adventure) {
 		const gearOptions = [];
 		const itemOptions = [];

--- a/source/rooms/merchant-overpriced.js
+++ b/source/rooms/merchant-overpriced.js
@@ -8,13 +8,12 @@ const uiGroups = [`gear${SAFE_DELIMITER}?`, `gear${SAFE_DELIMITER}Rare`];
 
 module.exports = new RoomTemplate("Overpriced Merchant",
 	"@{adventure}",
-	"Merchant",
 	"A masked figure sits in front of a packed rack of weapons and other gear. \"Best selction around! Looking for something particular?\"",
 	[
-		new ResourceTemplate("2*n+2", "always", "gear").setTier("?").setCostExpression("1.5*n").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("4", "always", "gear").setTier("Rare").setCostExpression("1.5*n").setUIGroup(uiGroups[1])
+		new ResourceTemplate("2*n+2", "always", "Gear").setTier("?").setCostExpression("1.5*n").setUIGroup(uiGroups[0]),
+		new ResourceTemplate("4", "always", "Gear").setTier("Rare").setCostExpression("1.5*n").setUIGroup(uiGroups[1])
 	],
-	function (adventure) { return {}; },
+	function (adventure) { },
 	function (roomEmbed, adventure) {
 		const mixedGearOptions = [];
 		const rareGearOptions = [];

--- a/source/rooms/restsite-challenger.js
+++ b/source/rooms/restsite-challenger.js
@@ -5,14 +5,14 @@ const { generateRoutingRow, inspectSelfButton } = require("../util/messageCompon
 
 module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 	"@{adventure}",
-	"Rest Site",
 	"The room contains a campfire... and a mysterious challenger hanging out in the corner.",
 	[
-		new ResourceTemplate("n", "internal", "roomAction"),
 		new ResourceTemplate("2", "internal", "challenge")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = adventure.delvers.length;
+
+		adventure.room.history = {
 			"Rested": [],
 			"New challenges": []
 		};
@@ -20,7 +20,7 @@ module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 	function (roomEmbed, adventure) {
 		const healPercent = Math.trunc(30 * (1 - (adventure.getChallengeIntensity("Restless") / 100)));
 		let restEmoji, restLabel, challengeEmoji, challengeLabel;
-		const hasRoomActions = adventure.room.hasResource("roomAction");
+		const hasRoomActions = adventure.room.actions > 0;
 		if (hasRoomActions) {
 			restEmoji = "1️⃣";
 			restLabel = `Rest [+${healPercent}% HP]`;

--- a/source/rooms/restsite-trainingdummy.js
+++ b/source/rooms/restsite-trainingdummy.js
@@ -1,17 +1,16 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
 const { generateRoutingRow, inspectSelfButton } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Rest Site: Training Dummy",
 	"@{adventure}",
-	"Rest Site",
 	"The room contains a campfire and a training dummy.",
-	[
-		new ResourceTemplate("n", "internal", "roomAction")
-	],
+	[],
 	function (adventure) {
-		return {
+		adventure.room.actions = adventure.delvers.length;
+
+		adventure.room.history = {
 			"Rested": [],
 			"Trained": []
 		};
@@ -19,7 +18,7 @@ module.exports = new RoomTemplate("Rest Site: Training Dummy",
 	function (roomEmbed, adventure) {
 		const healPercent = Math.trunc(30 * (1 - (adventure.getChallengeIntensity("Restless") / 100)));
 		let restEmoji, restLabel, trainingEmoji, trainingLabel;
-		const hasRoomActions = adventure.room.hasResource("roomAction");
+		const hasRoomActions = adventure.room.actions > 0;
 		if (hasRoomActions) {
 			restEmoji = "1️⃣";
 			restLabel = `Rest [+${healPercent}% HP]`;

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -7,20 +7,20 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 	"@{adventure}",
-	"Treasure",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
-		new ResourceTemplate("1", "internal", "roomAction"),
 		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
 		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Treasure picked": []
 		};
 	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {

--- a/source/rooms/treasure-artifactvsgold.js
+++ b/source/rooms/treasure-artifactvsgold.js
@@ -8,20 +8,20 @@ const { listifyEN } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 	"@{adventure}",
-	"Treasure",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gold' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
-		new ResourceTemplate("1", "internal", "roomAction"),
 		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
 		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Treasure picked": []
 		};
 	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {

--- a/source/rooms/treasure-artifactvsitems.js
+++ b/source/rooms/treasure-artifactvsitems.js
@@ -8,20 +8,20 @@ const { listifyEN } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 	"@{adventure}",
-	"Treasure",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
-		new ResourceTemplate("1", "internal", "roomAction"),
 		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
 		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Treasure picked": []
 		};
 	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -8,20 +8,20 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gear or Items?",
 	"@{adventure}",
-	"Treasure",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gear' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
-		new ResourceTemplate("1", "internal", "roomAction"),
 		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0"),
 		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Treasure picked": []
 		};
 	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -8,20 +8,20 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 	"@{adventure}",
-	"Treasure",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
-		new ResourceTemplate("1", "internal", "roomAction"),
 		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0"),
 		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Treasure picked": []
 		};
 	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -8,20 +8,20 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Items?",
 	"@{adventure}",
-	"Treasure",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
 	[
-		new ResourceTemplate("1", "internal", "roomAction"),
 		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0"),
 		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		adventure.room.actions = 1;
+
+		adventure.room.history = {
 			"Treasure picked": []
 		};
 	},
 	function (roomEmbed, adventure) {
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			const options = [];
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {

--- a/source/rooms/workshop-blackbox.js
+++ b/source/rooms/workshop-blackbox.js
@@ -4,14 +4,20 @@ const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Workshop with Black Box",
 	"@{adventure}",
-	"Workshop",
 	"In this workshop there's a black box with a gear-shaped keyhole on the front. You figure it's designed to trade a piece of your gear for a Rare piece of gear.",
 	[
-		new ResourceTemplate("n", "internal", "roomAction"),
 		new ResourceTemplate("1", "internal", "Gear").setTier("Rare").setCostExpression("0")
 	],
 	function (adventure) {
-		return {
+		let pendingActions = adventure.delvers.length;
+		const hammerCount = adventure.getArtifactCount("Best-in-Class Hammer");
+		if (hammerCount > 0) {
+			pendingActions += hammerCount;
+			adventure.updateArtifactStat("Best-in-Class Hammer", "Extra Room Actions", hammerCount);
+		}
+		adventure.room.actions = pendingActions;
+
+		adventure.room.history = {
 			"Upgraders": [],
 			"Repairers": [],
 			"Traded for box": []
@@ -19,7 +25,7 @@ module.exports = new RoomTemplate("Workshop with Black Box",
 	},
 	function (roomEmbed, adventure) {
 		let upgradeEmoji, upgradeLabel, isUpgradeDisabled, repairEmoji, repairLabel, isRepairDisabled, boxEmoji, boxLabel, isBoxDisabled;
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			upgradeEmoji = "1️⃣";
 			upgradeLabel = "Consider gear upgrades";
 			isUpgradeDisabled = false;

--- a/source/rooms/workshop-gearcapup.js
+++ b/source/rooms/workshop-gearcapup.js
@@ -1,17 +1,22 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 const { MAX_MESSAGE_ACTION_ROWS } = require("../constants");
 
 module.exports = new RoomTemplate("Tanning Workshop",
 	"@{adventure}",
-	"Workshop",
 	"This workshop contains various leatherworking tools. You could make some bags, bandoliers, or holsters for the party to carry more gear.",
-	[
-		new ResourceTemplate("n", "internal", "roomAction")
-	],
+	[],
 	function (adventure) {
-		return {
+		let pendingActions = adventure.delvers.length;
+		const hammerCount = adventure.getArtifactCount("Best-in-Class Hammer");
+		if (hammerCount > 0) {
+			pendingActions += hammerCount;
+			adventure.updateArtifactStat("Best-in-Class Hammer", "Extra Room Actions", hammerCount);
+		}
+		adventure.room.actions = pendingActions;
+
+		adventure.room.history = {
 			"Upgraders": [],
 			"Repairers": [],
 			"Cap boosters": []
@@ -19,7 +24,7 @@ module.exports = new RoomTemplate("Tanning Workshop",
 	},
 	function (roomEmbed, adventure) {
 		let upgradeEmoji, upgradeLabel, isUpgradeDisabled, repairEmoji, repairLabel, isRepairDisabled, capUpEmoji, capUpLabel, isCapUpDisabled;
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			upgradeEmoji = "1️⃣";
 			upgradeLabel = "Consider gear upgrades";
 			isUpgradeDisabled = false;

--- a/source/rooms/workshop-tinker.js
+++ b/source/rooms/workshop-tinker.js
@@ -1,16 +1,21 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateRoutingRow } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Abandoned Forge",
 	"@{adventure}",
-	"Workshop",
 	"The forge in this room could be used to recast some of your upgraded gear to change it's form.",
-	[
-		new ResourceTemplate("n", "internal", "roomAction")
-	],
+	[],
 	function (adventure) {
-		return {
+		let pendingActions = adventure.delvers.length;
+		const hammerCount = adventure.getArtifactCount("Best-in-Class Hammer");
+		if (hammerCount > 0) {
+			pendingActions += hammerCount;
+			adventure.updateArtifactStat("Best-in-Class Hammer", "Extra Room Actions", hammerCount);
+		}
+		adventure.room.actions = pendingActions;
+
+		adventure.room.history = {
 			"Upgraders": [],
 			"Repairers": [],
 			"Tinkerers": []
@@ -18,7 +23,7 @@ module.exports = new RoomTemplate("Abandoned Forge",
 	},
 	function (roomEmbed, adventure) {
 		let upgradeEmoji, upgradeLabel, isUpgradeDisabled, repairEmoji, repairLabel, isRepairDisabled, tinkerEmoji, tinkerLabel, isTinkerDisabled;
-		if (adventure.room.hasResource("roomAction")) {
+		if (adventure.room.actions > 0) {
 			upgradeEmoji = "1️⃣";
 			upgradeLabel = "Consider gear upgrades";
 			isUpgradeDisabled = false;

--- a/source/selects/artifactdupe.js
+++ b/source/selects/artifactdupe.js
@@ -13,8 +13,8 @@ module.exports = new SelectWrapper(mainId, 3000,
 			return;
 		}
 
-		if (adventure.room.hasResource("roomAction")) {
-			adventure.room.decrementResource("roomAction", "all");
+		if (adventure.room.actions > 0) {
+			adventure.room.actions = 0;
 			const artifactName = interaction.values[0];
 			adventure.room.history["Duped artifact"].push(artifactName);
 			adventure.gainArtifact(artifactName, 1);

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -16,7 +16,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 			return;
 		}
 
-		if (!adventure.room.hasResource("roomAction", 1)) {
+		if (adventure.room.actions < 1) {
 			interaction.reply({ content: "There aren't any more treasure picks to use.", ephemeral: true });
 			return;
 		}
@@ -64,7 +64,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 								delver.hp = delver.getMaxHP();
 							}
 							collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
-								adventure.room.decrementResource("roomAction", 1);
+								adventure.room.actions--;
 								adventure.room.decrementResource(name, 1);
 								adventure.room.history["Treasure picked"].push(name);
 								return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
@@ -98,7 +98,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 				delete adventure.room.resources[name];
 				break;
 		}
-		adventure.room.decrementResource("roomAction", 1);
+		adventure.room.actions--;
 		adventure.room.history["Treasure picked"].push(name);
 		setAdventure(adventure);
 		interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -181,8 +181,8 @@ function renderRoom(adventure, thread, descriptionOverride) {
 				]
 			}
 		default:
-			if ("roomAction" in adventure.room.resources) {
-				roomEmbed.addFields({ name: "Room Actions", value: `${getNumberEmoji(adventure.room.resources.roomAction.count)} remaining` });
+			if (adventure.room.actions > 0) {
+				roomEmbed.addFields({ name: `Room Actions: ${getNumberEmoji(adventure.room.actions)}`, value: `The party can take ${adventure.room.actions} more actions in this room. Action costs will be noted with similar emoji on the UI component.` });
 			}
 
 			if (roomTemplate?.buildRoom) {


### PR DESCRIPTION
Summary
-------
- refactored room actions to be a number property on Adventure.room instead of a Resource
- RoomTemplate.init() (formerly RoomTemplate.buildHistory()) now sets room actions and assigns the history map to the adventure
- removed unused Resource type "scouting"
- removed now unused RoomTemplate property "primaryCategory"
- fixed vestigial cases of Resource.type being "gear"

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] received treasure in treasure room

Issue
-----
Closes #433