### PR TITLE
#401: filter out dead targets from "all" targeting on readymove instead of using needsLivingTargets flag on all moves

### DIFF
--- a/source/buttons/readymove.js
+++ b/source/buttons/readymove.js
@@ -120,7 +120,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 							targetText = "all enemies";
 						}
 						for (let i = 0; i < targetCount; i++) {
-							newMove.addTarget(new CombatantReference(team === "ally" ? "delver" : "enemy", i));
+							if (adventure.room.enemies[i].hp > 0) {
+								newMove.addTarget(new CombatantReference(team === "ally" ? "delver" : "enemy", i));
+							}
 						}
 					} else if (type.startsWith("random")) {
 						const targetCount = Number(type.split(SAFE_DELIMITER)[1]) + adventure.getArtifactCount("Loaded Dice");

--- a/source/classes/EnemyTemplate.js
+++ b/source/classes/EnemyTemplate.js
@@ -67,7 +67,6 @@ class EnemyTemplate {
 	 * @param {number} actionsInput.priority
 	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => string[]} actionsInput.effect
 	 * @param {(self: Combatant, adventure: Adventure) => CombatantReference[]} actionsInput.selector
-	 * @param {boolean} actionsInput.needsLivingTargets Only enemies stay at 0 hp without game over, so only true if it can target an enemy
 	 * @param {string} actionsInput.next
 	 * @param {?string} actionsInput.combatFlavor
 	 * @param {Record<string,number|Record<string,number>>} actionsInput.rnConfig

--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -25,7 +25,7 @@ class GearTemplate {
 		this.cost = costInput;
 		this.effect = effectInput;
 	}
-	/** @type {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none", needsLivingTargets: boolean}} */
+	/** @type {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} */
 	targetingTags;
 	maxDurability = 0;
 	/** @type {string[]} */
@@ -59,7 +59,7 @@ class GearTemplate {
 	/** @type  {Record<string, number>} */
 	rnConfig;
 
-	/** @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none", needsLivingTargets: boolean}} tagObject */
+	/** @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} tagObject */
 	setTargetingTags(tagObject) {
 		this.targetingTags = tagObject;
 		return this;

--- a/source/classes/ItemTemplate.js
+++ b/source/classes/ItemTemplate.js
@@ -10,13 +10,12 @@ class ItemTemplate {
 	 * @param {(self, adventure: Adventure) => CombatantReference[]} selectTargetsFunction
 	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => string[]} effectFunction
 	 */
-	constructor(nameInput, descriptionInput, elementLabel, costInput, selectTargetsFunction, needsLivingTargetsInput, effectFunction) {
+	constructor(nameInput, descriptionInput, elementLabel, costInput, selectTargetsFunction, effectFunction) {
 		this.name = nameInput;
 		this.description = descriptionInput;
 		this.element = elementLabel;
 		this.cost = costInput;
 		this.selectTargets = selectTargetsFunction;
-		this.needsLivingTargets = needsLivingTargetsInput;
 		this.effect = effectFunction;
 	}
 	/** @type {import("discord.js").EmbedField} */

--- a/source/enemies/_enemy_blueprint.js
+++ b/source/enemies/_enemy_blueprint.js
@@ -19,7 +19,6 @@ module.exports = new EnemyTemplate("name",
 	selector: (self, adventure) => { // check shared/actionComponents for reusable selctors and next functions
 		return [];
 	},
-	needsLivingTargets: false,
 	next: "",
 	combatFlavor: "(should mostly be omitted except for boss actions)"
 });

--- a/source/enemies/asteroid.js
+++ b/source/enemies/asteroid.js
@@ -26,7 +26,6 @@ module.exports = new EnemyTemplate("Asteroid",
 		return dealDamage(targets, user, damage, false, user.element, adventure).concat(dealDamage([user], user, recoilDmg, true, "Untyped", adventure));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "random"
 }).addAction({
 	name: "Bolide Burst",
@@ -43,6 +42,5 @@ module.exports = new EnemyTemplate("Asteroid",
 		return [...dealDamage(targets, user, damage, false, user.element, adventure), `${user.name} is downed.`];
 	},
 	selector: selectAllOtherCombatants,
-	needsLivingTargets: true,
 	next: "random"
 });

--- a/source/enemies/bloodtailhawk.js
+++ b/source/enemies/bloodtailhawk.js
@@ -25,6 +25,5 @@ module.exports = new EnemyTemplate("Bloodtail Hawk",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Rake"
 });

--- a/source/enemies/earthlyknight.js
+++ b/source/enemies/earthlyknight.js
@@ -39,7 +39,6 @@ module.exports = new EnemyTemplate("Earthly Knight",
 		return resultLines;
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "random",
 	rnConfig: { "buffs": 1 }
 }).addAction({
@@ -56,7 +55,6 @@ module.exports = new EnemyTemplate("Earthly Knight",
 		return [...dealDamage(targets, user, damage, false, user.element, adventure), joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered.")];
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: true,
 	next: "random"
 }).addAction({
 	name: "Call Asteroid",
@@ -68,6 +66,5 @@ module.exports = new EnemyTemplate("Earthly Knight",
 		return ["An Asteroid arrives on the battlefield."];
 	},
 	selector: selectNone,
-	needsLivingTargets: false,
 	next: "Tremor Smash"
 });

--- a/source/enemies/elkemist.js
+++ b/source/enemies/elkemist.js
@@ -34,7 +34,6 @@ module.exports = new EnemyTemplate("Elkemist",
 		return resultLines;
 	},
 	selector: selectSelf,
-	needsLivingTargets: false,
 	next: "random",
 	combatFlavor: "It gathers some materials to fortify its lab.",
 	rnConfig: { "debuffs": 1, "progress": { base: 30, crit: 15, random: 15 } }
@@ -55,7 +54,6 @@ module.exports = new EnemyTemplate("Elkemist",
 		return resultLines;
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random",
 	combatFlavor: "An obstacle to potion progress is identified and mitigated!",
 	rnConfig: { "progress": { base: 30, crit: 15, random: 15 } }
@@ -72,7 +70,6 @@ module.exports = new EnemyTemplate("Elkemist",
 		return dealDamage(targets, user, damage, false, "Fire", adventure);
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "random",
 }).addAction({
 	name: "Bubble",
@@ -109,7 +106,6 @@ module.exports = new EnemyTemplate("Elkemist",
 		return resultLines;
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "random",
 	rnConfig: { "progress": { base: 0, crit: 15, random: 15 } }
 }).setFlavorText({ name: "Progress", value: `Each time the Elkemist reaches 100 @e{Progress}, it'll gain a large amount of @e{Power Up}. Stun the Elkemist to reduce its @e{Progress}.` });

--- a/source/enemies/firearrowfrog.js
+++ b/source/enemies/firearrowfrog.js
@@ -22,7 +22,6 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 		return resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 6 : 3 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random"
 }).addAction({
 	name: "Burrow",
@@ -38,7 +37,6 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 		return generateModifierResultLines(addModifier([user], { name: "Evade", stacks }));
 	},
 	selector: selectSelf,
-	needsLivingTargets: false,
 	next: "Venom Cannon"
 }).addAction({
 	name: "Goop Spray",
@@ -52,6 +50,5 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: user.crit ? 3 : 2 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Venom Cannon"
 });

--- a/source/enemies/geodetortoise.js
+++ b/source/enemies/geodetortoise.js
@@ -26,7 +26,6 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random"
 }).addAction({
 	name: "Crystallize",
@@ -45,6 +44,5 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 		return [`${user.name} gains protection${addedPowerUp ? ` and ${getApplicationEmojiMarkdown("Power Up")}` : ` but was oblivious to ${getApplicationEmojiMarkdown("Power Up")}`}.`];
 	},
 	selector: selectSelf,
-	needsLivingTargets: false,
 	next: "random"
 });

--- a/source/enemies/mechabeedrone.js
+++ b/source/enemies/mechabeedrone.js
@@ -23,7 +23,6 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 		return dealDamage(targets, user, damage, false, user.element, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Barrel Roll"
 }).addAction({
 	name: "Barrel Roll",
@@ -39,7 +38,6 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	},
 	selector: selectSelf,
-	needsLivingTargets: false,
 	next: "Call for Help"
 }).addAction({
 	name: "Call for Help",
@@ -51,7 +49,6 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 		return ["Another mechabee arrives."];
 	},
 	selector: selectNone,
-	needsLivingTargets: false,
 	next: "Self-Destruct"
 }).addAction({
 	name: "Self-Destruct",
@@ -69,6 +66,5 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "Sting"
 });

--- a/source/enemies/mechabeesoldier.js
+++ b/source/enemies/mechabeesoldier.js
@@ -22,7 +22,6 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		return dealDamage(targets, user, damage, false, user.element, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Neurotoxin Strike"
 }).addAction({
 	name: "Barrel Roll",
@@ -38,7 +37,6 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	},
 	selector: selectSelf,
-	needsLivingTargets: false,
 	next: "Sting"
 }).addAction({
 	name: "Neurotoxin Strike",
@@ -51,7 +49,6 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		return dealDamage(targets, user, damage, false, user.element, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Paralysis", stacks: user.crit ? 5 : 3 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "Self-Destruct"
 }).addAction({
 	name: "Self-Destruct",
@@ -69,6 +66,5 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "Barrel Roll"
 });

--- a/source/enemies/mechaqueenbee.js
+++ b/source/enemies/mechaqueenbee.js
@@ -30,7 +30,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		return [`${user.name} gains protection.`];
 	},
 	selector: selectNone,
-	needsLivingTargets: false,
 	next: "V.E.N.O.Missile",
 	combatFlavor: "The Queen demands reinforcements!"
 }).addAction({
@@ -51,7 +50,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		return [`${user.name} gains protection.`];
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "V.E.N.O.Missile",
 	combatFlavor: "The Queen orders a full-on attack!"
 }).addAction({
@@ -66,7 +64,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	},
 	selector: selectAllAllies,
-	needsLivingTargets: false,
 	next: "V.E.N.O.Missile",
 	combatFlavor: "The Queen personally optimizes the flight formation."
 }).addAction({
@@ -84,7 +81,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		return [`${user.name} gains protection.`];
 	},
 	selector: selectRandomOtherAlly,
-	needsLivingTargets: true,
 	next: "V.E.N.O.Missile",
 	combatFlavor: "The Queen employs desperate measures!"
 }).addAction({
@@ -97,7 +93,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		return ["Another mechabee arrives."];
 	},
 	selector: selectNone,
-	needsLivingTargets: false,
 	next: "a random protocol"
 }).addAction({
 	name: "V.E.N.O.Missile",
@@ -109,6 +104,5 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		return generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 5 : 3 }));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Deploy Drone"
 });

--- a/source/enemies/mechaqueenmech.js
+++ b/source/enemies/mechaqueenmech.js
@@ -30,7 +30,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		return [`${user.name} gains protection.`];
 	},
 	selector: selectNone,
