### PR TITLE
#420: add confirmation messages on gear acquisition and merchant purchases

### DIFF
--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -95,13 +95,13 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 	},
 	{
 		// Labyrinth Particulars - more customized
-		"Event": ["Door 1 or Door 2?"],
-		"Battle": ["Frog Ranch", "Wild Fire-Arrow Frogs", "Meteor Knight Fight"],
+		"Event": ["Apple Pie Wishing Well", "Door 1 or Door 2?", "Free Gold?", "Gear Collector", "Imp Contract Faire", "Repair Kit, just hanging out", "The Score Beggar", "Twin Pedestals", "Workshop", "Merchant", "Rest Site", "Treasure"],
+		"Battle": ["Hawk Fight", "Frog Ranch", "Wild Fire-Arrow Frogs", "Mechabee Fight", "Slime Fight", "Tortoise Fight", "Meteor Knight Fight"],
 		"Artifact Guardian": ["A Slimy Throneroom", "A windfall of treasure!"],
-		"Final Battle": ["Hall of Mirrors"],
+		"Final Battle": ["A Northern Laboratory", "Hall of Mirrors", "The Hexagon: Bee Mode", "The Hexagon: Mech Mode", "Confronting the Top Celestial Knight"],
 
 		// Labyrinth Infrastructure - less customized
-		"Merchant": ["Gear Buying Merchant"],
+		"Merchant": ["Gear Merchant", "Item Merchant", "Overpriced Merchant", "Gear Buying Merchant"],
 		"Rest Site": ["Rest Site: Mysterious Challenger", "Rest Site: Training Dummy"],
 		"Workshop": ["Abandoned Forge", "Workshop with Black Box", "Tanning Workshop"],
 		"Treasure": ["Treasure! Artifact or Gear?", "Treasure! Artifact or Gold?", "Treasure! Artifact or Items?", "Treasure! Gear or Items?", "Treasure! Gold or Gear?", "Treasure! Gold or Items?"],

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -2,7 +2,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
@@ -25,7 +25,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
 					options.push({
-						label: `${name} x ${count}`,
+						label: `${type !== "Gear" ? `${getNumberEmoji(1)} ` : ""}${name} x ${count}`,
 						description: type,
 						value: `${name}${SAFE_DELIMITER}${options.length}`
 					});

--- a/source/rooms/treasure-artifactvsgold.js
+++ b/source/rooms/treasure-artifactvsgold.js
@@ -4,7 +4,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 	"@{adventure}",
@@ -26,7 +26,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
 					options.push({
-						label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+						label: type === "Currency" ? `${getNumberEmoji(1)} ${count} ${name}` : `${getNumberEmoji(1)} ${name} x ${count}`,
 						description: type,
 						value: `${name}${SAFE_DELIMITER}${options.length}`
 					});

--- a/source/rooms/treasure-artifactvsitems.js
+++ b/source/rooms/treasure-artifactvsitems.js
@@ -4,7 +4,7 @@ const { RoomTemplate, ResourceTemplate } = require("../classes");
 
 const { EMPTY_SELECT_OPTION_SET, SAFE_DELIMITER } = require("../constants");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 	"@{adventure}",
@@ -26,7 +26,7 @@ module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
 					options.push({
-						label: `${name} x ${count}`,
+						label: `${getNumberEmoji(1)} ${name} x ${count}`,
 						description: type,
 						value: `${name}${SAFE_DELIMITER}${options.length}`
 					});

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -3,7 +3,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gear or Items?",
@@ -26,7 +26,7 @@ module.exports = new RoomTemplate("Treasure! Gear or Items?",
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
 					options.push({
-						label: `${name} x ${count}`,
+						label: `${type !== "Gear" ? `${getNumberEmoji(1)} ` : ""}${name} x ${count}`,
 						description: type,
 						value: `${name}${SAFE_DELIMITER}${options.length}`
 					});

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -3,7 +3,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Gear?",
@@ -26,7 +26,7 @@ module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
 					options.push({
-						label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+						label: type === "Currency" ? `${getNumberEmoji(1)} ${count} ${name}` : `${name} x ${count}`,
 						description: type,
 						value: `${name}${SAFE_DELIMITER}${options.length}`
 					});

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -3,7 +3,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { RoomTemplate, ResourceTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
 module.exports = new RoomTemplate("Treasure! Gold or Items?",
@@ -26,7 +26,7 @@ module.exports = new RoomTemplate("Treasure! Gold or Items?",
 			for (const { name, type, count, visibility } of Object.values(adventure.room.resources)) {
 				if (visibility === "always" && count > 0) {
 					options.push({
-						label: type === "Currency" ? `${count} ${name}` : `${name} x ${count}`,
+						label: type === "Currency" ? `${getNumberEmoji(1)} ${count} ${name}` : `${getNumberEmoji(1)} ${name} x ${count}`,
 						description: type,
 						value: `${name}${SAFE_DELIMITER}${options.length}`
 					});

--- a/source/selects/buygear.js
+++ b/source/selects/buygear.js
@@ -1,9 +1,10 @@
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, bold } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, bold, EmbedBuilder } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require('../constants');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
-const { buildGearRecord } = require('../gear/_gearDictionary');
-const { renderRoom } = require('../util/embedUtil');
+const { buildGearRecord, getGearProperty } = require('../gear/_gearDictionary');
+const { renderRoom, randomAuthorTip, gearToEmbedField } = require('../util/embedUtil');
+const { getColor } = require('../util/elementUtil');
 
 const mainId = "buygear";
 module.exports = new SelectWrapper(mainId, 3000,
@@ -28,59 +29,76 @@ module.exports = new SelectWrapper(mainId, 3000,
 			return;
 		}
 
-		if (delver.gear.length < adventure.getGearCapacity()) {
-			adventure.gold -= cost;
-			adventure.room.decrementResource(name, 1);
-			delver.gear.push(buildGearRecord(name, adventure));
-			if (delver.hp > delver.getMaxHP()) {
-				delver.hp = delver.getMaxHP();
-			}
-			interaction.message.edit(renderRoom(adventure, interaction.channel));
-			interaction.reply({ content: `${interaction.member.displayName} buys a ${name} for ${cost}g.` });
-			setAdventure(adventure);
+		const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
+		let durability = getGearProperty(name, "maxDurability");
+		const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Craftsmanship");
+		if (shoddyPenalty) {
+			durability = Math.ceil(durability * (100 - shoddyPenalty) / 100);
+		}
+		const embed = new EmbedBuilder().setColor(getColor(adventure.room.element))
+			.setAuthor(randomAuthorTip())
+			.setTitle("Buy this gear?")
+			.addFields(gearToEmbedField(name, durability, delver));
+		const components = [];
+		if (hasFreeGearSlots) {
+			components.push(
+				new ActionRowBuilder().addComponents(
+					new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}buy${SAFE_DELIMITER}${adventure.depth}`)
+						.setStyle(ButtonStyle.Success)
+						.setLabel(`Buy: ${cost}g`)
+				)
+			);
 		} else {
-			interaction.reply({
-				content: `You can only carry ${adventure.getGearCapacity()} pieces of gear at a time. Pick one to replace:`,
-				components: [new ActionRowBuilder().addComponents(
-					delver.gear.map((gear, index) => {
-						return new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${adventure.depth}${SAFE_DELIMITER}${index}`)
-							.setLabel(`Discard ${gear.name}`)
-							.setStyle(ButtonStyle.Secondary)
-					})
-				)],
-				ephemeral: true,
-				fetchReply: true
-			}).then(reply => {
-				const collector = reply.createMessageComponentCollector({ max: 1 });
-				collector.on("collect", collectedInteraction => {
-					const [_, startedDepth, gearIndex] = collectedInteraction.customId.split(SAFE_DELIMITER);
-					const adventure = getAdventure(collectedInteraction.channelId);
-					const { count, cost } = adventure.room.resources[name];
-					if (count < 1 || startedDepth !== adventure.depth.toString()) {
-						return;
-					}
-
-					const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
-					const discardedName = delver.gear[gearIndex].name;
-					delver.gear.splice(gearIndex, 1, buildGearRecord(name, adventure));
-					if (delver.hp > delver.getMaxHP()) {
-						delver.hp = delver.getMaxHP();
-					}
-					collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
-						adventure.room.decrementResource(name, 1);
-						adventure.gold -= cost;
-						return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
-					}).then(() => {
-						collectedInteraction.channel.send(`${bold(collectedInteraction.member.displayName)} buys a ${name} for ${cost}g (${discardedName} discarded).`);
-						setAdventure(adventure);
-					})
+			embed.addFields({ name: "Replacing Gear", value: `You can only carry ${adventure.getGearCapacity()} pieces of gear at a time. You'll have to discard gear you're holding to buy this new one.` })
+			components.push(new ActionRowBuilder().addComponents(
+				delver.gear.map((gear, index) => {
+					return new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}replace${SAFE_DELIMITER}${adventure.depth}${SAFE_DELIMITER}${index}`)
+						.setStyle(ButtonStyle.Secondary)
+						.setLabel(`Replace: ${gear.name}`)
 				})
+			));
+		}
+		interaction.reply({
+			embeds: [embed],
+			components,
+			ephemeral: true,
+			fetchReply: true
+		}).then(reply => {
+			const collector = reply.createMessageComponentCollector({ max: 1 });
+			collector.on("collect", collectedInteraction => {
+				const [mainId, startedDepth, gearIndex] = collectedInteraction.customId.split(SAFE_DELIMITER);
+				const adventure = getAdventure(collectedInteraction.channelId);
+				const { count, cost } = adventure.room.resources[name];
+				if (count < 1 || startedDepth !== adventure.depth.toString()) {
+					return;
+				}
 
-				collector.on("end", async (interactionCollection) => {
-					await interactionCollection.first().update({ components: [] });
-					interaction.deleteReply();
+				const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
+				const gearRecord = buildGearRecord(name, adventure);
+				let discardedName;
+				if (mainId.endsWith("replace")) {
+					discardedName = delver.gear[gearIndex].name;
+					delver.gear.splice(gearIndex, 1, gearRecord);
+				} else {
+					delver.gear.push(gearRecord);
+				}
+				if (delver.hp > delver.getMaxHP()) {
+					delver.hp = delver.getMaxHP();
+				}
+				collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
+					adventure.room.decrementResource(name, 1);
+					adventure.gold -= cost;
+					return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
+				}).then(() => {
+					collectedInteraction.channel.send(`${bold(collectedInteraction.member.displayName)} buys a ${name} for ${cost}g${discardedName ? ` (${discardedName} discarded)` : ""}.`);
+					setAdventure(adventure);
 				})
 			})
-		}
+
+			collector.on("end", async (interactionCollection) => {
+				await interactionCollection.first().update({ components: [] });
+				interaction.deleteReply();
+			})
+		});
 	}
 );

--- a/source/selects/buyitem.js
+++ b/source/selects/buyitem.js
@@ -1,7 +1,11 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const { SelectWrapper } = require('../classes');
-const { SAFE_DELIMITER } = require('../constants');
+const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require('../constants');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
-const { renderRoom } = require('../util/embedUtil');
+const { renderRoom, randomAuthorTip } = require('../util/embedUtil');
+const { getColor } = require('../util/elementUtil');
+const { getItem } = require('../items/_itemDictionary');
+const { injectApplicationEmojiMarkdown } = require('../util/graphicsUtil');
 
 const mainId = "buyitem";
 module.exports = new SelectWrapper(mainId, 3000,
@@ -25,11 +29,36 @@ module.exports = new SelectWrapper(mainId, 3000,
 			return;
 		}
 
-		adventure.gold -= cost;
-		adventure.room.decrementResource(name, 1);
-		adventure.gainItem(name, 1);
-		interaction.message.edit(renderRoom(adventure, interaction.channel));
-		interaction.reply({ content: `${interaction.member.displayName} buys a ${name} for ${cost}g.` });
-		setAdventure(adventure);
+		const embed = new EmbedBuilder().setColor(getColor(adventure.room.element))
+			.setAuthor(randomAuthorTip())
+			.setTitle("Buy this item?")
+			.addFields({ name, value: injectApplicationEmojiMarkdown(getItem(name).description) });
+		interaction.reply({
+			embeds: [embed],
+			components: [
+				new ActionRowBuilder().addComponents(
+					new ButtonBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
+						.setStyle(ButtonStyle.Success)
+						.setLabel(`Buy: ${cost}g`)
+				)
+			],
+			ephemeral: true,
+			fetchReply: true
+		}).then(reply => {
+			const collector = reply.createMessageComponentCollector({ max: 1 });
+			collector.on("collect", collectedInteraction => {
+				adventure.gold -= cost;
+				adventure.room.decrementResource(name, 1);
+				adventure.gainItem(name, 1);
+				interaction.message.edit(renderRoom(adventure, interaction.channel));
+				collectedInteraction.channel.send({ content: `${interaction.member.displayName} buys a ${name} for ${cost}g.` });
+				setAdventure(adventure);
+			})
+
+			collector.on("end", async (interactionCollection) => {
+				await interactionCollection.first().update({ components: [] });
+				interaction.deleteReply();
+			})
+		})
 	}
 );

--- a/source/selects/loot.js
+++ b/source/selects/loot.js
@@ -1,9 +1,10 @@
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
-const { buildGearRecord } = require('../gear/_gearDictionary');
+const { buildGearRecord, getGearProperty } = require('../gear/_gearDictionary');
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITESPACE } = require('../constants');
-const { renderRoom } = require('../util/embedUtil');
+const { renderRoom, randomAuthorTip, gearToEmbedField } = require('../util/embedUtil');
+const { getColor } = require('../util/elementUtil');
 
 const mainId = "loot";
 module.exports = new SelectWrapper(mainId, 2000,
@@ -22,93 +23,105 @@ module.exports = new SelectWrapper(mainId, 2000,
 			return;
 		}
 
-		let result;
 		const { type, count } = adventure.room.resources[name];
 		switch (type) {
 			case "Currency":
 				adventure.gainGold(count);
 				delete adventure.room.resources[name];
-				result = {
-					content: `The party acquires ${count} gold.`
-				}
+				setAdventure(adventure);
+				interaction.reply({ content: `The party acquires ${count} gold.` }).then(() => {
+					interaction.message.edit(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				});
 				break;
 			case "Artifact":
 				adventure.gainArtifact(name, count);
 				delete adventure.room.resources[name];
-				result = {
-					content: `The party acquires ${count} ${name}.`
-				}
+				setAdventure(adventure);
+				interaction.reply({ content: `The party acquires ${count} ${name}.` }).then(() => {
+					interaction.message.edit(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				});
 				break;
 			case "Gear":
-				if (delver.gear.length >= adventure.getGearCapacity()) {
-					interaction.reply({
-						content: `You can only carry ${adventure.getGearCapacity()} pieces of gear at a time. Pick one to replace with the ${name}:`,
-						components: [new ActionRowBuilder().addComponents(delver.gear.map((gear, index) => {
-							return new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${adventure.depth}${SAFE_DELIMITER}${index}`)
-								.setLabel(`Discard ${gear.name}`)
+				const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
+				let durability = getGearProperty(name, "maxDurability");
+				const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Craftsmanship");
+				if (shoddyPenalty) {
+					durability = Math.ceil(durability * (100 - shoddyPenalty) / 100);
+				}
+				const embed = new EmbedBuilder().setColor(getColor(adventure.room.element))
+					.setAuthor(randomAuthorTip())
+					.setTitle("Take this gear?")
+					.addFields(gearToEmbedField(name, durability, delver));
+				const components = [];
+				if (hasFreeGearSlots) {
+					components.push(
+						new ActionRowBuilder().addComponents(
+							new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}take${SAFE_DELIMITER}${adventure.depth}`)
+								.setStyle(ButtonStyle.Success)
+								.setLabel(`Take: ${name}`)
+						)
+					);
+				} else {
+					embed.addFields({ name: "Replacing Gear", value: `You can only carry ${adventure.getGearCapacity()} pieces of gear at a time. You'll have to discard gear you're holding to buy this new one.` })
+					components.push(new ActionRowBuilder().addComponents(
+						delver.gear.map((gear, index) => {
+							return new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}replace${SAFE_DELIMITER}${adventure.depth}${SAFE_DELIMITER}${index}`)
 								.setStyle(ButtonStyle.Secondary)
-						}))],
-						ephemeral: true,
-						fetchReply: true
-					}).then(reply => {
-						const collector = reply.createMessageComponentCollector({ max: 1 });
-						collector.on("collect", collectedInteraction => {
-							const [_, startedDepth, gearIndex] = collectedInteraction.customId.split(SAFE_DELIMITER);
-							const adventure = getAdventure(collectedInteraction.channelId);
-							if (adventure.room.resources[name].count < 1 || startedDepth !== adventure.depth.toString()) {
-								return;
-							}
-
-							const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
-							const discardedName = delver.gear[gearIndex].name;
-							delver.gear.splice(gearIndex, 1, buildGearRecord(name, adventure));
-							if (delver.hp > delver.getMaxHP()) {
-								delver.hp = delver.getMaxHP();
-							}
-							collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
-								adventure.room.decrementResource(name, 1);
-								return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
-							}).then(() => {
-								collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}** takes a ${name} (${discardedName} discarded).`);
-								setAdventure(adventure);
-							})
+								.setLabel(`Replace: ${gear.name}`)
 						})
+					));
+				}
+				interaction.reply({
+					embeds: [embed],
+					components,
+					ephemeral: true,
+					fetchReply: true
+				}).then(reply => {
+					const collector = reply.createMessageComponentCollector({ max: 1 });
+					collector.on("collect", collectedInteraction => {
+						const [mainId, startedDepth, gearIndex] = collectedInteraction.customId.split(SAFE_DELIMITER);
+						const adventure = getAdventure(collectedInteraction.channelId);
+						const { count } = adventure.room.resources[name];
+						if (count < 1 || startedDepth !== adventure.depth.toString()) {
+							return;
+						}
 
-						collector.on("end", async (interactionCollection) => {
-							await interactionCollection.first().update({ components: [] });
-							interaction.deleteReply();
+						const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
+						const gearRecord = buildGearRecord(name, adventure);
+						let discardedName;
+						if (mainId.endsWith("replace")) {
+							discardedName = delver.gear[gearIndex].name;
+							delver.gear.splice(gearIndex, 1, gearRecord);
+						} else {
+							delver.gear.push(gearRecord);
+						}
+						if (delver.hp > delver.getMaxHP()) {
+							delver.hp = delver.getMaxHP();
+						}
+						adventure.room.decrementResource(name, 1);
+						interaction.message.edit(renderRoom(adventure, collectedInteraction.channel)).then(() => {
+							collectedInteraction.channel.send({ content: `${interaction.member.displayName} takes a ${name}${discardedName ? ` (${discardedName} discarded)` : ""}. There are ${count - 1} remaining.` });
+							setAdventure(adventure);
 						})
 					})
-					return;
-				} else {
-					delver.gear.push(buildGearRecord(name, adventure));
-					if (delver.hp > delver.getMaxHP()) {
-						delver.hp = delver.getMaxHP();
-					}
-					if (adventure.room.resources[name].count > 1) {
-						adventure.room.resources[name].count--;
-					} else {
-						delete adventure.room.resources[name];
-					}
-					result = {
-						content: `${interaction.member.displayName} takes a ${name}. There are ${count - 1} remaining.`
-					}
-				}
+
+					collector.on("end", async (interactionCollection) => {
+						await interactionCollection.first().update({ components: [] });
+						interaction.deleteReply();
+					})
+				});
 				break;
 			case "Item":
 				adventure.gainItem(name, count);
 				delete adventure.room.resources[name];
-				result = {
-					content: `The party acquires ${count} ${name}.`
-				}
+				setAdventure(adventure);
+				interaction.reply({ content: `The party acquires ${count} ${name}.` }).then(() => {
+					interaction.message.edit(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				});
 				break;
 			default:
 				interaction.update({ content: ZERO_WIDTH_WHITESPACE });
 				return;
 		}
-		setAdventure(adventure);
-		interaction.reply(result).then(() => {
-			interaction.message.edit(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
-		});
 	}
 );

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -1,9 +1,11 @@
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, bold } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
-const { buildGearRecord } = require('../gear/_gearDictionary');
+const { buildGearRecord, getGearProperty } = require('../gear/_gearDictionary');
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITESPACE } = require('../constants');
-const { renderRoom } = require('../util/embedUtil');
+const { renderRoom, randomAuthorTip, gearToEmbedField } = require('../util/embedUtil');
+const { getColor } = require('../util/elementUtil');
+const { getNumberEmoji } = require('../util/textUtil');
 
 const mainId = "treasure";
 module.exports = new SelectWrapper(mainId, 2000,
@@ -32,75 +34,103 @@ module.exports = new SelectWrapper(mainId, 2000,
 			case "Currency":
 				adventure.gainGold(count);
 				delete adventure.room.resources[name];
+				adventure.room.actions--;
+				adventure.room.history["Treasure picked"].push(name);
+				setAdventure(adventure);
+				interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
 				break;
 			case "Artifact":
 				adventure.gainArtifact(name, count);
 				delete adventure.room.resources[name];
-				break;
-			case "Gear":
-				if (delver.gear.length >= adventure.getGearCapacity()) {
-					interaction.reply({
-						content: `You can only carry ${adventure.getGearCapacity()} pieces of gear at a time. Pick one to replace with the ${name}:`,
-						components: [new ActionRowBuilder().addComponents(delver.gear.map((gear, index) => {
-							return new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${adventure.depth}${SAFE_DELIMITER}${index}`)
-								.setLabel(`Discard ${gear.name}`)
-								.setStyle(ButtonStyle.Secondary)
-						}))],
-						ephemeral: true,
-						fetchReply: true
-					}).then(reply => {
-						const collector = reply.createMessageComponentCollector({ max: 1 });
-						collector.on("collect", collectedInteraction => {
-							const [_, startedDepth, gearIndex] = collectedInteraction.customId.split(SAFE_DELIMITER);
-							const adventure = getAdventure(collectedInteraction.channelId);
-							if (adventure.room.resources[name].count < 1 || startedDepth !== adventure.depth.toString()) {
-								return;
-							}
-
-							const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
-							const discardedName = delver.gear[gearIndex].name;
-							delver.gear.splice(gearIndex, 1, buildGearRecord(name, adventure));
-							if (delver.hp > delver.getMaxHP()) {
-								delver.hp = delver.getMaxHP();
-							}
-							collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
-								adventure.room.actions--;
-								adventure.room.decrementResource(name, 1);
-								adventure.room.history["Treasure picked"].push(name);
-								return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
-							}).then(() => {
-								collectedInteraction.channel.send(`**${collectedInteraction.member.displayName}** takes a ${name} (${discardedName} discarded).`);
-								setAdventure(adventure);
-							})
-						})
-
-						collector.on("end", async (interactionCollection) => {
-							await interactionCollection.first().update({ components: [] });
-							interaction.deleteReply();
-						})
-					})
-					return;
-				} else {
-					delver.gear.push(buildGearRecord(name, adventure));
-					if (delver.hp > delver.getMaxHP()) {
-						delver.hp = delver.getMaxHP();
-					}
-					if (adventure.room.resources[name].count > 1) {
-						adventure.room.resources[name].count--;
-					} else {
-						delete adventure.room.resources[name];
-					}
-					interaction.channel.send({ content: `${interaction.member.displayName} takes a ${name}. There are ${count - 1} remaining.` });
-				}
+				adventure.room.actions--;
+				adventure.room.history["Treasure picked"].push(name);
+				setAdventure(adventure);
+				interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
 				break;
 			case "Item":
 				adventure.gainItem(name, count);
 				delete adventure.room.resources[name];
