### PR TITLE
#423: fix Lance descriptions not accounting for Impactful damage

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 - Fixed Reckless Certain Victory not reporting its user paying HP
 - Fixed the party stats embed not showing the Final Battle after it had been scouted
 - Fixed Curse of Midas reporting generating fractional gold, not scaling with stacks, and being added to party gold immediately instead of being added to loot
+- Fixed Lance descriptions not accounting for double Power Up contribution
 ## Prophets of the Labyrinth v0.16.0:
 ### Archetypes
 - Changed Detective to Untyped

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -307,9 +307,11 @@ function buildGearDescription(gearName, buildFullDescription, holder) {
 			if (gearName === "Iron Fist Punch") {
 				damage += 45 * holder.getModifierStacks("Iron Fist Stance");
 			}
-			text = text.replace(/@{damage}/g, Math.floor(Math.min(damage, holder.getDamageCap())));
+			text = text.replace(/@{damage}/g, Math.floor(Math.min(damage, holder.getDamageCap())))
+				.replace(/@{impactfulDamage}/g, Math.floor(Math.min(damage + holder.getModifierStacks("Power Up"), holder.getDamageCap())));
 		} else {
-			text = text.replace(/@{damage}/g, `(${damage} + power)`);
+			text = text.replace(/@{damage}/g, `(${damage} + power)`)
+				.replace(/@{impactfulDamage}/g, `(${damage} + power + Power Up)`);
 		}
 	}
 

--- a/source/gear/lance-accelerating.js
+++ b/source/gear/lance-accelerating.js
@@ -3,7 +3,7 @@ const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = 
 
 module.exports = new GearTemplate("Accelerating Lance",
 	[
-		["use", "Strike a foe for @{damage} @{element} damage (double increase from @{mod1}), then gain @{mod0Stacks} @{mod0}"],
+		["use", "Strike a foe for @{impactfulDamage} @{element} damage (double increase from @{mod1}), then gain @{mod0Stacks} @{mod0}"],
 		["Critical💥", "Damage x@{critMultiplier}"]
 	],
 	"Weapon",

--- a/source/gear/lance-base.js
+++ b/source/gear/lance-base.js
@@ -3,7 +3,7 @@ const { dealDamage, changeStagger } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Lance",
 	[
-		["use", "Strike a foe for @{damage} @{element} damage (double increase from @{mod0})"],
+		["use", "Strike a foe for @{impactfulDamage} @{element} damage (double increase from @{mod0})"],
 		["Critical💥", "Damage x@{critMultiplier}"]
 	],
 	"Weapon",

--- a/source/gear/lance-shattering.js
+++ b/source/gear/lance-shattering.js
@@ -3,7 +3,7 @@ const { dealDamage, addModifier, changeStagger, generateModifierResultLines } = 
 
 module.exports = new GearTemplate("Shattering Lance",
 	[
-		["use", "Apply @{mod0Stacks} @{mod0} and @{damage} @{element} damage (double increase from @{mod1}) to a foe"],
+		["use", "Apply @{mod0Stacks} @{mod0} and @{impactfulDamage} @{element} damage (double increase from @{mod1}) to a foe"],
 		["Critical💥", "Damage x@{critMultiplier}"]
 	],
 	"Weapon",

--- a/source/gear/lance-unstoppable.js
+++ b/source/gear/lance-unstoppable.js
@@ -3,7 +3,7 @@ const { dealDamage, changeStagger } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Unstoppable Lance",
 	[
-		["use", "Strike a foe for @{damage} @{element} unblockable damage (double increase from @{mod0}), even while Stunned"],
+		["use", "Strike a foe for @{impactfulDamage} @{element} unblockable damage (double increase from @{mod0}), even while Stunned"],
 		["Critical💥", "Damage x@{critMultiplier}"]
 	],
 	"Weapon",

--- a/wiki/Element-Themes.md
+++ b/wiki/Element-Themes.md
@@ -39,6 +39,7 @@ Archetypes: Knight, Detective
 - Charging
 - Guarding
 - Hunter's
+- Impactful
 - Organic
 - Staggering
 

--- a/wiki/Gear-Variants.md
+++ b/wiki/Gear-Variants.md
@@ -207,6 +207,12 @@ Gain Power Up on kill
 - Morning Star (Light)
 - Power from Wrath (Darkness)
 
+### Impactful
+Double benefits from Power Up
+
+**Available on**
+- all Lances (Earth)
+
 ### Lethal
 Increased crit damage
 
@@ -486,7 +492,6 @@ Increases stats gained by level up
 ## Unnamed Variants
 - Adds Floating Mist Stance to user (all Floating Mist Stances)
 - Adds Iron Fist Stance to user (all Iron Fist Stances)
-- Double benefits from Power Up (all Lances)
 - Adds Power Up to target (all Inspiration)
 - Also hits targets with Exposed (all War Cries)
 - Adds Power Up to random ally if hitting weakness (all Pistols)


### PR DESCRIPTION
Summary
-------
- fix Lance descriptions not accounting for Impactful damage

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] viewed descriptions in Inspect Self payload and old merchant descriptions

Issue
-----
Closes #423