-	needsLivingTargets: false,
 	next: "Laser Array",
 	combatFlavor: "The Queen demands reinforcements!"
 }).addAction({
@@ -45,7 +44,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	},
 	selector: selectAllAllies,
-	needsLivingTargets: false,
 	next: "Laser Array",
 	combatFlavor: "The Queen personally optimizes the flight formation."
 }).addAction({
@@ -66,7 +64,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		return [`${user.name} gains protection.`];
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Laser Array",
 	combatFlavor: "The Queen orders a full-on attack!"
 }).addAction({
@@ -84,7 +81,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		return [`${user.name} gains protection.`];
 	},
 	selector: selectRandomOtherAlly,
-	needsLivingTargets: true,
 	next: "Laser Array",
 	combatFlavor: "The Queen employs desperate measures!"
 }).addAction({
@@ -97,7 +93,6 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		return ["Another mechabee arrives."];
 	},
 	selector: selectNone,
-	needsLivingTargets: false,
 	next: "a random protocol"
 }).addAction({
 	name: "Laser Array",
@@ -113,6 +108,5 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		return dealDamage(targets, user, pendingDamage, false, "Darkness", adventure);
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "Deploy Drone"
 });

--- a/source/enemies/meteorknight.js
+++ b/source/enemies/meteorknight.js
@@ -26,7 +26,6 @@ module.exports = new EnemyTemplate("Meteor Knight",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "random"
 }).addAction({
 	name: "Armored Avalanche",
@@ -45,7 +44,6 @@ module.exports = new EnemyTemplate("Meteor Knight",
 		return results;
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "random"
 }).addAction({
 	name: "Freefall Flare-Up",
@@ -62,6 +60,5 @@ module.exports = new EnemyTemplate("Meteor Knight",
 		return resultLines;
 	},
 	selector: selectAllCombatants,
-	needsLivingTargets: true,
 	next: "Sonic Slash"
 });

--- a/source/enemies/ooze.js
+++ b/source/enemies/ooze.js
@@ -22,7 +22,6 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: 3 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random"
 }).addAction({
 	name: "Tackle",
@@ -38,7 +37,6 @@ module.exports = new EnemyTemplate("@{adventureOpposite} Ooze",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random"
 })
 	.setFlavorText({ name: "Ooze's Element", value: "The Ooze's element will be the opposite of the current adventure." });

--- a/source/enemies/royalslime.js
+++ b/source/enemies/royalslime.js
@@ -34,7 +34,6 @@ module.exports = new EnemyTemplate("Royal Slime",
 		}
 	},
 	selector: selectSelf,
-	needsLivingTargets: false,
 	next: "random",
 	rnConfig: { "elements": 1 }
 }).addAction({
@@ -51,7 +50,6 @@ module.exports = new EnemyTemplate("Royal Slime",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "random"
 }).addAction({
 	name: "Opposite Rolling Tackle",
@@ -67,7 +65,6 @@ module.exports = new EnemyTemplate("Royal Slime",
 		return dealDamage(targets, user, damage, false, user.element, adventure);
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "random"
 }).addAction({
 	name: "Goop Deluge",
@@ -81,7 +78,6 @@ module.exports = new EnemyTemplate("Royal Slime",
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: user.crit ? 3 : 2 })));
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: false,
 	next: "random"
 })
 	.setFlavorText({ name: "Royal Slime's Element", value: "The Royal Slime will start as the adventure's element and change it with Element Shift." });

--- a/source/enemies/slime.js
+++ b/source/enemies/slime.js
@@ -24,7 +24,6 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 		return dealDamage(targets, user, damage, false, adventure.element, adventure);
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random"
 }).addAction({
 	name: "Goop Spray",
@@ -38,7 +37,6 @@ module.exports = new EnemyTemplate("@{adventure} Slime",
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks: user.crit ? 3 : 2 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: false,
 	next: "random"
 })
 	.setFlavorText({ name: "Slime's Element", value: "The Slime's element will match the current adventure." });

--- a/source/enemies/starryknight.js
+++ b/source/enemies/starryknight.js
@@ -54,7 +54,6 @@ module.exports = new EnemyTemplate("Starry Knight",
 		}
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "random"
 }).addAction({
 	name: "Center of Attention",
@@ -68,7 +67,6 @@ module.exports = new EnemyTemplate("Starry Knight",
 			.concat(combineModifierReceipts(addNewRandomInsults(targets, user.crit ? 2 : 1, adventure)));
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: true,
 	next: "random",
 	combatFlavor: "\"Fear not! I have enough Star Power to take you all on!\""
 }).addAction({
@@ -85,7 +83,6 @@ module.exports = new EnemyTemplate("Starry Knight",
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	},
 	selector: selectAllFoes,
-	needsLivingTargets: true,
 	next: "random"
 }).addAction({
 	name: "Boast",
@@ -101,7 +98,6 @@ module.exports = new EnemyTemplate("Starry Knight",
 		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Distracted", stacks: 4 })));
 	},
 	selector: selectRandomFoe,
-	needsLivingTargets: true,
 	next: "random"
 }).setFlavorText({ name: "Insult to Injury", value: "Insult debuffs (@e{Ugly}, @e{Stupid}, @e{Smelly}, @e{Boring}, @e{Lacking Rhythm}) make the Starry Knight's Mock the Accursed more dangerous. Appease the Starry Knight to cure them all." });
 

--- a/source/enemies/treasureelemental.js
+++ b/source/enemies/treasureelemental.js
@@ -24,7 +24,6 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			return dealDamage(targets, user, damage, false, user.element, adventure).concat([`${user.name} gains protection.`]);
 		},
 		selector: selectRandomFoe,
-		needsLivingTargets: false,
 		next: "random"
 	}).addAction({
 		name: "Hail of Gemstones",
@@ -44,7 +43,6 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			return texts;
 		},
 		selector: selectRandomFoe,
-		needsLivingTargets: false,
 		next: "random"
 	}).addAction({
 		name: "Heavy Pockets",
@@ -59,6 +57,5 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Slow", stacks })));
 		},
 		selector: selectAllFoes,
-		needsLivingTargets: false,
 		next: "random"
 	});

--- a/source/gear/_appease.js
+++ b/source/gear/_appease.js
@@ -13,4 +13,4 @@ module.exports = new GearTemplate("Appease",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false });
+).setTargetingTags({ type: "self", team: "ally" });

--- a/source/gear/_gear_blueprint.js
+++ b/source/gear/_gear_blueprint.js
@@ -20,5 +20,5 @@ module.exports = new GearTemplate("name",
 		}
 		return []; // see style guide for conventions on result texts
 	}
-).setTargetingTags({ type: "", team: "", needsLivingTargets: true })
+).setTargetingTags({ type: "", team: "" })
 	.setDurability();

--- a/source/gear/_greed.js
+++ b/source/gear/_greed.js
@@ -11,5 +11,5 @@ module.exports = new GearTemplate("Greed",
 		const affectedTargets = targets.filter(target => target.archetype === "Treasure Elemental");
 		return generateModifierResultLines(combineModifierReceipts(addModifier(affectedTargets, powerUp).concat(addModifier(affectedTargets, midas))));
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setModifiers({ name: "Curse of Midas", stacks: 1 }, { name: "Power Up", stacks: 20 });

--- a/source/gear/_punch-base.js
+++ b/source/gear/_punch-base.js
@@ -20,6 +20,6 @@ module.exports = new GearTemplate("Punch",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setDurability(Infinity)
 	.setDamage(0);

--- a/source/gear/_punch-floatingmist.js
+++ b/source/gear/_punch-floatingmist.js
@@ -27,6 +27,6 @@ module.exports = new GearTemplate("Floating Mist Punch",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setDurability(Infinity)
 	.setDamage(0);

--- a/source/gear/_punch-ironfist.js
+++ b/source/gear/_punch-ironfist.js
@@ -18,6 +18,6 @@ module.exports = new GearTemplate("Iron Fist Punch",
 		}
 		return dealDamage(targets, user, pendingDamage, false, user.element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setDurability(Infinity)
 	.setDamage(0);

--- a/source/gear/abacus-base.js
+++ b/source/gear/abacus-base.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Abacus",
 		})
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Sharpened Abacus", "Thief's Abacus", "Unstoppable Abacus")
 	.setDurability(15)
 	.setDamage(40);

--- a/source/gear/abacus-sharpened.js
+++ b/source/gear/abacus-sharpened.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Sharpened Abacus",
 		})
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Thief's Abacus", "Unstoppable Abacus")
 	.setDurability(15)
 	.setDamage(65);

--- a/source/gear/abacus-thiefs.js
+++ b/source/gear/abacus-thiefs.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Thief's Abacus",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Sharpened Abacus", "Unstoppable Abacus")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/abacus-unstoppable.js
+++ b/source/gear/abacus-unstoppable.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Unstoppable Abacus",
 		})
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Thief's Abacus", "Sharpened Abacus")
 	.setDurability(15)
 	.setDamage(40);

--- a/source/gear/barrier-base.js
+++ b/source/gear/barrier-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Barrier",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingVigilance).concat(addModifier([user], evade))))
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Cleansing Barrier", "Devoted Barrier", "Vigilant Barrier")
 	.setModifiers({ name: "Evade", stacks: 3 }, { name: "Vigilance", stacks: 1 })
 	.setDurability(5);

--- a/source/gear/barrier-cleansing.js
+++ b/source/gear/barrier-cleansing.js
@@ -29,7 +29,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Devoted Barrier", "Vigilant Barrier")
 	.setModifiers({ name: "Evade", stacks: 3 }, { name: "Vigilance", stacks: 1 })
 	.setDurability(5)

--- a/source/gear/barrier-devoted.js
+++ b/source/gear/barrier-devoted.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Devoted Barrier",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, vigilance).concat(addModifier(targets, evade))));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Cleansing Barrier", "Vigilant Barrier")
 	.setModifiers({ name: "Evade", stacks: 3 }, { name: "Vigilance", stacks: 1 })
 	.setDurability(5);

--- a/source/gear/barrier-vigilant.js
+++ b/source/gear/barrier-vigilant.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Vigilant Barrier",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingVigilance).concat(addModifier([user], evade))));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Cleansing Barrier", "Devoted Barrier")
 	.setModifiers({ name: "Evade", stacks: 3 }, { name: "Vigilance", stacks: 2 })
 	.setDurability(5);

--- a/source/gear/battleaxe-base.js
+++ b/source/gear/battleaxe-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Battleaxe",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Furious Battleaxe", "Reactive Battleaxe", "Thirsting Battleaxe")
 	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/battleaxe-furious.js
+++ b/source/gear/battleaxe-furious.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Furious Battleaxe",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Reactive Battleaxe", "Thirsting Battleaxe")
 	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/battleaxe-reactive.js
+++ b/source/gear/battleaxe-reactive.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Reactive Battleaxe",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Furious Battleaxe", "Thirsting Battleaxe")
 	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(30)