+				adventure.room.actions--;
+				adventure.room.history["Treasure picked"].push(name);
+				setAdventure(adventure);
+				interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				break;
+			case "Gear":
+				const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
+				let durability = getGearProperty(name, "maxDurability");
+				const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Craftsmanship");
+				if (shoddyPenalty) {
+					durability = Math.ceil(durability * (100 - shoddyPenalty) / 100);
+				}
+				const embed = new EmbedBuilder().setColor(getColor(adventure.room.element))
+					.setAuthor(randomAuthorTip())
+					.setTitle("Pick this gear?")
+					.addFields(gearToEmbedField(name, durability, delver));
+				const components = [];
+				if (hasFreeGearSlots) {
+					components.push(
+						new ActionRowBuilder().addComponents(
+							new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}take${SAFE_DELIMITER}${adventure.depth}`)
+								.setStyle(ButtonStyle.Success)
+								.setEmoji(getNumberEmoji(1))
+								.setLabel(`Pick: ${name}`)
+						)
+					);
+				} else {
+					embed.addFields({ name: "Replacing Gear", value: `You can only carry ${adventure.getGearCapacity()} pieces of gear at a time. You'll have to discard gear you're holding to buy this new one.` })
+					components.push(new ActionRowBuilder().addComponents(
+						delver.gear.map((gear, index) => {
+							return new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}replace${SAFE_DELIMITER}${adventure.depth}${SAFE_DELIMITER}${index}`)
+								.setStyle(ButtonStyle.Secondary)
+								.setEmoji(getNumberEmoji(1))
+								.setLabel(`Replace: ${gear.name}`)
+						})
+					));
+				}
+				interaction.reply({
+					embeds: [embed],
+					components,
+					ephemeral: true,
+					fetchReply: true
+				}).then(reply => {
+					const collector = reply.createMessageComponentCollector({ max: 1 });
+					collector.on("collect", collectedInteraction => {
+						const [mainId, startedDepth, gearIndex] = collectedInteraction.customId.split(SAFE_DELIMITER);
+						const adventure = getAdventure(collectedInteraction.channelId);
+						const { count } = adventure.room.resources[name];
+						if (count < 1 || startedDepth !== adventure.depth.toString()) {
+							return;
+						}
+
+						const delver = adventure.delvers.find(delver => delver.id === collectedInteraction.user.id);
+						const gearRecord = buildGearRecord(name, adventure);
+						let discardedName;
+						if (mainId.endsWith("replace")) {
+							discardedName = delver.gear[gearIndex].name;
+							delver.gear.splice(gearIndex, 1, gearRecord);
+						} else {
+							delver.gear.push(gearRecord);
+						}
+						if (delver.hp > delver.getMaxHP()) {
+							delver.hp = delver.getMaxHP();
+						}
+						collectedInteraction.channel.messages.fetch(adventure.messageIds.room).then(roomMessage => {
+							adventure.room.actions--;
+							adventure.room.decrementResource(name, 1);
+							adventure.room.history["Treasure picked"].push(name);
+							return roomMessage.edit(renderRoom(adventure, collectedInteraction.channel));
+						}).then(() => {
+							collectedInteraction.channel.send(`${bold(collectedInteraction.member.displayName)} takes a ${name}${discardedName ? ` (${discardedName} discarded)` : ""}.`);
+							setAdventure(adventure);
+						})
+					})
+
+					collector.on("end", async (interactionCollection) => {
+						await interactionCollection.first().update({ components: [] });
+						interaction.deleteReply();
+					})
+				});
 				break;
 		}
-		adventure.room.actions--;
-		adventure.room.history["Treasure picked"].push(name);
-		setAdventure(adventure);
-		interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
 	}
 );

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -376,7 +376,7 @@ function generateArtifactEmbed(artifactTemplate, count, adventure) {
 	return embed;
 }
 
-/** Seen in target selection embeds and /inspect-self gear fields contain nearly all information about the gear they represent
+/** Seen in /inspect-self, gear fields contain nearly all information about the gear they represent
  * @param {string} gearName
  * @param {number} durability
  * @param {Delver} holder


### PR DESCRIPTION
Summary
-------
- add confirmation messages on gear acquisition and merchant purchases

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] tested merchants, loot, and treasure individually

Issue
-----
Closes #420