### PR TITLE
#416: add subcommand `/manual modifier-info`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,10 @@
 # Prophets of the Labyrinth Change Log
 ## Prophets of the Labyrinth v0.17.0:
+### Command Improvements
+- Added `/manual modifier-info`
 - Added context menu option to check a server member's PotL stats (Apps -> PotL Stats)
 - Renamed `/give-up` to `/adventure retreat`
+### Other Changes
 - New Challenge: Cursed Run - One of your starting gear pieces is randomly replaced with cursed gear
 - Fixed delvers being able to end up above max HP when acquiring Cursed Blade
 - Fixed Reckless Certain Victory not reporting its user paying HP

--- a/source/buttons/modifier.js
+++ b/source/buttons/modifier.js
@@ -1,10 +1,8 @@
 const { EmbedBuilder, Colors } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { getApplicationEmojiMarkdown } = require('../util/graphicsUtil');
 const { modifiersToString } = require('../util/combatantUtil');
-const { randomAuthorTip } = require('../util/embedUtil');
-const { isBuff, isDebuff, getModifierDescription } = require('../modifiers/_modifierDictionary');
+const { randomAuthorTip, generateModifierEmbed } = require('../util/embedUtil');
 
 const mainId = "modifier";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -18,25 +16,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		const delver = adventure.delvers.find(delver => delver.id === interaction.user.id);
 		if (modifierName !== "MORE") {
-			const buff = isBuff(modifierName);
-			const debuff = isDebuff(modifierName);
-			let styleColor;
-			if (buff) {
-				styleColor = Colors.Blurple;
-			} else if (debuff) {
-				styleColor = Colors.Red;
-			} else {
-				styleColor = Colors.LightGrey;
-			}
-			interaction.reply({
-				embeds: [
-					new EmbedBuilder().setColor(styleColor)
-						.setAuthor(randomAuthorTip())
-						.setTitle(`${modifierName} x ${delver.modifiers[modifierName]} ${getApplicationEmojiMarkdown(modifierName)}`)
-						.setDescription(getModifierDescription(modifierName, delver, adventure))
-						.addFields({ name: "Category", value: `${buff ? "Buff" : debuff ? "Debuff" : "Modifier"}` })
-				], ephemeral: true
-			});
+			interaction.reply({ embeds: [generateModifierEmbed(modifierName, delver.modifiers[modifierName], delver.getPoise(), adventure.getArtifactCount("Spiral Funnel"))], ephemeral: true });
 		} else {
 			interaction.reply({
 				embeds: [

--- a/source/commands/manual/index.js
+++ b/source/commands/manual/index.js
@@ -8,7 +8,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"enemyinfo.js",
 	"artifactinfo.js",
 	"gearinfo.js",
-	"iteminfo.js"
+	"iteminfo.js",
+	"modifierinfo.js"
 ]);
 module.exports = new CommandWrapper(mainId, "Get information about how to play or game entities", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	(interaction) => {

--- a/source/commands/manual/modifierinfo.js
+++ b/source/commands/manual/modifierinfo.js
@@ -1,0 +1,37 @@
+const { CommandInteraction, bold } = require("discord.js");
+const { generateModifierEmbed } = require("../../util/embedUtil");
+const { getModifierEmojiFileTuples } = require("../../modifiers/_modifierDictionary");
+
+const modifierNames = getModifierEmojiFileTuples().map(([name]) => name);
+
+/**
+ * @param {CommandInteraction} interaction
+ * @param {...unknown} args
+ */
+async function executeSubcommand(interaction, ...args) {
+	const modifierName = interaction.options.getString("modifier-name");
+	const nameInTitleCaps = modifierNames.find(name => name.toLowerCase() === modifierName.toLowerCase());
+	if (!nameInTitleCaps) {
+		interaction.reply({ content: `Stats on ${bold(modifierName)} could not be found. Check for typos!`, ephemeral: true });
+		return;
+	}
+
+	interaction.reply({ embeds: [generateModifierEmbed(nameInTitleCaps, 1, 6, 0)], ephemeral: true });
+};
+
+module.exports = {
+	data: {
+		name: "modifier-info",
+		description: "Look up details on an modifier",
+		optionsInput: [
+			{
+				type: "String",
+				name: "modifier-name",
+				description: "Provides information at 1 stack",
+				required: true,
+				autocomplete: modifierNames.map(name => ({ name, value: name }))
+			}
+		]
+	},
+	executeSubcommand
+};

--- a/source/modifiers/_modifierDictionary.js
+++ b/source/modifiers/_modifierDictionary.js
@@ -1,4 +1,4 @@
-const { Adventure, ModifierTemplate, BuildError, Combatant } = require("../classes");
+const { ModifierTemplate, BuildError } = require("../classes");
 const { sanitizeEmojiName } = require("../util/graphicsUtil");
 const { calculateTagContent } = require("../util/textUtil");
 
@@ -65,14 +65,15 @@ function getModifierEmojiFileTuples() {
 
 /**
  * @param {string} modifierName
- * @param {Combatant} bearer
- * @param {Adventure} adventure
+ * @param {number} stackCount
+ * @param {number} bearerPoise
+ * @param {number} funnelCount
  */
-function getModifierDescription(modifierName, bearer, adventure) {
+function getModifierDescription(modifierName, stackCount, bearerPoise, funnelCount) {
 	return calculateTagContent(MODIFIERS[modifierName].description, [
-		{ tag: 'stackCount', count: bearer.modifiers[modifierName] },
-		{ tag: 'poise', count: bearer.getPoise() },
-		{ tag: 'funnelCount', count: adventure.getArtifactCount("Spiral Funnel") },
+		{ tag: 'stackCount', count: stackCount },
+		{ tag: 'poise', count: bearerPoise },
+		{ tag: 'funnelCount', count: funnelCount },
 		{ tag: 'roundDecrement', count: getTurnDecrement(modifierName) }
 	]);
 }

--- a/source/modifiers/quicken.js
+++ b/source/modifiers/quicken.js
@@ -2,7 +2,7 @@ const { ModifierTemplate } = require("../classes");
 
 module.exports = new ModifierTemplate("Quicken",
 	"Increase move speed by @{stackCount*5} for @{stackCount} rounds.",
-	false,
 	true,
+	false,
 	0
 ).setInverse("Slow");

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -383,7 +383,7 @@ function addProtection(combatants, value) {
 function modifiersToString(combatant, adventure) {
 	let modifiersText = "";
 	for (const modifier in combatant.modifiers) {
-		modifiersText += `*${modifier} x ${combatant.modifiers[modifier]}* - ${getModifierDescription(modifier, combatant, adventure)}\n`;
+		modifiersText += `*${modifier} x ${combatant.modifiers[modifier]}* - ${getModifierDescription(modifier, combatant.modifiers[modifier], combatant.getPoise(), adventure.getArtifactCount("Spiral Funnel"))}\n`;
 	}
 	return modifiersText;
 }

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -6,7 +6,7 @@ const { DISCORD_ICON_URL, POTL_ICON_URL, SAFE_DELIMITER, MAX_BUTTONS_PER_ROW, MA
 
 const { getChallenge, getStartingChallenges } = require("../challenges/_challengeDictionary");
 const { getGearProperty, buildGearDescription } = require("../gear/_gearDictionary");
-const { isBuff, isDebuff } = require("../modifiers/_modifierDictionary");
+const { isBuff, isDebuff, getModifierDescription } = require("../modifiers/_modifierDictionary");
 const { getRoom } = require("../rooms/_roomDictionary");
 
 const { getEmoji, getColor } = require("./elementUtil");
@@ -531,6 +531,24 @@ function generateStatsEmbed(user, guildId) {
 		)
 }
 
+function generateModifierEmbed(modifierName, count, bearerPoise, funnelCount) {
+	const buff = isBuff(modifierName);
+	const debuff = isDebuff(modifierName);
+	let styleColor;
+	if (buff) {
+		styleColor = Colors.Blurple;
+	} else if (debuff) {
+		styleColor = Colors.Red;
+	} else {
+		styleColor = Colors.LightGrey;
+	}
+	return new EmbedBuilder().setColor(styleColor)
+		.setAuthor(randomAuthorTip())
+		.setTitle(`${modifierName} x ${count} ${getApplicationEmojiMarkdown(modifierName)}`)
+		.setDescription(getModifierDescription(modifierName, count, bearerPoise, funnelCount))
+		.addFields({ name: "Category", value: `${buff ? "Buff" : debuff ? "Debuff" : "State"}` })
+}
+
 module.exports = {
 	randomAuthorTip,
 	randomFooterTip,
@@ -544,5 +562,6 @@ module.exports = {
 	gearToEmbedField,
 	inspectSelfPayload,
 	generatePartyStatsPayload,
-	generateStatsEmbed
+	generateStatsEmbed,
+	generateModifierEmbed
 };


### PR DESCRIPTION
Summary
-------
- add subcommand `/manual modifier-info`
- fixed Quicken being categorized as a debuff

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] /manual modifier-info provides information about 1 stack of the provided modifier
- [x] modifier button still works post refactor

Issue
-----
Closes #416