--- a/source/gear/battleaxe-thirsting.js
+++ b/source/gear/battleaxe-thirsting.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Thirsting Battleaxe",
 		resultLines.push(gainHealth(user, healing * killCount, adventure));
 		return resultLines.concat(generateModifierResultLines(addModifier([user], exposed)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Furious Battleaxe", "Reactive Battleaxe")
 	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/bloodaegis-base.js
+++ b/source/gear/bloodaegis-base.js
@@ -38,7 +38,7 @@ module.exports = new GearTemplate("Blood Aegis",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Charging Blood Aegis", "Reinforced Blood Aegis", "Toxic Blood Aegis")
 	.setDurability(15)
 	.setHPCost(25)

--- a/source/gear/bloodaegis-charging.js
+++ b/source/gear/bloodaegis-charging.js
@@ -39,7 +39,7 @@ module.exports = new GearTemplate("Charging Blood Aegis",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Reinforced Blood Aegis", "Toxic Blood Aegis")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/bloodaegis-reinforced.js
+++ b/source/gear/bloodaegis-reinforced.js
@@ -38,7 +38,7 @@ module.exports = new GearTemplate("Reinforced Blood Aegis",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Charging Blood Aegis", "Toxic Blood Aegis")
 	.setDurability(15)
 	.setHPCost(25)

--- a/source/gear/bloodaegis-toxic.js
+++ b/source/gear/bloodaegis-toxic.js
@@ -42,7 +42,7 @@ module.exports = new GearTemplate("Toxic Blood Aegis",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Charging Blood Aegis", "Reinforced Blood Aegis")
 	.setDurability(15)
 	.setModifiers({ name: "Poison", stacks: 3 })

--- a/source/gear/bow-base.js
+++ b/source/gear/bow-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Bow",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Evasive Bow", "Thief's Bow", "Unstoppable Bow")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/bow-evasive.js
+++ b/source/gear/bow-evasive.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Evasive Bow",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], evade)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Thief's Bow", "Unstoppable Bow")
 	.setModifiers({ name: "Evade", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/bow-thiefs.js
+++ b/source/gear/bow-thiefs.js
@@ -32,7 +32,7 @@ module.exports = new GearTemplate("Thief's Bow",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Evasive Bow", "Unstoppable Bow")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/bow-unstoppable.js
+++ b/source/gear/bow-unstoppable.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Unstoppable Bow",
 		}
 		return dealDamage(targets, user, pendingDamage, true, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Evasive Bow", "Thief's Bow")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/buckler-base.js
+++ b/source/gear/buckler-base.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Buckler",
 		addProtection(targets, pendingProtection);
 		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier([user], powerUp))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Devoted Buckler", "Guarding Buckler", "Reinforced Buckler")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/buckler-devoted.js
+++ b/source/gear/buckler-devoted.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Devoted Buckler",
 		addProtection(targets, pendingProtection);
 		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier(targets, powerUp))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Guarding Buckler", "Reinforced Buckler")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/buckler-guarding.js
+++ b/source/gear/buckler-guarding.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Guarding Buckler",
 		addProtection(targets, pendingProtection);
 		return [joinAsStatement(false, [user, ...targets].map(combatant => combatant.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier([user], powerUp))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Devoted Buckler", "Reinforced Buckler")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/buckler-reinforced.js
+++ b/source/gear/buckler-reinforced.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Reinforced Buckler",
 		addProtection([user, ...targets], pendingProtection);
 		return [joinAsStatement(false, [user, ...targets].map(combatant => combatant.name), "gains", "gain", "protection."), ...generateModifierResultLines(addModifier([user], powerUp))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Devoted Buckler", "Guarding Buckler")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/cauldronstir-base.js
+++ b/source/gear/cauldronstir-base.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Corrosive Cauldron Stir", "Toxic Cauldron Stir", "Sabotaging Cauldron Stir")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/cauldronstir-corrosive.js
+++ b/source/gear/cauldronstir-corrosive.js
@@ -27,7 +27,7 @@ module.exports = new GearTemplate(gearName,
 
 		return resultLines.concat(generateModifierResultLines(addModifier(targets, powerdown)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Sabotaging Cauldron Stir", "Toxic Cauldron Stir")
 	.setModifiers({ name: "Power Down", stacks: 10 })
 	.setDurability(15)

--- a/source/gear/cauldronstir-sabotaging.js
+++ b/source/gear/cauldronstir-sabotaging.js
@@ -36,7 +36,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setModifiers({ name: "unparsed random weakness", stacks: 2 })
 	.setSidegrades("Corrosive Cauldron Stir", "Toxic Cauldron Stir")
 	.setDurability(15)

--- a/source/gear/cauldronstir-toxic.js
+++ b/source/gear/cauldronstir-toxic.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines.concat(generateModifierResultLines(addModifier(targets, poison)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Corrosive Cauldron Stir", "Sabotaging Cauldron Stir")
 	.setDurability(15)
 	.setModifiers({ name: "Poison", stacks: 4 })

--- a/source/gear/censer-base.js
+++ b/source/gear/censer-base.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Censer",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Staggering Censer", "Thick Censer", "Tormenting Censer")
 	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(15)

--- a/source/gear/censer-staggering.js
+++ b/source/gear/censer-staggering.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Staggering Censer",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Thick Censer", "Tormenting Censer")
 	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(15)

--- a/source/gear/censer-thick.js
+++ b/source/gear/censer-thick.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Thick Censer",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Staggering Censer", "Tormenting Censer")
 	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(15)

--- a/source/gear/censer-tormenting.js
+++ b/source/gear/censer-tormenting.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Tormenting Censer",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Staggering Censer", "Thick Censer")
 	.setModifiers({ name: "Slow", stacks: 2 })
 	.setDamage(15)

--- a/source/gear/certainvictory-base.js
+++ b/source/gear/certainvictory-base.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Certain Victory",
 			payHP(user, user.getModifierStacks("Power Up"), adventure)
 		);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Hunter's Certain Victory", "Lethal Certain Victory", "Reckless Certain Victory")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/certainvictory-hunters.js
+++ b/source/gear/certainvictory-hunters.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Hunter's Certain Victory",
 		}
 		return resultLines.concat(generateModifierResultLines(addModifier([user], powerUp)), payHP(user, user.getModifierStacks("Power Up"), adventure));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Lethal Certain Victory", "Reckless Certain Victory")
 	.setModifiers({ name: "Power Up", stacks: 25 }, { name: "Power Up", stacks: 30 })
 	.setDurability(15)

--- a/source/gear/certainvictory-lethal.js
+++ b/source/gear/certainvictory-lethal.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Lethal Certain Victory",
 			payHP(user, user.getModifierStacks("Power Up"), adventure)
 		);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Hunter's Certain Victory", "Reckless Certain Victory")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setDurability(15)

--- a/source/gear/certainvictory-reckless.js
+++ b/source/gear/certainvictory-reckless.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Reckless Certain Victory",
 		const receipts = addModifier([user], powerUp).concat(addModifier([user], exposed));
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)), payHP(user, user.getModifierStacks("Power Up"), adventure));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Hunter's Certain Victory", "Lethal Certain Victory")
 	.setModifiers({ name: "Power Up", stacks: 25 }, { name: "Exposed", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/chainmail-base.js
+++ b/source/gear/chainmail-base.js
@@ -8,7 +8,5 @@ module.exports = new GearTemplate("Chainmail",
 	"Untyped",
 	200,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setUpgrades("Poised Chainmail", "Powerful Chainmail", "Wise Chainmail")
-	.setDurability(0)
+).setUpgrades("Poised Chainmail", "Powerful Chainmail", "Wise Chainmail")
 	.setMaxHP(50);

--- a/source/gear/chainmail-poised.js
+++ b/source/gear/chainmail-poised.js
@@ -8,8 +8,6 @@ module.exports = new GearTemplate("Poised Chainmail",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Powerful Chainmail", "Wise Chainmail")
-	.setDurability(0)
+).setSidegrades("Powerful Chainmail", "Wise Chainmail")
 	.setMaxHP(50)
 	.setPoise(2);

--- a/source/gear/chainmail-powerful.js
+++ b/source/gear/chainmail-powerful.js
@@ -8,8 +8,6 @@ module.exports = new GearTemplate("Powerful Chainmail",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Poised Chainmail", "Wise Chainmail")
-	.setDurability(0)
+).setSidegrades("Poised Chainmail", "Wise Chainmail")
 	.setMaxHP(50)
 	.setPower(15);

--- a/source/gear/chainmail-wise.js
+++ b/source/gear/chainmail-wise.js
@@ -8,7 +8,5 @@ module.exports = new GearTemplate("Wise Chainmail",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Poised Chainmail", "Powerful Chainmail")
-	.setDurability(0)
+).setSidegrades("Poised Chainmail", "Powerful Chainmail")
 	.setMaxHP(50);

--- a/source/gear/cloak-accelerating.js
+++ b/source/gear/cloak-accelerating.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Accelerating Cloak",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingEvade).concat(addModifier([user], pendingQuicken))));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Accurate Cloak", "Evasive Cloak")
 	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Quicken", stacks: 1 })
 	.setBonus(1) // Evade stacks

--- a/source/gear/cloak-accurate.js
+++ b/source/gear/cloak-accurate.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Accurate Cloak",
 		}
 		return generateModifierResultLines(addModifier([user], pendingEvade));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Accelerating Cloak", "Evasive Cloak")
 	.setModifiers({ name: "Evade", stacks: 2 })
 	.setBonus(1) // Evade stacks

--- a/source/gear/cloak-base.js
+++ b/source/gear/cloak-base.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Cloak",
 		}
 		return generateModifierResultLines(addModifier([user], pendingEvade));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Accelerating Cloak", "Accurate Cloak", "Evasive Cloak")
 	.setModifiers({ name: "Evade", stacks: 2 })
 	.setBonus(1) // Evade stacks

--- a/source/gear/cloak-evasive.js
+++ b/source/gear/cloak-evasive.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Evasive Cloak",
 		}
 		return generateModifierResultLines(addModifier([user], pendingEvade));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Accelerating Cloak", "Accurate Cloak")
 	.setModifiers({ name: "Evade", stacks: 3 })
 	.setBonus(1) // Evade stacks

--- a/source/gear/corrosion-base.js
+++ b/source/gear/corrosion-base.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Corrosion",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Fate-Sealing Corrosion", "Harmful Corrosion", "Shattering Corrosion")
 	.setModifiers({ name: "Power Down", stacks: 20 })
 	.setBonus(2) // Crit Stagger

--- a/source/gear/corrosion-fatesealing.js
+++ b/source/gear/corrosion-fatesealing.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Fate-Sealing Corrosion",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Harmful Corrosion", "Shattering Corrosion")
 	.setModifiers({ name: "Power Down", stacks: 20 }, { name: "Retain", stacks: 1 })
 	.setBonus(2) // Crit Stagger

--- a/source/gear/corrosion-harmful.js
+++ b/source/gear/corrosion-harmful.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Harmful Corrosion",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, powerDown))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Fate-Sealing Corrosion", "Shattering Corrosion")
 	.setModifiers({ name: "Power Down", stacks: 20 })
 	.setBonus(2) // Crit Stagger

--- a/source/gear/corrosion-shattering.js
+++ b/source/gear/corrosion-shattering.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Shattering Corrosion",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, powerDown).concat(addModifier(targets, frail)))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Fate-Sealing Corrosion", "Harmful Corrosion")
 	.setModifiers({ name: "Power Down", stacks: 20 }, { name: "Frail", stacks: 4 })
 	.setBonus(2) // Crit Stagger

--- a/source/gear/cursed-blade.js
+++ b/source/gear/cursed-blade.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Cursed Blade",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Daggers", "Scythe", "Shortsword", "Spear")
 	.setDurability(15)
 	.setDamage(10)

--- a/source/gear/cursed-tome.js
+++ b/source/gear/cursed-tome.js
@@ -8,7 +8,5 @@ module.exports = new GearTemplate("Cursed Tome",
 	"Untyped",
 	-50,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "any", needsLivingTargets: false })
