### PR TITLE
#421: UI updates (Workshops especially)

### DIFF
--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -22,6 +22,7 @@ for (const file of [
 	"inspectself.js",
 	"join.js",
 	"modifier.js",
+	"modify.js",
 	"partystats.js",
 	"pillagepedestals.js",
 	"ready.js",
@@ -35,7 +36,6 @@ for (const file of [
 	"selltogearcollector.js",
 	"startingartifacts.js",
 	"stealwishingwellcore.js",
-	"tinker.js",
 	"trainingdummy.js",
 	"upgrade.js"
 ]) {

--- a/source/buttons/blackbox.js
+++ b/source/buttons/blackbox.js
@@ -1,9 +1,10 @@
-const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder, Colors } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants');
 const { buildGearRecord } = require('../gear/_gearDictionary');
-const { renderRoom } = require('../util/embedUtil');
+const { renderRoom, randomAuthorTip } = require('../util/embedUtil');
+const { getNumberEmoji } = require('../util/textUtil');
 
 const mainId = "blackbox";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -27,11 +28,15 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		interaction.reply({
-			content: "You can trade a piece of gear the mysterious Rare gear in the black box.",
+			embeds: [
+				new EmbedBuilder().setAuthor(randomAuthorTip())
+					.setTitle("Opening the Black Box")
+					.setDescription("The black box has a gear-shaped keyhole on the front and shaking the box makes the sound of Rare gear tumbling about inside. You could trade a piece of gear for the Rare gear in the black box, but there's no way to know what you'll get...")
+			],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${adventure.depth}`)
-						.setPlaceholder("Pick a piece of gear to trade...")
+						.setPlaceholder(`${getNumberEmoji(0)} Trade a gear piece...`)
 						.setOptions(delver.gear.map((gear, index) => ({
 							label: gear.name,
 							value: index.toString()

--- a/source/buttons/modify.js
+++ b/source/buttons/modify.js
@@ -1,15 +1,15 @@
-const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder, Colors, underline } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
-const { getGearProperty } = require('../gear/_gearDictionary');
+const { getGearProperty, buildGearDescription } = require('../gear/_gearDictionary');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants');
-const { trimForSelectOptionDescription, listifyEN } = require('../util/textUtil');
+const { trimForSelectOptionDescription, listifyEN, getNumberEmoji } = require('../util/textUtil');
 const { transformGear } = require('../util/delverUtil');
-const { renderRoom } = require('../util/embedUtil');
+const { renderRoom, randomAuthorTip } = require('../util/embedUtil');
 
-const mainId = "tinker";
+const mainId = "modify";
 module.exports = new ButtonWrapper(mainId, 3000,
-	/** Present the user with an opportunity to tinker with a piece of gear */
+	/** Present the user with an opportunity to modify a piece of gear */
 	(interaction, args) => {
 		const adventure = getAdventure(interaction.channelId);
 		const delver = adventure?.delvers.find(delver => delver.id === interaction.user.id);
@@ -18,33 +18,47 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		if (adventure.room.actions < 1) {
+		const actionCost = 1;
+		if (adventure.room.actions < actionCost) {
 			interaction.reply({ content: "The workshop's supplies have been exhausted.", ephemeral: true });
 			return;
 		}
 
+		const sidegradesPreviews = [];
 		const options = [];
 		delver.gear.forEach((gear, index) => {
 			const sidegrades = getGearProperty(gear.name, "sidegrades");
 			if (sidegrades.length > 0) {
+				sidegradesPreviews.push({
+					name: gear.name,
+					value: sidegrades.map(sidegrade => {
+						const description = buildGearDescription(sidegrade, false, delver);
+						return `- ${underline(sidegrade)} ${description}`;
+					}).join("\n")
+				});
 				options.push({
 					label: gear.name,
-					description: trimForSelectOptionDescription(`Possibilities: ${listifyEN(sidegrades, true)}`),
 					value: index.toString()
 				})
 			}
 		})
 		if (options.length < 1) {
-			interaction.reply({ content: "You don't have any gear that can be tinkered with.", ephemeral: true });
+			interaction.reply({ content: "You don't have any upgraded gear that can be tinkered with.", ephemeral: true });
 			return;
 		}
 
 		interaction.reply({
-			content: "You can use 1 room action to change a piece of gear to a different upgrade.",
+			embeds: [
+				new EmbedBuilder().setColor(Colors.DarkAqua)
+					.setAuthor(randomAuthorTip())
+					.setTitle("Modifying Gear")
+					.setDescription("The piece of gear you pick will be changed to a different upgrade. Here are the possible modifications:")
+					.addFields(sidegradesPreviews)
+			],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${adventure.depth}`)
-						.setPlaceholder("Pick a piece of gear to randomly tinker with...")
+						.setPlaceholder(`${getNumberEmoji(actionCost)} Modify a gear piece...`)
 						.setOptions(options)
 				)
 			],
@@ -67,7 +81,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const sidegradeName = sidegrades[adventure.generateRandomNumber(sidegrades.length, "general")];
 				transformGear(delver, index, gearName, sidegradeName);
 				adventure.room.history.Tinkerers.push(delver.name);
-				adventure.room.actions--;
+				adventure.room.actions -= actionCost;
 				collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}**'s *${gearName}* has been tinkered to **${sidegradeName}**!`);
 				setAdventure(adventure);
 				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {

--- a/source/buttons/repair.js
+++ b/source/buttons/repair.js
@@ -1,9 +1,10 @@
-const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder, Colors, underline } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require('../constants');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { getGearProperty } = require('../gear/_gearDictionary');
-const { renderRoom } = require('../util/embedUtil');
+const { renderRoom, randomAuthorTip } = require('../util/embedUtil');
+const { getNumberEmoji } = require('../util/textUtil');
 
 const mainId = "repair";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -16,19 +17,21 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		if (adventure.room.actions < 1) {
+		const actionCost = 1;
+		if (adventure.room.actions < actionCost) {
 			interaction.reply({ content: "The workshop's supplies have been exhausted.", ephemeral: true });
 			return;
 		}
 
+		let description = "The piece of gear you pick will regain half its max durability. Here is the state of your gear:";
 		const options = [];
 		delver.gear.forEach((gear, index) => {
 			const maxDurability = getGearProperty(gear.name, "maxDurability");
 			if (maxDurability > 0 && gear.durability < maxDurability) {
 				const value = Math.min(Math.ceil(maxDurability / 2), maxDurability - gear.durability);
+				description += `\n${underline(gear.name)} Will regain ${value} durability (${gear.durability}/${maxDurability})`
 				options.push({
 					label: gear.name,
-					description: `Regain ${value} uses`,
 					value: `${gear.name}${SAFE_DELIMITER}${index}${SAFE_DELIMITER}${value}`
 				})
 			}
@@ -40,10 +43,15 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		interaction.reply({
-			content: "You can use 1 room action to repair a piece of gear. That piece of gear will regain half its max durability.",
+			embeds: [
+				new EmbedBuilder().setColor(Colors.LightGrey)
+					.setAuthor(randomAuthorTip())
+					.setTitle("Repairing Gear")
+					.setDescription(description)
+			],
 			components: [new ActionRowBuilder().addComponents(
 				new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${adventure.depth}`)
-					.setPlaceholder("Pick a piece of gear to repair...")
+					.setPlaceholder(`${getNumberEmoji(actionCost)} Repair a gear piece...`)
 					.setOptions(options)
 			)],
 			ephemeral: true,
@@ -61,7 +69,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const [gearName, index, value] = collectedInteraction.values[0].split(SAFE_DELIMITER);
 				delver.gear[Number(index)].durability += Number(value);
 				adventure.room.history.Repairers.push(delver.name);
-				adventure.room.actions--;
+				adventure.room.actions -= actionCost;
 				setAdventure(adventure);
 				collectedInteraction.channel.send({ content: `**${collectedInteraction.member.displayName}** repaired ${value} durability on their ${gearName}.` });
 				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {

--- a/source/buttons/routevote.js
+++ b/source/buttons/routevote.js
@@ -2,6 +2,7 @@ const { ActionRowBuilder, ButtonBuilder, ComponentType, StringSelectMenuBuilder,
 const { ButtonWrapper } = require('../classes');
 const { SAFE_DELIMITER, ZERO_WIDTH_WHITESPACE } = require('../constants');
 const { getAdventure, endRoom } = require('../orcustrators/adventureOrcustrator');
+const { pathVoteField } = require('../util/messageComponentUtil');
 
 const mainId = "routevote";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -56,7 +57,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						.setAuthor(embed.author)
 						.setTitle(embed.title)
 						.setDescription(embed.description)
-						.addFields(embed.fields.filter(field => field.name !== "Decide the next room" && !field.name.startsWith("Room Actions")))
+						.addFields(embed.fields.filter(field => field.name !== pathVoteField.name && !field.name.startsWith("Room Actions")))
 						.setFooter(embed.footer)
 				})
 				interaction.message.edit({ embeds: updatedEmbeds, components: uiRows });

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -313,20 +313,18 @@ function buildGearDescription(gearName, buildFullDescription, holder) {
 		}
 	}
 
-	return injectGearStats(text, gearName, buildFullDescription, gearName === "Iron Fist Punch" ? holder.element : null);
+	return injectGearStats(text, gearName, gearName === "Iron Fist Punch" ? holder.element : null);
 }
 
 /**
  * @param {string} text
  * @param {string} gearName
- * @param {boolean} markdownAllowed
  * @param {string | null} elementOverride
  */
-function injectGearStats(text, gearName, markdownAllowed, elementOverride) {
+function injectGearStats(text, gearName, elementOverride) {
 	getGearProperty(gearName, "modifiers")?.forEach((modifier, index) => {
 		if (!modifier.name.startsWith("unparsed")) {
-			const replacement = markdownAllowed ? getApplicationEmojiMarkdown(modifier.name) : modifier.name;
-			text = text.replace(new RegExp(`@{mod${index}}`, "g"), replacement);
+			text = text.replace(new RegExp(`@{mod${index}}`, "g"), getApplicationEmojiMarkdown(modifier.name));
 		}
 		text = text.replace(new RegExp(`@{mod${index}Stacks}`, "g"), modifier.stacks);
 	})

--- a/source/gear/bloodaegis-charging.js
+++ b/source/gear/bloodaegis-charging.js
@@ -3,7 +3,7 @@ const { addModifier, payHP, changeStagger, addProtection, generateModifierResult
 
 module.exports = new GearTemplate("Charging Blood Aegis",
 	[
-		["use", "Pay @{hpCost} HP; gain @{protection} protection, @{mod0Stacks} @{mod0}, intercept a later single target move"],
+		["use", "Pay @{hpCost} HP; gain @{protection} protection and @{mod0Stacks} @{mod0}, then intercept a later single target move"],
 		["Critical💥", "Protection x@{critMultiplier}"]
 	],
 	"Pact",

--- a/source/rooms/_roomDictionary.js
+++ b/source/rooms/_roomDictionary.js
@@ -41,7 +41,7 @@ for (const file of [
 	"treasure-goldvsitems.js",
 	"workshop-blackbox.js",
 	"workshop-gearcapup.js",
-	"workshop-tinker.js"
+	"workshop-modify.js"
 ]) {
 	/** @type {RoomTemplate} */
 	const room = require(`./${file}`);

--- a/source/rooms/_room_blueprint.js
+++ b/source/rooms/_room_blueprint.js
@@ -1,4 +1,5 @@
 const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { pathVoteField } = require("../util/messageComponentUtil");
 
 const enemies = [["name", "countExpression"], ["name", "countExpression"]];
 
@@ -15,7 +16,7 @@ module.exports = new RoomTemplate("name",
 	},
 	function (roomEmbed, adventure) {
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId(`routevote${SAFE_DELIMITER}Battle${SAFE_DELIMITER}${adventure.depth}`)

--- a/source/rooms/empty.js
+++ b/source/rooms/empty.js
@@ -1,6 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
+const { pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Empty Room",
 	"Untyped",
@@ -9,7 +10,7 @@ module.exports = new RoomTemplate("Empty Room",
 	function (adventure) { },
 	function (roomEmbed, adventure) {
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId(`routevote${SAFE_DELIMITER}Battle${SAFE_DELIMITER}${adventure.depth}`)

--- a/source/rooms/event-applepiewishingwell.js
+++ b/source/rooms/event-applepiewishingwell.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 module.exports = new RoomTemplate("Apple Pie Wishing Well",
@@ -43,7 +43,7 @@ module.exports = new RoomTemplate("Apple Pie Wishing Well",
 			isStealDisabled = true;
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId("applepiewishingwell")

--- a/source/rooms/event-artifactdupe.js
+++ b/source/rooms/event-artifactdupe.js
@@ -3,7 +3,7 @@ const { RoomTemplate } = require("../classes");
 const { getArtifact } = require("../artifacts/_artifactDictionary");
 const { trimForSelectOptionDescription } = require("../util/textUtil");
 const { EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Twin Pedestals",
 	"@{adventure}",
@@ -55,7 +55,7 @@ module.exports = new RoomTemplate("Twin Pedestals",
 			}
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId("artifactdupe")

--- a/source/rooms/event-door1ordoor2.js
+++ b/source/rooms/event-door1ordoor2.js
@@ -2,7 +2,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, italic } = require("discor
 const { RoomTemplate } = require("../classes");
 const { rollArtifactWithExclusions } = require("../artifacts/_artifactDictionary");
 const { SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow, partyStatsButton } = require("../util/messageComponentUtil");
+const { generateRoutingRow, partyStatsButton, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Door 1 or Door 2?",
 	"@{adventureOpposite}",
@@ -44,7 +44,7 @@ module.exports = new RoomTemplate("Door 1 or Door 2?",
 			door2Emoji = "✔️";
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId(`eventartifact${SAFE_DELIMITER}0${SAFE_DELIMITER}${door1Cost}`)

--- a/source/rooms/event-freegoldonfire.js
+++ b/source/rooms/event-freegoldonfire.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { SAFE_DELIMITER } = require("../constants");
 
 module.exports = new RoomTemplate("Free Gold?",
@@ -30,7 +30,7 @@ module.exports = new RoomTemplate("Free Gold?",
 			isGetDisabled = true;
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId(`getgoldonfire${SAFE_DELIMITER}${burnDamage}`)

--- a/source/rooms/event-freerepairkit.js
+++ b/source/rooms/event-freerepairkit.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Repair Kit, just hanging out",
 	"Earth",
@@ -36,7 +36,7 @@ module.exports = new RoomTemplate("Repair Kit, just hanging out",
 			}
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("freerepairkit")

--- a/source/rooms/event-gearcollector.js
+++ b/source/rooms/event-gearcollector.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { getNumberEmoji } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Gear Collector",
@@ -15,7 +15,7 @@ module.exports = new RoomTemplate("Gear Collector",
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new ButtonBuilder().setCustomId("selltogearcollector")
@@ -28,7 +28,7 @@ module.exports = new RoomTemplate("Gear Collector",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new ButtonBuilder().setCustomId("viewgearcollector")

--- a/source/rooms/event-impcontractfaire.js
+++ b/source/rooms/event-impcontractfaire.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { getEmoji } = require("../util/elementUtil");
 
 module.exports = new RoomTemplate("Imp Contract Faire",
@@ -32,7 +32,7 @@ module.exports = new RoomTemplate("Imp Contract Faire",
 			isShareDisabled = true;
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("elementresearch")

--- a/source/rooms/event-scorebeggar.js
+++ b/source/rooms/event-scorebeggar.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { SAFE_DELIMITER } = require("../constants");
 
 module.exports = new RoomTemplate("The Score Beggar",
@@ -63,7 +63,7 @@ module.exports = new RoomTemplate("The Score Beggar",
 			}
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [tradeButtons, generateRoutingRow(adventure)]
 		};
 	}

--- a/source/rooms/merchant-gear.js
+++ b/source/rooms/merchant-gear.js
@@ -2,7 +2,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { getGearProperty } = require("../gear/_gearDictionary");
-const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateMerchantScoutingRow, generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 const uiGroups = [`gear${SAFE_DELIMITER}?`, `gear${SAFE_DELIMITER}Rare`];
 
@@ -44,7 +44,7 @@ module.exports = new RoomTemplate("Gear Merchant",
 		const hasMixedGearOptions = mixedGearOptions.length > 0;
 		const hasRareGearOptions = rareGearOptions.length > 0;
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[0]}`)

--- a/source/rooms/merchant-gearbuying.js
+++ b/source/rooms/merchant-gearbuying.js
@@ -2,7 +2,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } 
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { getGearProperty } = require("../gear/_gearDictionary");
-const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateMerchantScoutingRow, generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Gear Buying Merchant",
 	"@{adventure}",
@@ -29,7 +29,7 @@ module.exports = new RoomTemplate("Gear Buying Merchant",
 
 		const hasMixedGearOptions = mixedGearOptions.length > 0;
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId("buygear")

--- a/source/rooms/merchant-item.js
+++ b/source/rooms/merchant-item.js
@@ -3,7 +3,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { getGearProperty } = require("../gear/_gearDictionary");
 const { getItem } = require("../items/_itemDictionary");
-const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateMerchantScoutingRow, generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 const uiGroups = [`gear${SAFE_DELIMITER}?`, "item"];
 
@@ -49,7 +49,7 @@ module.exports = new RoomTemplate("Item Merchant",
 		const hasGearOptions = gearOptions.length > 0;
 		const hasItemOptions = itemOptions.length > 0;
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[0]}`)

--- a/source/rooms/merchant-overpriced.js
+++ b/source/rooms/merchant-overpriced.js
@@ -2,7 +2,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { getGearProperty } = require("../gear/_gearDictionary");
-const { generateMerchantScoutingRow, generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateMerchantScoutingRow, generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 const uiGroups = [`gear${SAFE_DELIMITER}?`, `gear${SAFE_DELIMITER}Rare`];
 
@@ -44,7 +44,7 @@ module.exports = new RoomTemplate("Overpriced Merchant",
 		const hasMixedGearOptions = mixedGearOptions.length > 0;
 		const hasRareGearOptions = rareGearOptions.length > 0;
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`buy${uiGroups[0]}`)

--- a/source/rooms/restsite-challenger.js
+++ b/source/rooms/restsite-challenger.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow, inspectSelfButton } = require("../util/messageComponentUtil");
+const { generateRoutingRow, inspectSelfButton, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 	"@{adventure}",
@@ -47,7 +47,7 @@ module.exports = new RoomTemplate("Rest Site: Mysterious Challenger",
 			}
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					inspectSelfButton,

--- a/source/rooms/restsite-trainingdummy.js
+++ b/source/rooms/restsite-trainingdummy.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow, inspectSelfButton } = require("../util/messageComponentUtil");
+const { generateRoutingRow, inspectSelfButton, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Rest Site: Training Dummy",
 	"@{adventure}",
@@ -41,7 +41,7 @@ module.exports = new RoomTemplate("Rest Site: Training Dummy",
 			}
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					inspectSelfButton,

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -3,7 +3,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { listifyEN } = require("../util/textUtil");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 	"@{adventure}",
@@ -33,7 +33,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 			}
 			const hasOptions = options.length > 0;
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")
@@ -46,7 +46,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")

--- a/source/rooms/treasure-artifactvsgold.js
+++ b/source/rooms/treasure-artifactvsgold.js
@@ -3,7 +3,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { listifyEN } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
@@ -34,7 +34,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 			}
 			const hasOptions = options.length > 0;
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")
@@ -47,7 +47,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")

--- a/source/rooms/treasure-artifactvsitems.js
+++ b/source/rooms/treasure-artifactvsitems.js
@@ -3,7 +3,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 const { EMPTY_SELECT_OPTION_SET, SAFE_DELIMITER } = require("../constants");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { listifyEN } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Items?",
@@ -34,7 +34,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 			}
 			const hasOptions = options.length > 0;
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")
@@ -47,7 +47,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -4,7 +4,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { listifyEN } = require("../util/textUtil");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gear or Items?",
 	"@{adventure}",
@@ -34,7 +34,7 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 			}
 			const hasOptions = options.length > 0;
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")
@@ -47,7 +47,7 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -4,7 +4,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { listifyEN } = require("../util/textUtil");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 	"@{adventure}",
@@ -34,7 +34,7 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 			}
 			const hasOptions = options.length > 0;
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")
@@ -47,7 +47,7 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -4,7 +4,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { listifyEN } = require("../util/textUtil");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Items?",
 	"@{adventure}",
@@ -34,7 +34,7 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 			}
 			const hasOptions = options.length > 0;
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")
@@ -47,7 +47,7 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 			};
 		} else {
 			return {
-				embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
 					new ActionRowBuilder().addComponents(
 						new StringSelectMenuBuilder().setCustomId("treasure")

--- a/source/rooms/workshop-blackbox.js
+++ b/source/rooms/workshop-blackbox.js
@@ -1,10 +1,10 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Workshop with Black Box",
 	"@{adventure}",
-	"In this workshop there's a black box with a gear-shaped keyhole on the front. You figure it's designed to trade a piece of your gear for a Rare piece of gear.",
+	"This is a normal, fully-stocked workshop... with a mysterious black box off to the side.",
 	[
 		new ResourceTemplate("1", "internal", "Gear").setTier("Rare").setCostExpression("0")
 	],
@@ -24,50 +24,44 @@ module.exports = new RoomTemplate("Workshop with Black Box",
 		};
 	},
 	function (roomEmbed, adventure) {
-		let upgradeEmoji, upgradeLabel, isUpgradeDisabled, repairEmoji, repairLabel, isRepairDisabled, boxEmoji, boxLabel, isBoxDisabled;
+		let upgradeEmoji, isUpgradeDisabled, repairEmoji, isRepairDisabled, boxEmoji, isBoxDisabled;
 		if (adventure.room.actions > 0) {
-			upgradeEmoji = "1️⃣";
-			upgradeLabel = "Consider gear upgrades";
+			upgradeEmoji = "⬆️";
 			isUpgradeDisabled = false;
-			repairEmoji = "1️⃣";
-			repairLabel = "Plan gear repairs";
+			repairEmoji = "🛠️";
 			isRepairDisabled = false;
 		} else {
 			upgradeEmoji = adventure.room.history.Upgraders.length > 0 ? "✔️" : "✖️";
-			upgradeLabel = "Out of supplies";
 			isUpgradeDisabled = true;
 			repairEmoji = adventure.room.history.Repairers.length > 0 ? "✔️" : "✖️";
-			repairLabel = "Out of supplies";
 			isRepairDisabled = true;
 		}
 
 		if (adventure.room.history["Traded for box"].length < 1) {
-			boxEmoji = "0️⃣";
-			boxLabel = "Open the black box";
+			boxEmoji = "◼";
 			isBoxDisabled = false;
 		} else {
 			boxEmoji = "✔️";
-			boxLabel = `${adventure.room.history["Traded for box"][0]} traded`;
 			isBoxDisabled = true;
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("upgrade")
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(upgradeEmoji)
-						.setLabel(upgradeLabel)
+						.setLabel("Upgrade gear")
 						.setDisabled(isUpgradeDisabled),
 					new ButtonBuilder().setCustomId("repair")
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(repairEmoji)
-						.setLabel(repairLabel)
+						.setLabel("Repair gear")
 						.setDisabled(isRepairDisabled),
 					new ButtonBuilder().setCustomId("blackbox")
 						.setStyle(ButtonStyle.Success)
 						.setEmoji(boxEmoji)
-						.setLabel(boxLabel)
+						.setLabel("A black box?")
 						.setDisabled(isBoxDisabled)
 				),
 				generateRoutingRow(adventure)

--- a/source/rooms/workshop-gearcapup.js
+++ b/source/rooms/workshop-gearcapup.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { MAX_MESSAGE_ACTION_ROWS } = require("../constants");
 
 module.exports = new RoomTemplate("Tanning Workshop",
@@ -23,13 +23,11 @@ module.exports = new RoomTemplate("Tanning Workshop",
 		};
 	},
 	function (roomEmbed, adventure) {
-		let upgradeEmoji, upgradeLabel, isUpgradeDisabled, repairEmoji, repairLabel, isRepairDisabled, capUpEmoji, capUpLabel, isCapUpDisabled;
+		let upgradeEmoji, isUpgradeDisabled, repairEmoji, isRepairDisabled, capUpEmoji, capUpLabel, isCapUpDisabled;
 		if (adventure.room.actions > 0) {
-			upgradeEmoji = "1️⃣";
-			upgradeLabel = "Consider gear upgrades";
+			upgradeEmoji = "⬆️";
 			isUpgradeDisabled = false;
-			repairEmoji = "1️⃣";
-			repairLabel = "Plan gear repairs";
+			repairEmoji = "🛠️";
 			isRepairDisabled = false;
 			if (adventure.gearCapacity < MAX_MESSAGE_ACTION_ROWS) {
 				capUpEmoji = "1️⃣";
@@ -42,28 +40,30 @@ module.exports = new RoomTemplate("Tanning Workshop",
 			}
 		} else {
 			upgradeEmoji = adventure.room.history.Upgraders.length > 0 ? "✔️" : "✖️";
-			upgradeLabel = "Out of supplies";
 			isUpgradeDisabled = true;
 			repairEmoji = adventure.room.history.Repairers.length > 0 ? "✔️" : "✖️";
-			repairLabel = "Out of supplies";
 			isRepairDisabled = true;
 			capUpEmoji = adventure.room.history["Cap boosters"].length > 0 ? "✔️" : "✖️";
-			capUpLabel = "Out of supplies";
+			if (adventure.gearCapacity < MAX_MESSAGE_ACTION_ROWS) {
+				capUpLabel = "Increase party Gear Capacity";
+			} else {
+				capUpLabel = "Max Gear Capacity";
+			}
 			isCapUpDisabled = true;
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("upgrade")
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(upgradeEmoji)
-						.setLabel(upgradeLabel)
+						.setLabel("Upgrade gear")
 						.setDisabled(isUpgradeDisabled),
 					new ButtonBuilder().setCustomId("repair")
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(repairEmoji)
-						.setLabel(repairLabel)
+						.setLabel("Repair gear")
 						.setDisabled(isRepairDisabled),
 					new ButtonBuilder().setCustomId("gearcapup")
 						.setStyle(ButtonStyle.Success)

--- a/source/rooms/workshop-modify.js
+++ b/source/rooms/workshop-modify.js
@@ -1,10 +1,10 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
-const { generateRoutingRow } = require("../util/messageComponentUtil");
+const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Abandoned Forge",
 	"@{adventure}",
-	"The forge in this room could be used to recast some of your upgraded gear to change it's form.",
+	"The forge in this room could be used to modify some of your upgraded gear to change its form.",
 	[],
 	function (adventure) {
 		let pendingActions = adventure.delvers.length;
@@ -22,46 +22,40 @@ module.exports = new RoomTemplate("Abandoned Forge",
 		};
 	},
 	function (roomEmbed, adventure) {
-		let upgradeEmoji, upgradeLabel, isUpgradeDisabled, repairEmoji, repairLabel, isRepairDisabled, tinkerEmoji, tinkerLabel, isTinkerDisabled;
+		let upgradeEmoji, isUpgradeDisabled, repairEmoji, isRepairDisabled, tinkerEmoji, isTinkerDisabled;
 		if (adventure.room.actions > 0) {
-			upgradeEmoji = "1️⃣";
-			upgradeLabel = "Consider gear upgrades";
+			upgradeEmoji = "⬆️";
 			isUpgradeDisabled = false;
-			repairEmoji = "1️⃣";
-			repairLabel = "Plan gear repairs";
+			repairEmoji = "🛠️";
 			isRepairDisabled = false;
-			tinkerEmoji = "1️⃣";
-			tinkerLabel = "Tinker with your gear";
+			tinkerEmoji = "↔️";
 			isTinkerDisabled = false;
 		} else {
 			upgradeEmoji = adventure.room.history.Upgraders.length > 0 ? "✔️" : "✖️";
-			upgradeLabel = "Out of supplies";
 			isUpgradeDisabled = true;
 			repairEmoji = adventure.room.history.Repairers.length > 0 ? "✔️" : "✖️";
-			repairLabel = "Out of supplies";
 			isRepairDisabled = true;
 			tinkerEmoji = adventure.room.history.Tinkerers.length > 0 ? "✔️" : "✖️";
-			tinkerLabel = "Out of supplies";
 			isTinkerDisabled = true;
 		}
 		return {
-			embeds: [roomEmbed.addFields({ name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." })],
+			embeds: [roomEmbed.addFields(pathVoteField)],
 			components: [
 				new ActionRowBuilder().addComponents(
 					new ButtonBuilder().setCustomId("upgrade")
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(upgradeEmoji)
-						.setLabel(upgradeLabel)
+						.setLabel("Upgrade gear")
 						.setDisabled(isUpgradeDisabled),
 					new ButtonBuilder().setCustomId("repair")
 						.setStyle(ButtonStyle.Primary)
 						.setEmoji(repairEmoji)
-						.setLabel(repairLabel)
+						.setLabel("Repair gear")
 						.setDisabled(isRepairDisabled),
-					new ButtonBuilder().setCustomId("tinker")
+					new ButtonBuilder().setCustomId("modify")
 						.setStyle(ButtonStyle.Success)
 						.setEmoji(tinkerEmoji)
-						.setLabel(tinkerLabel)
+						.setLabel("Modify gear")
 						.setDisabled(isTinkerDisabled)
 				),
 				generateRoutingRow(adventure)

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -60,7 +60,7 @@ function generateCombatRoomBuilder(extraButtons) {
 		} else {
 			roomEmbed.setTitle(`${adventure.room.title} - Victory!`);
 
-			roomEmbed.addFields({ name: "Level-Up!", value: `Everyone gains ${adventure.room.resources.levelsGained.count ?? 0} levels.` }, { name: "Decide the next room", value: "Each delver can pick or change their pick for the next room. The party will move on when the decision is unanimous." });
+			roomEmbed.addFields({ name: "Level-Up!", value: `Everyone gains ${adventure.room.resources.levelsGained.count ?? 0} levels.` }, pathVoteField);
 			return {
 				embeds: [roomEmbed],
 				components: [generateLootRow(adventure), generateRoutingRow(adventure)]
@@ -104,7 +104,7 @@ function generateRoutingRow(adventure) {
 		...Object.keys(adventure.roomCandidates).map((candidateTag, index) => {
 			const [roomType, depth] = candidateTag.split(SAFE_DELIMITER);
 			return new ButtonBuilder().setCustomId(`routevote${SAFE_DELIMITER}${candidateTag}`)
-				.setLabel(`Next room: ${adventure.roomCandidates[candidateTag].isHidden ? `Unknown ${index + 1}` : roomType}`)
+				.setLabel(`Path Vote: ${adventure.roomCandidates[candidateTag].isHidden ? `Unknown ${index + 1}` : roomType}`)
 				.setStyle(ButtonStyle.Secondary)
 		}));
 }
@@ -137,6 +137,7 @@ module.exports = {
 		.setStyle(ButtonStyle.Secondary),
 	generateCombatRoomBuilder,
 	generateLootRow,
+	pathVoteField: { name: "Path Vote", value: "Each delver must vote for the next room (changes allowed). The party will move on when the decision is unanimous." },
 	generateRoutingRow,
 	generateMerchantScoutingRow
 };


### PR DESCRIPTION
Summary
-------
- move action cost emoji to final selection points
- add more instructions and list out untrimmed descriptions for upgrade/sidegrade results
- Remove "Out of Supplies" state for buttons in favor or retaining label of what button did
- rename "tinker with" to "modify"
- grammar fixes in Charging Blood Aegis description
- Update "Decide the next room" instructions to "Room Vote", consolidate usages to imported constant

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] viewed each workshop and interactions

Issue
-----
Closes #421