-	.setUpgrades("Blood Aegis", "Certain Victory", "Infinite Regeneration", "Power from Wrath")
-	.setDurability(0)
+).setUpgrades("Blood Aegis", "Certain Victory", "Infinite Regeneration", "Power from Wrath")
 	.setPoise(-2);

--- a/source/gear/daggers-base.js
+++ b/source/gear/daggers-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Daggers",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Sharpened Daggers", "Sweeping Daggers", "Slowing Daggers")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/daggers-sharpened.js
+++ b/source/gear/daggers-sharpened.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Sharpened Daggers",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Sweeping Daggers", "Slowing Daggers")
 	.setDurability(15)
 	.setCritMultiplier(3)

--- a/source/gear/daggers-slowing.js
+++ b/source/gear/daggers-slowing.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Slowing Daggers",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Sharpened Daggers", "Sweeping Daggers")
 	.setModifiers({ name: "Slow", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/daggers-sweeping.js
+++ b/source/gear/daggers-sweeping.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Sweeping Daggers",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setSidegrades("Sharpened Daggers", "Slowing Daggers")
 	.setDurability(15)
 	.setCritMultiplier(3)

--- a/source/gear/feverbreak-base.js
+++ b/source/gear/feverbreak-base.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate("Fever Break",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Organic Fever Break", "Surpassing Fever Break", "Urgent Fever Break")
 	.setModifiers({ name: "Poison", stacks: 0 }, { name: "Frail", stacks: 0 })
 	.setDurability(5);

--- a/source/gear/feverbreak-organic.js
+++ b/source/gear/feverbreak-organic.js
@@ -37,7 +37,7 @@ module.exports = new GearTemplate("Organic Fever Break",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Surpassing Fever Break", "Urgent Fever Break")
 	.setModifiers({ name: "Poison", stacks: 0 }, { name: "Frail", stacks: 0 })
 	.setDurability(5);

--- a/source/gear/feverbreak-surpassing.js
+++ b/source/gear/feverbreak-surpassing.js
@@ -37,7 +37,7 @@ module.exports = new GearTemplate("Surpassing Fever Break",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Organic Fever Break", "Urgent Fever Break")
 	.setModifiers({ name: "Poison", stacks: 0 }, { name: "Frail", stacks: 0 })
 	.setDurability(5);

--- a/source/gear/feverbreak-urgent.js
+++ b/source/gear/feverbreak-urgent.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate("Urgent Fever Break",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Organic Fever Break", "Surpassing Fever Break")
 	.setModifiers({ name: "Poison", stacks: 0 }, { name: "Frail", stacks: 0 })
 	.setDurability(5)

--- a/source/gear/firecracker-base.js
+++ b/source/gear/firecracker-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Firecracker",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "foe" })
 	.setUpgrades("Double Firecracker", "Midas's Firecracker", "Toxic Firecracker")
 	.setDurability(15)
 	.setDamage(5)

--- a/source/gear/firecracker-double.js
+++ b/source/gear/firecracker-double.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Double Firecracker",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: `random${SAFE_DELIMITER}6`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `random${SAFE_DELIMITER}6`, team: "foe" })
 	.setSidegrades("Midas's Firecracker", "Toxic Firecracker")
 	.setDurability(15)
 	.setDamage(5)

--- a/source/gear/firecracker-midass.js
+++ b/source/gear/firecracker-midass.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Midas's Firecracker",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "foe" })
 	.setSidegrades("Double Firecracker", "Toxic Firecracker")
 	.setModifiers({ name: "Curse of Midas", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/firecracker-toxic.js
+++ b/source/gear/firecracker-toxic.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Toxic Firecracker",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "foe" })
 	.setSidegrades("Double Firecracker", "Midas's Firecracker")
 	.setModifiers({ name: "Poison", stacks: 3 })
 	.setDurability(15)

--- a/source/gear/floatingmiststance-agile.js
+++ b/source/gear/floatingmiststance-agile.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Agile Floating Mist Stance",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Devoted Floating Mist Stance", "Soothing Floating Mist Stance")
 	.setModifiers({ name: "Evade", stacks: 1 }, { name: "Floating Mist Stance", stacks: 1 }, { name: "Agility", stacks: 2 })
 	.setDurability(10)

--- a/source/gear/floatingmiststance-base.js
+++ b/source/gear/floatingmiststance-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Floating Mist Stance",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Agile Floating Mist Stance", "Devoted Floating Mist Stance", "Soothing Floating Mist Stance")
 	.setModifiers({ name: "Evade", stacks: 1 }, { name: "Floating Mist Stance", stacks: 1 })
 	.setDurability(10)

--- a/source/gear/floatingmiststance-devoted.js
+++ b/source/gear/floatingmiststance-devoted.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Devoted Floating Mist Stance",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Agile Floating Mist Stance", "Soothing Floating Mist Stance")
 	.setModifiers({ name: "Evade", stacks: 1 }, { name: "Floating Mist Stance", stacks: 1 })
 	.setDurability(10)

--- a/source/gear/floatingmiststance-soothing.js
+++ b/source/gear/floatingmiststance-soothing.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Soothing Floating Mist Stance",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Agile Floating Mist Stance", "Devoted Floating Mist Stance")
 	.setModifiers({ name: "Evade", stacks: 1 }, { name: "Floating Mist Stance", stacks: 1 }, { name: "Regen", stacks: 2 })
 	.setDurability(10)

--- a/source/gear/goadfutility-base.js
+++ b/source/gear/goadfutility-base.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Goad Futility",
 		}
 		return generateModifierResultLines(receipts).concat(resultLines);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Flanking Goad Futility", "Poised Goad Futility", "Shattering Goad Futility")
 	.setModifiers({ name: "Oblivious", stacks: 1 }, { name: "Unlucky", stacks: 3 })
 	.setDurability(10);

--- a/source/gear/goadfutility-flanking.js
+++ b/source/gear/goadfutility-flanking.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Flanking Goad Futility",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Poised Goad Futility", "Shattering Goad Futility")
 	.setModifiers({ name: "Oblivious", stacks: 1 }, { name: "Unlucky", stacks: 3 }, { name: "Exposed", stacks: 2 })
 	.setDurability(10);

--- a/source/gear/goadfutility-poised.js
+++ b/source/gear/goadfutility-poised.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Poised Goad Futility",
 		}
 		return generateModifierResultLines(receipts).concat(resultLines);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Flanking Goad Futility", "Shattering Goad Futility")
 	.setModifiers({ name: "Oblivious", stacks: 1 }, { name: "Unlucky", stacks: 3 })
 	.setDurability(10)

--- a/source/gear/goadfutility-shattering.js
+++ b/source/gear/goadfutility-shattering.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Shattering Goad Futility",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Flanking Goad Futility", "Poised Goad Futility")
 	.setModifiers({ name: "Oblivious", stacks: 1 }, { name: "Unlucky", stacks: 3 }, { name: "Frail", stacks: 4 })
 	.setDurability(10);

--- a/source/gear/heatmirage-base.js
+++ b/source/gear/heatmirage-base.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Heat Mirage",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Evasive Heat Mirage", "Unlucky Heat Mirage", "Vigilant Heat Mirage")
 	.setModifiers({ name: "Evade", stacks: 2 })
 	.setDurability(10);

--- a/source/gear/heatmirage-evasive.js
+++ b/source/gear/heatmirage-evasive.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Evasive Heat Mirage",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Unlucky Heat Mirage", "Vigilant Heat Mirage")
 	.setModifiers({ name: "Evade", stacks: 3 })
 	.setDurability(10);

--- a/source/gear/heatmirage-unlucky.js
+++ b/source/gear/heatmirage-unlucky.js
@@ -45,7 +45,7 @@ module.exports = new GearTemplate("Unlucky Heat Mirage",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Evasive Heat Mirage", "Vigilant Heat Mirage")
 	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Unlucky", stacks: 2 })
 	.setDurability(10);

--- a/source/gear/heatmirage-vigilant.js
+++ b/source/gear/heatmirage-vigilant.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Vigilant Heat Mirage",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Evasive Heat Mirage", "Unlucky Heat Mirage")
 	.setModifiers({ name: "Evade", stacks: 2 }, { name: "Vigilance", stacks: 1 })
 	.setDurability(10);

--- a/source/gear/herbbasket-base.js
+++ b/source/gear/herbbasket-base.js
@@ -30,7 +30,7 @@ module.exports = new GearTemplate(gearName,
 			return [`${user.name} gathers a batch of ${randomHerb}.`];
 		}
 	}
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
+).setTargetingTags({ type: "none", team: "none" })
 	.setUpgrades("Organic Herb Basket", "Reinforced Herb Basket", "Urgent Herb Basket")
 	.setBonus(1) // Herb count
 	.setDurability(15)

--- a/source/gear/herbbasket-organic.js
+++ b/source/gear/herbbasket-organic.js
@@ -32,7 +32,7 @@ module.exports = new GearTemplate(gearName,
 			return [`${user.name} gathers a batch of ${randomHerb}.`];
 		}
 	}
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
+).setTargetingTags({ type: "none", team: "none" })
 	.setSidegrades("Reinforced Herb Basket", "Urgent Herb Basket")
 	.setBonus(1) // Herb count
 	.setDurability(15)

--- a/source/gear/herbbasket-reinforced.js
+++ b/source/gear/herbbasket-reinforced.js
@@ -31,7 +31,7 @@ module.exports = new GearTemplate(gearName,
 			return [`${user.name} gains protection and gathers a batch of ${randomHerb}.`];
 		}
 	}
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
+).setTargetingTags({ type: "none", team: "none" })
 	.setSidegrades("Organic Herb Basket", "Urgent Herb Basket")
 	.setBonus(1) // Herb count
 	.setProtection(75)

--- a/source/gear/herbbasket-urgent.js
+++ b/source/gear/herbbasket-urgent.js
@@ -30,7 +30,7 @@ module.exports = new GearTemplate(gearName,
 			return [`${user.name} gathers a batch of ${randomHerb}.`];
 		}
 	}
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
+).setTargetingTags({ type: "none", team: "none" })
 	.setSidegrades("Organic Herb Basket", "Reinforced Herb Basket")
 	.setBonus(1) // Herb count
 	.setPriority(1)

--- a/source/gear/icebolt-awesome.js
+++ b/source/gear/icebolt-awesome.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Awesome Ice Bolt",
 		const resultLines = targets.reduce((array, target) => array.concat(dealDamage([target], user, target.isStunned ? stunnedDamage : pendingDamage, false, element, adventure)), []);
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Distracting Ice Bolt", "Unlucky Ice Bolt")
 	.setDamage(40)
 	.setModifiers({ name: "Slow", stacks: 2 })

--- a/source/gear/icebolt-base.js
+++ b/source/gear/icebolt-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Ice Bolt",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Awesome Ice Bolt", "Distracting Ice Bolt", "Unlucky Ice Bolt")
 	.setDamage(40)
 	.setModifiers({ name: "Slow", stacks: 2 })

--- a/source/gear/icebolt-distracting.js
+++ b/source/gear/icebolt-distracting.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Distracting Ice Bolt",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow).concat(addModifier(targets, distracted)))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Awesome Ice Bolt", "Unlucky Ice Bolt")
 	.setDamage(40)
 	.setModifiers({ name: "Slow", stacks: 2 }, { name: "Distracted", stacks: 2 })

--- a/source/gear/icebolt-unlucky.js
+++ b/source/gear/icebolt-unlucky.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Unlucky Ice Bolt",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, slow).concat(addModifier(targets, unlucky)))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Awesome Ice Bolt", "Distracting Ice Bolt")
 	.setDamage(40)
 	.setModifiers({ name: "Slow", stacks: 2 }, { name: "Unlucky", stacks: 1 })

--- a/source/gear/infiniteregeneration-base.js
+++ b/source/gear/infiniteregeneration-base.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Infinite Regeneration",
 		}
 		return [paymentSentence, ...generateModifierResultLines(addModifier(targets, regen))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Discounted Infinite Regeneration", "Fate-Sealing Infinite Regeneration", "Purifying Infinite Regeneration")
 	.setModifiers({ name: "Regen", stacks: 4 })
 	.setHPCost(50)

--- a/source/gear/infiniteregeneration-discounted.js
+++ b/source/gear/infiniteregeneration-discounted.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Discounted Infinite Regeneration",
 		}
 		return [paymentSentence, ...generateModifierResultLines(addModifier(targets, regen))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Fate-Sealing Infinite Regeneration", "Purifying Infinite Regeneration")
 	.setModifiers({ name: "Regen", stacks: 4 })
 	.setHPCost(50)

--- a/source/gear/infiniteregeneration-fatesealing.js
+++ b/source/gear/infiniteregeneration-fatesealing.js
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Fate-Sealing Infinite Regeneration",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Discounted Infinite Regeneration", "Purifying Infinite Regeneration")
 	.setModifiers({ name: "Regen", stacks: 4 }, { name: "Retain", stacks: 1 })
 	.setHPCost(50)

--- a/source/gear/infiniteregeneration-purifying.js
+++ b/source/gear/infiniteregeneration-purifying.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Purifying Infinite Regeneration",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Discounted Infinite Regeneration", "Fate-Sealing Infinite Regeneration")
 	.setModifiers({ name: "Regen", stacks: 4 })
 	.setHPCost(50)

--- a/source/gear/inspiration-base.js
+++ b/source/gear/inspiration-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Inspiration",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp)));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Guarding Inspiration", "Soothing Inspiration", "Sweeping Inspiration")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setBonus(25) // Power Up stacks

--- a/source/gear/inspiration-guarding.js
+++ b/source/gear/inspiration-guarding.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Guarding Inspiration",
 		addProtection(targets, protection);
 		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp)))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Soothing Inspiration", "Sweeping Inspiration")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setBonus(25) // Power Up stacks

--- a/source/gear/inspiration-soothing.js
+++ b/source/gear/inspiration-soothing.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Soothing Inspiration",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp).concat(addModifier(targets, regen))));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Guarding Inspiration", "Sweeping Inspiration")
 	.setModifiers({ name: "Power Up", stacks: 25 }, { name: "Regen", stacks: 2 })
 	.setBonus(25) // Power Up stacks

--- a/source/gear/inspiration-sweeping.js
+++ b/source/gear/inspiration-sweeping.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Sweeping Inspiration",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPowerUp)));
 	}
-).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "ally" })
 	.setSidegrades("Guarding Inspiration", "Soothing Inspiration")
 	.setModifiers({ name: "Power Up", stacks: 25 })
 	.setBonus(25) // Power Up stacks

--- a/source/gear/ironfiststance-accurate.js
+++ b/source/gear/ironfiststance-accurate.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Accurate Iron Fist Stance",
 
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Lucky Iron Fist Stance", "Organic Iron Fist Stance")
 	.setModifiers({ name: "Iron Fist Stance", stacks: 1 }, { name: "Frail", stacks: 4 })
 	.setBonus(45) // Punch damage boost

--- a/source/gear/ironfiststance-base.js
+++ b/source/gear/ironfiststance-base.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Iron Fist Stance",
 
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Accurate Iron Fist Stance", "Lucky Iron Fist Stance", "Organic Iron Fist Stance")
 	.setModifiers({ name: "Iron Fist Stance", stacks: 1 }, { name: "Frail", stacks: 4 })
 	.setBonus(45) // Punch damage boost

--- a/source/gear/ironfiststance-lucky.js
+++ b/source/gear/ironfiststance-lucky.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Lucky Iron Fist Stance",
 
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Accurate Iron Fist Stance", "Organic Iron Fist Stance")
 	.setModifiers({ name: "Iron Fist Stance", stacks: 1 }, { name: "Frail", stacks: 4 }, { name: "Lucky", stacks: 1 })
 	.setBonus(45) // Punch damage boost

--- a/source/gear/ironfiststance-organic.js
+++ b/source/gear/ironfiststance-organic.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Organic Iron Fist Stance",
 
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: false })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Organic Iron Fist Stance", "Lucky Iron Fist Stance")
 	.setModifiers({ name: "Iron Fist Stance", stacks: 1 }, { name: "Frail", stacks: 4 })
 	.setBonus(45) // Punch damage boost

--- a/source/gear/lance-accelerating.js
+++ b/source/gear/lance-accelerating.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Accelerating Lance",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([user], quicken)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Shattering Lance", "Unstoppable Lance")
 	.setModifiers({ name: "Quicken", stacks: 1 }, { name: "Power Up", stacks: 0 })
 	.setDurability(15)

--- a/source/gear/lance-base.js
+++ b/source/gear/lance-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Lance",
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
 ).setUpgrades("Accelerating Lance", "Shattering Lance", "Unstoppable Lance")
-	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+	.setTargetingTags({ type: "single", team: "foe" })
 	.setModifiers({ name: "Power Up", stacks: 0 })
 	.setDurability(15)
 	.setDamage(40);

--- a/source/gear/lance-shattering.js
+++ b/source/gear/lance-shattering.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Shattering Lance",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Accelerating Lance", "Unstoppable Lance")
 	.setModifiers({ name: "Frail", stacks: 4 }, { name: "Power Up", stacks: 0 })
 	.setDurability(15)

--- a/source/gear/lance-unstoppable.js
+++ b/source/gear/lance-unstoppable.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Unstoppable Lance",
 		}
 		return dealDamage(targets, user, pendingDamage, true, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Accelerating Lance", "Shattering Lance")
 	.setModifiers({ name: "Power Up", stacks: 0 })
 	.setDurability(15)

--- a/source/gear/lifedrain-base.js
+++ b/source/gear/lifedrain-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Life Drain",
 		}
 		return [...dealDamage(targets, user, pendingDamage, false, element, adventure), gainHealth(user, pendingHealing, adventure)];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Flanking Life Drain", "Furious Life Drain", "Thirsting Life Drain")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/lifedrain-flanking.js
+++ b/source/gear/lifedrain-flanking.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Flanking Life Drain",
 
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Furios Life Drain", "Thirsting Life Drain")
 	.setModifiers({ name: "Exposed", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/lifedrain-furious.js
+++ b/source/gear/lifedrain-furious.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Furious Life Drain",
 		}
 		return [...dealDamage(targets, user, pendingDamage, false, element, adventure), gainHealth(user, pendingHealing, adventure)];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Flanking Life Drain", "Thirsting Life Drain")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/lifedrain-thirsting.js
+++ b/source/gear/lifedrain-thirsting.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Thirsting Life Drain",
 		resultLines.push(gainHealth(user, pendingHealing, adventure));
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Flanking Life Drain", "Furious Life Drain")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/medicine-base.js
+++ b/source/gear/medicine-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Medicine",
 		}
 		return generateModifierResultLines(addModifier(targets, pendingRegen));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Bouncing Medicine", "Cleansing Medicine", "Soothing Medicine")
 	.setModifiers({ name: "Regen", stacks: 3 })
 	.setDurability(15);

--- a/source/gear/medicine-bouncing.js
+++ b/source/gear/medicine-bouncing.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Bouncing Medicine",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingRegen)));
 	}
-).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: `random${SAFE_DELIMITER}3`, team: "ally" })
 	.setSidegrades("Cleansing Medicine", "Soothing Medicine")
 	.setModifiers({ name: "Regen", stacks: 3 })
 	.setDurability(15)

--- a/source/gear/medicine-cleansing.js
+++ b/source/gear/medicine-cleansing.js
@@ -32,7 +32,7 @@ module.exports = new GearTemplate(gearName,
 
 		return generateModifierResultLines(receipts);
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Bouncing Medicine", "Soothing Medicine")
 	.setModifiers({ name: "Regen", stacks: 3 })
 	.setDurability(15)

--- a/source/gear/medicine-soothing.js
+++ b/source/gear/medicine-soothing.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Soothing Medicine",
 		}
 		return generateModifierResultLines(addModifier(targets, pendingRegen));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Bouncing Medicine", "Cleansing Medicine")
 	.setModifiers({ name: "Regen", stacks: 5 })
 	.setDurability(15);

--- a/source/gear/midasstaff-accelerating.js
+++ b/source/gear/midasstaff-accelerating.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Accelerating Midas Staff",
 		const receipts = addModifier([target], pendingCurse).concat(addModifier([user], quicken));
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setSidegrades("Discounted Midas Staff", "Soothing Midas Staff")
 	.setModifiers({ name: "Curse of Midas", stacks: 2 }, { name: "Quicken", stacks: 1 })
 	.setBonus(1) // Curse of Midas stacks

--- a/source/gear/midasstaff-base.js
+++ b/source/gear/midasstaff-base.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Midas Staff",
 		}
 		return generateModifierResultLines(addModifier([target], pendingCurse));
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setUpgrades("Accelerating Midas Staff", "Discounted Midas Staff", "Soothing Midas Staff")
 	.setModifiers({ name: "Curse of Midas", stacks: 2 })
 	.setBonus(1) // Curse of Midas stacks

--- a/source/gear/midasstaff-discounted.js
+++ b/source/gear/midasstaff-discounted.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Discounted Midas Staff",
 		}
 		return generateModifierResultLines(addModifier([target], pendingCurse));
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setSidegrades("Accelerating Midas Staff", "Soothing Midas Staff")
 	.setModifiers({ name: "Curse of Midas", stacks: 2 })
 	.setBonus(1) // Curse of Midas stacks

--- a/source/gear/midasstaff-soothing.js
+++ b/source/gear/midasstaff-soothing.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Soothing Midas Staff",
 		const receipts = addModifier([target], pendingCurse).concat(addModifier([target], regen));
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setSidegrades("Accelerating Midas Staff", "Discounted Midas Staff")
 	.setModifiers({ name: "Curse of Midas", stacks: 2 }, { name: "Regen", stacks: 2 })
 	.setBonus(1) // Curse of Midas stacks

--- a/source/gear/morningstar-awesome.js
+++ b/source/gear/morningstar-awesome.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Awesome Morning Star",
 		changeStagger([target], stagger);
 		return [...dealDamage([target], user, pendingDamage, false, element, adventure), `${target.name} is Staggered.`];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Bashing Morning Star", "Hunter's Morning Star")
 	.setStagger(2)
 	.setDurability(15)

--- a/source/gear/morningstar-base.js
+++ b/source/gear/morningstar-base.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Morning Star",
 		changeStagger(targets, stagger);
 		return [...dealDamage(targets, user, pendingDamage, false, element, adventure), joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered.")];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Awesome Morning Star", "Bashing Morning Star", "Hunter's Morning Star")
 	.setStagger(2)
 	.setDurability(15)

--- a/source/gear/morningstar-bashing.js
+++ b/source/gear/morningstar-bashing.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Bashing Morning Star",
 		changeStagger(targets, stagger);
 		return [...dealDamage(targets, user, pendingDamage, false, element, adventure), joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered.")];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Awesome Morning Star", "Hunter's Morning Star")
 	.setStagger(2)
 	.setDurability(15)

--- a/source/gear/morningstar-hunters.js
+++ b/source/gear/morningstar-hunters.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Hunter's Morning Star",
 		resultLines.push(joinAsStatement(false, stillLivingTargets.map(target => target.name), "was", "were", "Staggered."))
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Awesome Morning Star", "Bashing Morning Star")
 	.setStagger(2)
 	.setDurability(15)

--- a/source/gear/omamori-base.js
+++ b/source/gear/omamori-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Omamori",
 		addProtection([user], protection);
 		return [`${user.name} gains protection.`].concat(generateModifierResultLines(addModifier([user], pendingLucky)));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Centering Omamori", "Cleansing Omamori", "Devoted Omamori")
 	.setModifiers({ name: "Lucky", stacks: 2 })
 	.setProtection(50)

--- a/source/gear/omamori-centering.js
+++ b/source/gear/omamori-centering.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Centering Omamori",
 		}
 		return [`${user.name} ${listifyEN(userEffects)}.`].concat(generateModifierResultLines(addModifier([user], pendingLucky)));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Cleansing Omamori", "Devoted Omamori")
 	.setModifiers({ name: "Lucky", stacks: 2 })
 	.setProtection(50)

--- a/source/gear/omamori-cleansing.js
+++ b/source/gear/omamori-cleansing.js
@@ -30,7 +30,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "self", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Centering Omamori", "Devoted Omamori")
 	.setModifiers({ name: "Lucky", stacks: 2 })
 	.setProtection(50)

--- a/source/gear/omamori-devoted.js
+++ b/source/gear/omamori-devoted.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Devoted Omamori",
 		addProtection(targets, protection);
 		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection.")].concat(generateModifierResultLines(addModifier(targets, pendingLucky)));
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Centering Omamori", "Cleansing Omamori")
 	.setModifiers({ name: "Lucky", stacks: 2 })
 	.setProtection(50)

--- a/source/gear/pistol-base.js
+++ b/source/gear/pistol-base.js
@@ -31,7 +31,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Double Pistol", "Duelist's Pistol", "Flanking Pistol")
 	.setModifiers({ name: "Power Up", stacks: 30 })
 	.setDurability(15)

--- a/source/gear/pistol-double.js
+++ b/source/gear/pistol-double.js
@@ -31,7 +31,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Duelist's Pistol", "Flanking Pistol")
 	.setModifiers({ name: "Power Up", stacks: 30 })
 	.setDurability(15)

--- a/source/gear/pistol-duelists.js
+++ b/source/gear/pistol-duelists.js
@@ -37,7 +37,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Double Pistol", "Flanking Pistol")
 	.setModifiers({ name: "Power Up", stacks: 30 })
 	.setDurability(15)

--- a/source/gear/pistol-flanking.js
+++ b/source/gear/pistol-flanking.js
@@ -32,7 +32,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines.concat(generateModifierResultLines(receipts));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Double Pistol", "Duelist's Pistol")
 	.setModifiers({ name: "Power Up", stacks: 30 }, { name: "Exposed", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/poisontorrent-base.js
+++ b/source/gear/poisontorrent-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Poison Torrent",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPoison)));
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setUpgrades("Distracting Poison Torrent", "Harmful Poison Torrent", "Staggering Poison Torrent")
 	.setModifiers({ name: "Poison", stacks: 2 })
 	.setDurability(15);

--- a/source/gear/poisontorrent-distracting.js
+++ b/source/gear/poisontorrent-distracting.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Distracting Poison Torrent",
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPoison).concat(addModifier(targets, distracted))));
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setSidegrades("Harmful Poison Torrent", "Staggering Poison Torrent")
 	.setModifiers({ name: "Poison", stacks: 2 }, { name: "Distracted", stacks: 2 })
 	.setDurability(15);

--- a/source/gear/poisontorrent-harmful.js
+++ b/source/gear/poisontorrent-harmful.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Harmful Poison Torrent",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setSidegrades("Distracting Poison Torrent", "Staggering Poison Torrent")
 	.setModifiers({ name: "Poison", stacks: 2 })
 	.setDamage(15)

--- a/source/gear/poisontorrent-staggering.js
+++ b/source/gear/poisontorrent-staggering.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Staggering Poison Torrent",
 		changeStagger(targets, stagger);
 		return ["All foes were Staggered.", ...generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingPoison)))];
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setSidegrades("Distracting Poison Torrent", "Harmful Poison Torrent")
 	.setModifiers({ name: "Poison", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/powerfromwrath-base.js
+++ b/source/gear/powerfromwrath-base.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Power from Wrath",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Bashing Power from Wrath", "Hunter's Power from Wrath", "Staggering Power from Wrath")
 	.setDurability(15)
 	.setHPCost(40)

--- a/source/gear/powerfromwrath-bashing.js
+++ b/source/gear/powerfromwrath-bashing.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Bashing Power from Wrath",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Hunter's Power from Wrath", "Staggering Power from Wrath")
 	.setDurability(15)
 	.setHPCost(40)

--- a/source/gear/powerfromwrath-hunters.js
+++ b/source/gear/powerfromwrath-hunters.js
@@ -29,7 +29,7 @@ module.exports = new GearTemplate("Hunter's Power from Wrath",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Bashing Power from Wrath", "Staggering Power from Wrath")
 	.setDurability(15)
 	.setHPCost(40)

--- a/source/gear/powerfromwrath-staggering.js
+++ b/source/gear/powerfromwrath-staggering.js
@@ -31,7 +31,7 @@ module.exports = new GearTemplate("Staggering Power from Wrath",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Bashing Power from Wrath", "Hunter's Power from Wrath")
 	.setDurability(15)
 	.setHPCost(40)

--- a/source/gear/prismaticblast-base.js
+++ b/source/gear/prismaticblast-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Prismatic Blast",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setUpgrades("Distracting Prismatic Blast", "Flanking Prismatic Blast", "Vexing Prismatic Blast")
 	.setDurability(15)
 	.setDamage(40);

--- a/source/gear/prismaticblast-distracting.js
+++ b/source/gear/prismaticblast-distracting.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Distracting Prismatic Blast",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, distracted))));
 	}
-).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setSidegrades("Flanking Prismatic Blast", "Vexing Prismatic Blast")
 	.setModifiers({ name: "Distracted", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/prismaticblast-flanking.js
+++ b/source/gear/prismaticblast-flanking.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Flanking Prismatic Blast",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, exposed))));
 	}
-).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setSidegrades("Distracting Prismatic Blast", "Vexing Prismatic Blast")
 	.setModifiers({ name: "Exposed", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/prismaticblast-vexing.js
+++ b/source/gear/prismaticblast-vexing.js
@@ -39,7 +39,7 @@ module.exports = new GearTemplate("Vexing Prismatic Blast",
 			return dealDamage(nondebuffedTargets, user, nonDebuffedDamage, false, element, adventure);
 		}
 	}
-).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setSidegrades("Distracting Prismatic Blast", "Flanking Prismatic Blast")
 	.setDurability(15)
 	.setBonus(50) // vexing damage

--- a/source/gear/refreshingbreeze-accelerating.js
+++ b/source/gear/refreshingbreeze-accelerating.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "ally" })
 	.setSidegrades("Supportive Refreshing Breeze", "Swift Refreshing Breeze")
 	.setModifiers({ name: "Quicken", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/refreshingbreeze-base.js
+++ b/source/gear/refreshingbreeze-base.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate(gearName,
 		})
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "ally" })
 	.setUpgrades("Accelerating Refereshing Breeze", "Supportive Refreshing Breeze", "Swift Refreshing Breeze")
 	.setDurability(15)
 	.setRnConfig({ debuffs: 1 });

--- a/source/gear/refreshingbreeze-supportive.js
+++ b/source/gear/refreshingbreeze-supportive.js
@@ -37,7 +37,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "ally" })
 	.setSidegrades("Accelerating Refreshing Breeze", "Swift Refreshing Breeze")
 	.setDurability(15)
 	.setStagger(-2)

--- a/source/gear/refreshingbreeze-swift.js
+++ b/source/gear/refreshingbreeze-swift.js
@@ -37,7 +37,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "ally" })
 	.setSidegrades("Accelerating Refreshing Breeze", "Supportive Refreshing Breeze")
 	.setDurability(15)
 	.setSpeed(2)

--- a/source/gear/riskymixture-base.js
+++ b/source/gear/riskymixture-base.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Risky Mixture",
 			return generateModifierResultLines(addModifier([target], poison));
 		}
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setUpgrades("Midas's Risky Mixture", "Potent Risky Mixture", "Thick Risky Mixture")
 	.setModifiers({ name: "Poison", stacks: 4 }, { name: "Regen", stacks: 4 })
 	.setDurability(15);

--- a/source/gear/riskymixture-midass.js
+++ b/source/gear/riskymixture-midass.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Midas's Risky Mixture",
 		}
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setSidegrades("Potent Risky Mixture", "Thick Risky Mixture")
 	.setModifiers({ name: "Poison", stacks: 4 }, { name: "Regen", stacks: 4 }, { name: "Curse of Midas", stacks: 1 })
 	.setDurability(15);

--- a/source/gear/riskymixture-potent.js
+++ b/source/gear/riskymixture-potent.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Potent Risky Mixture",
 			return generateModifierResultLines(addModifier([target], poison));
 		}
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setSidegrades("Midas's Risky Mixture", "Thick Risky Mixture")
 	.setModifiers({ name: "Poison", stacks: 6 }, { name: "Regen", stacks: 6 })
 	.setDurability(15);

--- a/source/gear/riskymixture-thick.js
+++ b/source/gear/riskymixture-thick.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Thick Risky Mixture",
 			return generateModifierResultLines(addModifier([target], poison));
 		}
 	}
-).setTargetingTags({ type: "single", team: "any", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "any" })
 	.setSidegrades("Potent Risky Mixture", "Midas's Risky Mixture")
 	.setModifiers({ name: "Poison", stacks: 4 }, { name: "Regen", stacks: 4 })
 	.setDurability(30);

--- a/source/gear/sabotagekit-base.js
+++ b/source/gear/sabotagekit-base.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate(gearName,
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setUpgrades("Potent Sabotage Kit", "Shattering Sabotage Kit", "Urgent Sabotage Kit")
-	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+	.setTargetingTags({ type: "single", team: "foe" })
 	.setModifiers({ name: "Slow", stacks: 2 }, { name: "unparsed random weakness", stacks: 3 })
 	.setBonus(2) // Crit Slow and Weakness stacks
 	.setDurability(15)

--- a/source/gear/sabotagekit-potent.js
+++ b/source/gear/sabotagekit-potent.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate(gearName,
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setSidegrades("Shattering Sabotage Kit", "Urgent Sabotage Kit")
-	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+	.setTargetingTags({ type: "single", team: "foe" })
 	.setModifiers({ name: "Slow", stacks: 3 }, { name: "unparsed random weakness", stacks: 4 })
 	.setBonus(2) // Crit Slow and Weakness stacks
 	.setDurability(15)

--- a/source/gear/sabotagekit-shattering.js
+++ b/source/gear/sabotagekit-shattering.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate(gearName,
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setSidegrades("Potent Sabotage Kit", "Urget Sabotage Kit")
-	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+	.setTargetingTags({ type: "single", team: "foe" })
 	.setModifiers({ name: "Slow", stacks: 2 }, { name: "unparsed random weakness", stacks: 3 }, { name: "Frail", stacks: 4 })
 	.setBonus(2) // Crit Slow and Weakness stacks
 	.setDurability(15)

--- a/source/gear/sabotagekit-urgent.js
+++ b/source/gear/sabotagekit-urgent.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate(gearName,
 		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}
 ).setSidegrades("Potent Sabotage Kit", "Shattering Sabotage Kit")
-	.setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+	.setTargetingTags({ type: "single", team: "foe" })
 	.setModifiers({ name: "Slow", stacks: 2 }, { name: "unparsed random weakness", stacks: 3 })
 	.setBonus(2) // Crit Slow and Weakness stacks
 	.setDurability(15)

--- a/source/gear/scarf-accurate.js
+++ b/source/gear/scarf-accurate.js
@@ -8,8 +8,6 @@ module.exports = new GearTemplate("Accurate Scarf",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Hearty Scarf", "Wise Scarf")
-	.setDurability(0)
+).setSidegrades("Hearty Scarf", "Wise Scarf")
 	.setSpeed(5)
 	.setCritRate(5);

--- a/source/gear/scarf-base.js
+++ b/source/gear/scarf-base.js
@@ -9,7 +9,5 @@ module.exports = new GearTemplate("Scarf",
 	"Untyped",
 	200,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setUpgrades("Accurate Scarf", "Hearty Scarf", "Wise Scarf")
-	.setDurability(0)
+).setUpgrades("Accurate Scarf", "Hearty Scarf", "Wise Scarf")
 	.setSpeed(5);

--- a/source/gear/scarf-hearty.js
+++ b/source/gear/scarf-hearty.js
@@ -8,8 +8,6 @@ module.exports = new GearTemplate("Hearty Scarf",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Accurate Scarf", "Wise Scarf")
-	.setDurability(0)
+).setSidegrades("Accurate Scarf", "Wise Scarf")
 	.setSpeed(5)
 	.setMaxHP(50);

--- a/source/gear/scarf-wise.js
+++ b/source/gear/scarf-wise.js
@@ -8,7 +8,5 @@ module.exports = new GearTemplate("Wise Scarf",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Accurate Scarf", "Hearty Scarf")
-	.setDurability(0)
+).setSidegrades("Accurate Scarf", "Hearty Scarf")
 	.setSpeed(5);

--- a/source/gear/scutum-base.js
+++ b/source/gear/scutum-base.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Scutum",
 		addProtection([target, user], pendingProtection);
 		return [`${target.name} and ${user.name} gain protection.`];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Guarding Scutum", "Lucky Scutum", "Sweeping Scutum")
 	.setDurability(15)
 	.setProtection(75);

--- a/source/gear/scutum-guarding.js
+++ b/source/gear/scutum-guarding.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Guarding Scutum",
 		addProtection([user], selfProtection);
 		return [`${target.name} and ${user.name} gain protection.`];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Lucky Scutum", "Sweeping Scutum")
 	.setDurability(15)
 	.setProtection(100)

--- a/source/gear/scutum-lucky.js
+++ b/source/gear/scutum-lucky.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Lucky Scutum",
 		addProtection([target, user], pendingProtection);
 		return [`${target.name} and ${user.name} gain protection.`, ...generateModifierResultLines(addModifier([user], lucky))];
 	}
-).setTargetingTags({ type: "single", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Guarding Scutum", "Sweeping Scutum")
 	.setModifiers({ name: "Lucky", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/scutum-sweeping.js
+++ b/source/gear/scutum-sweeping.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Sweeping Scutum",
 		addProtection([user, ...targets], pendingProtection);
 		return ["Everyone gains protection."];
 	}
-).setTargetingTags({ type: "all", team: "ally", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "ally" })
 	.setSidegrades("Guarding Scutum", "Lucky Scutum")
 	.setDurability(15)
 	.setProtection(75);

--- a/source/gear/scythe-base.js
+++ b/source/gear/scythe-base.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Scythe",
 			return [`${target.name} meets the reaper.`];
 		}
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Lethal Scythe", "Toxic Scythe", "Unstoppable Scythe")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/scythe-lethal.js
+++ b/source/gear/scythe-lethal.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Lethal Scythe",
 			return [`${target.name} meets the reaper.`];
 		}
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Toxic Scythe", "Unstoppable Scythe")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/scythe-toxic.js
+++ b/source/gear/scythe-toxic.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Toxic Scythe",
 			return [`${target.name} meets the reaper.`];
 		}
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Lethal Scythe", "Unstoppable Scythe")
 	.setModifiers({ name: "Poison", stacks: 3 })
 	.setDurability(15)

--- a/source/gear/scythe-unstoppable.js
+++ b/source/gear/scythe-unstoppable.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Unstoppable Scythe",
 			return [`${target.name} meets the reaper.`];
 		}
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Lethal Scythe", "Toxic Scythe")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/secondwind-base.js
+++ b/source/gear/secondwind-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Second Wind",
 		}
 		return [gainHealth(user, pendingHealing, adventure)];
 	}
-).setTargetingTags({ type: "self", team: "none", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Cleansing Second Wind", "Lucky Second Wind", "Soothing Second Wind")
 	.setDurability(10)
 	.setDamage(0);

--- a/source/gear/secondwind-cleansing.js
+++ b/source/gear/secondwind-cleansing.js
@@ -29,7 +29,7 @@ module.exports = new GearTemplate(gearName,
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "self", team: "none", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Lucky Second Wind", "Soothing Second Wind")
 	.setDurability(10)
 	.setDamage(0)

--- a/source/gear/secondwind-lucky.js
+++ b/source/gear/secondwind-lucky.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Lucky Second Wind",
 		}
 		return [gainHealth(user, pendingHealing, adventure), ...generateModifierResultLines(addModifier([user]), lucky)];
 	}
-).setTargetingTags({ type: "self", team: "none", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Cleansing Second Wind", "Soothing Second Wind")
 	.setModifiers({ name: "Lucky", stacks: 1 })
 	.setDurability(10)

--- a/source/gear/secondwind-soothing.js
+++ b/source/gear/secondwind-soothing.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Soothing Second Wind",
 		}
 		return [gainHealth(user, pendingHealing, adventure), ...generateModifierResultLines(addModifier([user], regen))];
 	}
-).setTargetingTags({ type: "self", team: "none", needsLivingTargets: true })
+).setTargetingTags({ type: "self", team: "ally" })
 	.setSidegrades("Cleansing Second Wind", "Lucky Second Wind")
 	.setDurability(10)
 	.setDamage(0)

--- a/source/gear/shortsword-accelerating.js
+++ b/source/gear/shortsword-accelerating.js
@@ -24,7 +24,7 @@ module.exports = new GearTemplate("Accelerating Shortsword",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user, ...stillLivingTargets], exposed), addModifier([user], quicken))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Lethal Shortsword", "Toxic Shortsword")
 	.setModifiers({ name: "Exposed", stacks: 1 }, { name: "Quicken", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/shortsword-base.js
+++ b/source/gear/shortsword-base.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Shortsword",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user, ...stillLivingTargets], exposed))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Accelerating Shortsword", "Lethal Shortsword", "Toxic Shortsword")
 	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/shortsword-lethal.js
+++ b/source/gear/shortsword-lethal.js
@@ -22,7 +22,7 @@ module.exports = new GearTemplate("Lethal Shortsword",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user, ...stillLivingTargets], exposed))));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Accelerating Shortsword", "Toxic Shortsword")
 	.setModifiers({ name: "Exposed", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/shortsword-toxic.js
+++ b/source/gear/shortsword-toxic.js
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Toxic Shortsword",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Accelerating Shortsword", "Lethal Shortsword")
 	.setModifiers({ name: "Exposed", stacks: 1 }, { name: "Poison", stacks: 3 })
 	.setDurability(15)

--- a/source/gear/shoulderthrow-base.js
+++ b/source/gear/shoulderthrow-base.js
@@ -32,7 +32,7 @@ module.exports = new GearTemplate("Shoulder Throw",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Evasive Shoulder Throw", "Harmful Shoulder Throw", "Staggering Shoulder Throw")
 	.setDurability(10)
 	.setModifiers({ name: "Evade", stacks: 1 });

--- a/source/gear/shoulderthrow-evasive.js
+++ b/source/gear/shoulderthrow-evasive.js
@@ -33,7 +33,7 @@ module.exports = new GearTemplate("Evasive Shoulder Throw",
 		}
 		return resultLines.concat(generateModifierResultLines(addModifier([user], pendingEvade)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Harmful Shoulder Throw", "Staggering Shoulder Throw")
 	.setDurability(10)
 	.setModifiers({ name: "Evade", stacks: 1 });

--- a/source/gear/shoulderthrow-harmful.js
+++ b/source/gear/shoulderthrow-harmful.js
@@ -34,7 +34,7 @@ module.exports = new GearTemplate("Harmful Shoulder Throw",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Evasive Shoulder Throw", "Staggering Shoulder Throw")
 	.setDurability(10)
 	.setModifiers({ name: "Evade", stacks: 1 })

--- a/source/gear/shoulderthrow-staggering.js
+++ b/source/gear/shoulderthrow-staggering.js
@@ -32,7 +32,7 @@ module.exports = new GearTemplate("Staggering Shoulder Throw",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Evasive Shoulder Throw", "Harmful Shoulder Throw")
 	.setDurability(10)
 	.setModifiers({ name: "Evade", stacks: 1 })

--- a/source/gear/spear-lethal.js
+++ b/source/gear/spear-lethal.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Lethal Spear",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Reactive Spear", "Sweeping Spear")
 	.setBonus(2) // Crit Stagger
 	.setDurability(15)

--- a/source/gear/spear-reactive.js
+++ b/source/gear/spear-reactive.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Reactive Spear",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Lethal Spear", "Sweeping Spear")
 	.setDurability(15)
 	.setDamage(65)

--- a/source/gear/spear-sweeping.js
+++ b/source/gear/spear-sweeping.js
@@ -26,7 +26,7 @@ module.exports = new GearTemplate("Sweeping Spear",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "all", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "all", team: "foe" })
 	.setSidegrades("Lethal Spear", "Reactive Spear")
 	.setStagger(2)
 	.setDurability(15)

--- a/source/gear/strongattack-base.js
+++ b/source/gear/strongattack-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Strong Attack",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Flanking Strong Attack", "Sharpened Strong Attack", "Staggering Strong Attack")
 	.setDurability(15)
 	.setDamage(65);

--- a/source/gear/strongattack-flanking.js
+++ b/source/gear/strongattack-flanking.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Flanking Strong Attack",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier(targets, exposed)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Sharpened Strong Attack", "Staggering Strong Attack")
 	.setModifiers({ name: "Exposed", stacks: 2 })
 	.setDurability(15)

--- a/source/gear/strongattack-sharpened.js
+++ b/source/gear/strongattack-sharpened.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Sharpened Strong Attack",
 		}
 		return dealDamage(targets, user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Flanking Strong Attack", "Staggering Strong Attack")
 	.setDurability(15)
 	.setDamage(90);

--- a/source/gear/strongattack-staggering.js
+++ b/source/gear/strongattack-staggering.js
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Staggering Strong Attack",
 		}
 		return resultLines;
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Flanking Strong Attack", "Sharpened Strong Attack")
 	.setDurability(15)
 	.setDamage(65)

--- a/source/gear/warcry-base.js
+++ b/source/gear/warcry-base.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate("War Cry",
 		changeStagger(targetArray, pendingStaggerStacks);
 		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered.")];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Charging War Cry", "Slowing War Cry", "Tormenting War Cry")
 	.setModifiers({ name: "Exposed", stacks: 0 })
 	.setStagger(2)

--- a/source/gear/warcry-charging.js
+++ b/source/gear/warcry-charging.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate("Charging War Cry",
 		changeStagger(targetArray, pendingStaggerStacks);
 		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered."), ...generateModifierResultLines(addModifier([user], powerup))];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Slowing War Cry", "Tormenting War Cry")
 	.setModifiers({ name: "Power Up", stacks: 25 }, { name: "Exposed", stacks: 0 })
 	.setStagger(2)

--- a/source/gear/warcry-slowing.js
+++ b/source/gear/warcry-slowing.js
@@ -35,7 +35,7 @@ module.exports = new GearTemplate("Slowing War Cry",
 		changeStagger(targetArray, pendingStaggerStacks);
 		return [joinAsStatement(false, [...targetSet], "was", "were", "Staggered."), ...generateModifierResultLines(combineModifierReceipts(addModifier(targetArray, slow))) ];
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Charging War Cry", "Tormenting War Cry")
 	.setModifiers({ name: "Slow", stacks: 1 }, { name: "Exposed", stacks: 0 })
 	.setStagger(2)

--- a/source/gear/warcry-tormenting.js
+++ b/source/gear/warcry-tormenting.js
@@ -45,7 +45,7 @@ module.exports = new GearTemplate("Tormenting War Cry",
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: false })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Charging War Cry", "Slowing War Cry")
 	.setModifiers({ name: "Exposed", stacks: 0 })
 	.setStagger(2)

--- a/source/gear/warhammer-base.js
+++ b/source/gear/warhammer-base.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Warhammer",
 		}
 		return dealDamage([target], user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Reactive Warhammer", "Slowing Warhammer", "Unstoppable Warhammer")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/warhammer-reactive.js
+++ b/source/gear/warhammer-reactive.js
@@ -30,7 +30,7 @@ module.exports = new GearTemplate("Reactive Warhammer",
 		}
 		return dealDamage([target], user, pendingDamage, false, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Slowing Warhammer", "Unstoppable Warhammer")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/warhammer-slowing.js
+++ b/source/gear/warhammer-slowing.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Slowing Warhammer",
 		}
 		return dealDamage([target], user, pendingDamage, false, element, adventure).concat(generateModifierResultLines(addModifier([target], slow)));
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Reactive Warhammer", "Unstoppable Warhammer")
 	.setModifiers({ name: "Slow", stacks: 1 })
 	.setDurability(15)

--- a/source/gear/warhammer-unstoppable.js
+++ b/source/gear/warhammer-unstoppable.js
@@ -23,7 +23,7 @@ module.exports = new GearTemplate("Unstoppable Warhammer",
 		}
 		return dealDamage([target], user, pendingDamage, true, element, adventure);
 	}
-).setTargetingTags({ type: "single", team: "foe", needsLivingTargets: true })
+).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Reactive Warhammer", "Slowing Warhammer")
 	.setDurability(15)
 	.setDamage(40)

--- a/source/gear/wolfring-base.js
+++ b/source/gear/wolfring-base.js
@@ -8,7 +8,5 @@ module.exports = new GearTemplate("Wolf Ring",
 	"Untyped",
 	200,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setUpgrades("Surpassing Wolf Ring", "Swift Wolf Ring", "Wise Wolf Ring")
-	.setDurability(0)
+).setUpgrades("Surpassing Wolf Ring", "Swift Wolf Ring", "Wise Wolf Ring")
 	.setPoise(2);

--- a/source/gear/wolfring-surpassing.js
+++ b/source/gear/wolfring-surpassing.js
@@ -9,8 +9,6 @@ module.exports = new GearTemplate("Surpassing Wolf Ring",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Swift Wolf Ring", "Wise Wolf Ring")
-	.setDurability(0)
+).setSidegrades("Swift Wolf Ring", "Wise Wolf Ring")
 	.setPoise(2)
 	.setBonus(SURPASSING_VALUE);

--- a/source/gear/wolfring-swift.js
+++ b/source/gear/wolfring-swift.js
@@ -8,8 +8,6 @@ module.exports = new GearTemplate("Swift Wolf Ring",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Surpassing Wolf Ring", "Wise Wolf Ring")
-	.setDurability(0)
+).setSidegrades("Surpassing Wolf Ring", "Wise Wolf Ring")
 	.setPoise(2)
 	.setSpeed(5);

--- a/source/gear/wolfring-wise.js
+++ b/source/gear/wolfring-wise.js
@@ -8,7 +8,5 @@ module.exports = new GearTemplate("Wise Wolf Ring",
 	"Untyped",
 	350,
 	(targets, user, adventure) => []
-).setTargetingTags({ type: "none", team: "none", needsLivingTargets: false })
-	.setSidegrades("Surpassing Wolf Ring", "Swift Wolf Ring")
-	.setDurability(0)
+).setSidegrades("Surpassing Wolf Ring", "Swift Wolf Ring")
 	.setPoise(2);

--- a/source/items/_item_blueprint.js
+++ b/source/items/_item_blueprint.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("name",
 	(self, adventure) => {
 		return [[self.team, adventure.getCombatantIndex(self)]];
 	},
-	false,
 	(targets, user, adventure) => {
 		return []; // see style guide for conventions on result texts
 	}

--- a/source/items/clearpotion.js
+++ b/source/items/clearpotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Clear Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Untyped Absorb", stacks: 3 }));
 	}

--- a/source/items/earthenpotion.js
+++ b/source/items/earthenpotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Earthen Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Earth Absorb", stacks: 3 }));
 	}

--- a/source/items/explosionpotion.js
+++ b/source/items/explosionpotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Explosion Potion",
 	"Untyped",
 	30,
 	selectAllFoes,
-	true,
 	(targets, user, adventure) => {
 		return dealDamage(targets, user, 75, false, "Untyped", adventure);
 	}

--- a/source/items/fierypotion.js
+++ b/source/items/fierypotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Fiery Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Fire Absorb", stacks: 3 }));
 	}

--- a/source/items/glowingpotion.js
+++ b/source/items/glowingpotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Glowing Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Light Absorb", stacks: 3 }));
 	}

--- a/source/items/healthpotion.js
+++ b/source/items/healthpotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Health Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return [gainHealth(user, Math.floor(user.getMaxHP() * 0.25), adventure)];
 	}

--- a/source/items/inkypotion.js
+++ b/source/items/inkypotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Inky Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Darkness Absorb", stacks: 3 }));
 	}

--- a/source/items/oblivionsalt.js
+++ b/source/items/oblivionsalt.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Salt of Oblivion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Oblivious", stacks: 1 }));
 	}

--- a/source/items/panacea.js
+++ b/source/items/panacea.js
@@ -11,7 +11,6 @@ module.exports = new ItemTemplate(itemName,
 	(self, adventure) => {
 		return [[self.team, adventure.getCombatantIndex(self)]];
 	},
-	false,
 	(targets, user, adventure) => {
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => isDebuff(modifier));
 		const debuffsToRemove = Math.min(userDebuffs.length, 2);

--- a/source/items/placebo.js
+++ b/source/items/placebo.js
@@ -6,7 +6,6 @@ module.exports = new ItemTemplate("Placebo",
 	"Untyped",
 	30,
 	selectNone,
-	false,
 	(targets, user, adventure) => {
 		adventure.score += 25;
 		return ["This adventure's score will be increased by 25."];

--- a/source/items/protectionpotion.js
+++ b/source/items/protectionpotion.js
@@ -8,7 +8,6 @@ module.exports = new ItemTemplate("Protection Potion",
 	"Untyped",
 	30,
 	selectAllAllies,
-	false,
 	(targets, user, adventure) => {
 		addProtection(targets, 50);
 		return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection.")];

--- a/source/items/quickpepper.js
+++ b/source/items/quickpepper.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Quick Pepper",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Quicken", stacks: 3 }));
 	}

--- a/source/items/regenroot.js
+++ b/source/items/regenroot.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Regen Root",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Regen", stacks: 5 }));
 	}

--- a/source/items/repairkit.js
+++ b/source/items/repairkit.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Repair Kit",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		user.gear.forEach((gear) => {
 			/** @type {number} */

--- a/source/items/smokebomb.js
+++ b/source/items/smokebomb.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Smoke Bomb",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Evade", stacks: 2 }));
 	}

--- a/source/items/stasisquartz.js
+++ b/source/items/stasisquartz.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Stasis Quartz",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Retain", stacks: 1 }));
 	}

--- a/source/items/strengthspinach.js
+++ b/source/items/strengthspinach.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Strength Spinach",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Power Up", stacks: 50 }));
 	}

--- a/source/items/vitamins.js
+++ b/source/items/vitamins.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Vitamins",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		const gains = 50;
 		user.maxHP += gains;

--- a/source/items/waterypotion.js
+++ b/source/items/waterypotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Watery Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Water Absorb", stacks: 3 }));
 	}

--- a/source/items/windypotion.js
+++ b/source/items/windypotion.js
@@ -7,7 +7,6 @@ module.exports = new ItemTemplate("Windy Potion",
 	"Untyped",
 	30,
 	selectSelf,
-	false,
 	(targets, user, adventure) => {
 		return generateModifierResultLines(addModifier([user], { name: "Wind Absorb", stacks: 3 }));
 	}

--- a/source/shared/actionComponents.js
+++ b/source/shared/actionComponents.js
@@ -81,7 +81,14 @@ function selectAllFoes(self, adventure) {
  */
 function selectRandomFoe(self, adventure) {
 	if (self.team === "delver") {
-		return [new CombatantReference("enemy", adventure.generateRandomNumber(adventure.room.enemies.length, "battle"))];
+		const livingEnemyIndicies = [];
+		for (let i = 0; i < adventure.room.enemies.length; i++) {
+			if (enemy.hp > 0) {
+				livingEnemyIndicies.push(i);
+			}
+		}
+		// If there are no living enemies, combat should already be over
+		return [new CombatantReference("enemy", livingEnemyIndicies[adventure.generateRandomNumber(livingEnemyIndicies.length, "battle")])];
 	} else {
 		return [new CombatantReference("delver", adventure.generateRandomNumber(adventure.delvers.length, "battle"))];
 	}


### PR DESCRIPTION
Summary
-------
- fix target all moves reporting enemies already who were already dead before the round's move resolutions as already dead
- remove targetingTags and durability from passive only gear (unused)
- fix Second Winds not calculating same element stagger relief

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Poison Torrent skips targeting/noting enemies that were already dead at beginning of round

Issue
-----
Closes #401