### PR TITLE
#396: predict text improvements

### DIFF
--- a/source/archetypes/assassin.js
+++ b/source/archetypes/assassin.js
@@ -1,4 +1,5 @@
-const { ArchetypeTemplate } = require("../classes");
+const { ArchetypeTemplate, Combatant } = require("../classes");
+const { ZERO_WIDTH_WHITESPACE } = require("../constants");
 const { getCombatantWeaknesses } = require("../util/combatantUtil");
 const { getEmoji, getResistances } = require("../util/elementUtil");
 
@@ -14,13 +15,17 @@ module.exports = new ArchetypeTemplate("Assassin",
 	},
 	["Daggers", "Cloak"],
 	(embed, adventure) => {
-		const eligibleCombatants = adventure.room.enemies.filter(combatant => combatant.hp > 0).concat(adventure.delvers)
-		eligibleCombatants.forEach(combatant => {
+		/** @param {Combatant} combatant */
+		function createElementAndCritField(combatant) {
 			const weaknesses = getCombatantWeaknesses(combatant);
 			const resistances = getResistances(combatant.element);
-			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.element)}`, value: `Critical Hit: ${combatant.crit ? "💥" : "🚫"}\nWeaknesses: ${weaknesses.map(weakness => getEmoji(weakness)).join(" ")}\nResistances: ${resistances.map(resistance => getEmoji(resistance)).join(" ")}` });
-		});
-		return embed.setTitle(`Assassin Predictions for Round ${adventure.room.round}`);
+			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.element)}`, value: `Critical Hit: ${combatant.crit ? "💥" : "🚫"}\nWeaknesses: ${weaknesses.map(weakness => getEmoji(weakness)).join(" ")}\nResistances: ${resistances.map(resistance => getEmoji(resistance)).join(" ")}`, inline: true });
+		}
+		// Separate Enemies and Delvers into different rows
+		adventure.room.enemies.filter(combatant => combatant.hp > 0).forEach(createElementAndCritField);
+		embed.addFields({ name: ZERO_WIDTH_WHITESPACE, value: ZERO_WIDTH_WHITESPACE });
+		adventure.delvers.forEach(createElementAndCritField);
+		return embed.setDescription(`Assassin predictions for Round ${adventure.room.round}:`);
 	},
 	(combatant) => {
 		const weaknesses = getCombatantWeaknesses(combatant);

--- a/source/archetypes/beasttamer.js
+++ b/source/archetypes/beasttamer.js
@@ -15,22 +15,24 @@ module.exports = new ArchetypeTemplate("Beast Tamer",
 	},
 	["Stick", "Carrot"],
 	(embed, adventure) => {
-		adventure.room.moves.forEach(({ userReference, targets, name, priority }) => {
+		const moveLines = [];
+		adventure.room.moves.forEach(({ userReference, name, priority }) => {
 			if (userReference.team === "enemy") {
 				const enemy = adventure.getCombatant(userReference);
 				if (enemy.hp > 0) {
 					if (name !== "@{clone}") {
-						embed.addFields({ name: enemy.name, value: `Round ${adventure.room.round + 1}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}` });
+						moveLines.push(`${bold(enemy.name)}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}`);
 					} else {
-						embed.addFields({ name: enemy.name, value: "Mirror Clones mimic your allies!" })
+						moveLines.push(`${bold(enemy.name)}: Mimic ${adventure.delvers[userReference.index].name}`);
 					}
 				}
 			}
 		})
+		embed.addFields({ name: `Enemy Moves (Round ${adventure.room.round + 1})`, value: moveLines.join("\n") });
 		const nextPetOwner = adventure.delvers[adventure.nextPet];
 		const ownerPlayer = getPlayer(nextPetOwner.id, adventure.guildId);
 		const [moveName, moveDescription] = getPetMoveDescription(nextPetOwner.pet, adventure.petRNs[0], ownerPlayer.pets[nextPetOwner.pet]);
-		return embed.setTitle(`Beast Tamer Predictions for Round ${adventure.room.round + 1}`).addFields({ name: `Next Pet Move (Round: ${adventure.room.round === 0 ? 2 : adventure.room.round + (adventure.room.round % 2)})`, value: `${nextPetOwner.name}'s ${nextPetOwner.pet} will use ${bold(moveName)}\n${italic(moveDescription)}` });
+		return embed.setDescription("Beast Tamer predictions:").addFields({ name: `Next Pet Move (Round ${2 + adventure.room.round - (adventure.room.round % 2)})`, value: `${nextPetOwner.name}'s ${nextPetOwner.pet} will use ${bold(moveName)}\n${italic(moveDescription)}` });
 	},
 	(combatant) => {
 		if (combatant.pet) {

--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -17,9 +17,9 @@ module.exports = new ArchetypeTemplate("Chemist",
 		const eligibleCombatants = adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0);
 		eligibleCombatants.forEach(combatant => {
 			const modifiersText = modifiersToString(combatant, adventure);
-			embed.addFields({ name: combatant.name, value: `${generateTextBar(combatant.hp, combatant.getMaxHP(), 16)} ${combatant.hp}/${combatant.getMaxHP()} HP${combatant.protection ? `, ${combatant.protection} Protection` : ""}\n${modifiersText ? `${modifiersText}` : "No modifiers"}` });
+			embed.addFields({ name: combatant.name, value: `${generateTextBar(combatant.hp, combatant.getMaxHP(), 16)} ${combatant.hp}/${combatant.getMaxHP()} HP${combatant.protection ? `, ${combatant.protection} Protection` : ""}\n${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` });
 		})
-		return embed.setTitle(`Chemist Predictions for Round ${adventure.room.round}`);
+		return embed.setDescription(`Chemist predictions for Round ${adventure.room.round}:`);
 	},
 	(combatant) => {
 		return `HP: ${combatant.hp}/${combatant.getMaxHP()}`;

--- a/source/archetypes/detective.js
+++ b/source/archetypes/detective.js
@@ -1,5 +1,5 @@
 const { ArchetypeTemplate } = require("../classes");
-const { POTL_ICON_URL } = require("../constants");
+const { POTL_ICON_URL, ZERO_WIDTH_WHITESPACE } = require("../constants");
 const { getCombatantWeaknesses } = require("../util/combatantUtil");
 const { getEmoji, getResistances } = require("../util/elementUtil");
 
@@ -15,16 +15,20 @@ module.exports = new ArchetypeTemplate("Detective",
 	},
 	["Pistol", "Sabotage Kit"],
 	(embed, adventure) => {
-		const eligibleCombatants = adventure.room.enemies.filter(combatant => combatant.hp > 0).concat(adventure.delvers);
-		eligibleCombatants.forEach(combatant => {
+		/** @param {Combatant} combatant */
+		function createElementField(combatant) {
 			const weaknesses = getCombatantWeaknesses(combatant);
 			const resistances = getResistances(combatant.element);
-			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.element)}`, value: `Weaknesses: ${weaknesses.map(weakness => getEmoji(weakness)).join(" ")}\nResistances: ${resistances.map(resistance => getEmoji(resistance)).join(" ")}` })
-		});
+			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.element)}`, value: `Weaknesses: ${weaknesses.map(weakness => getEmoji(weakness)).join(" ")}\nResistances: ${resistances.map(resistance => getEmoji(resistance)).join(" ")}`, inline: true });
+		}
+		// Separate Enemies and Delvers into different rows
+		adventure.room.enemies.filter(combatant => combatant.hp > 0).forEach(createElementField);
+		embed.addFields({ name: ZERO_WIDTH_WHITESPACE, value: ZERO_WIDTH_WHITESPACE });
+		adventure.delvers.forEach(createElementField);
 		if (adventure.room.detectivePredicts.length > 0) {
 			embed.addFields({ name: "Random Outcomes", value: `- ${adventure.room.detectivePredicts.join("\n- ")}` });
 		}
-		return embed.setTitle(`Detective Predictions for Round ${adventure.room.round}`).setAuthor({ name: "Random outcomes from moves are predicted as if they are the first move to happen.", iconURL: POTL_ICON_URL });
+		return embed.setDescription(`Detective predictions for Round ${adventure.room.round}:`).setAuthor({ name: "Random outcomes from moves are predicted as if they are the first move to happen.", iconURL: POTL_ICON_URL });
 	},
 	(combatant) => {
 		const weaknesses = getCombatantWeaknesses(combatant);

--- a/source/archetypes/fighter.js
+++ b/source/archetypes/fighter.js
@@ -12,21 +12,20 @@ module.exports = new ArchetypeTemplate("Fighter",
 	},
 	["Strong Attack", "Second Wind"],
 	(embed, adventure) => {
-		let descriptions = [];
-		descriptions.push(
+		const descriptions = [
 			`I'm a fighter.`,
 			`I don't have any fancy gear.`,
 			`I have double stat growths!`,
 			"¯\\_(ツ)\_/¯",
 			`This delve into ${adventure.name} is exciting!`,
 			`I *think* it's <t:${Math.floor(Date.now() / 1000)}:t>.`,
-			`It's high noon... (<t:${Math.floor(new Date().setHours(12, 0, 0) / 1000)}:R> for the server)`
-		);
+			`It's high noon... (<t:${Math.floor(new Date().setHours(12, 0, 0) / 1000)}:R> for the server)`,
+			"There's supposed to be predictions here."
+		];
 		if (adventure.delvers.length > 1) {
 			descriptions.push(`I'm so happy to have my ${adventure.delvers.length - 1} good friends with me.`);
 		}
-		return embed.setTitle(`Fighter Predictions for Round ${adventure.room.round + 1}`)
-			.setDescription(descriptions[Date.now() % descriptions.length]);
+		return embed.setDescription(`Fighter predictions for Round ${adventure.room.round + 1}:\n${descriptions[Date.now() % descriptions.length]}`);
 	},
 	(combatant) => ""
 );

--- a/source/archetypes/hemomancer.js
+++ b/source/archetypes/hemomancer.js
@@ -22,7 +22,7 @@ module.exports = new ArchetypeTemplate("Hemomancer",
 		activeCombatants.forEach(combatant => {
 			embed.addFields({ name: combatant.name, value: `${generateTextBar(combatant.hp, combatant.getMaxHP(), 16)} ${combatant.hp}/${combatant.getMaxHP()} HP${combatant.protection ? `, ${combatant.protection} Protection` : ""}\nSpeed: ${combatant.getSpeed(true)}` });
 		});
-		return embed.setTitle(`Hemomancer Predictions for Round ${adventure.room.round + 1}`).setAuthor({ name: "Combatants may act out of order if they have priority or are tied in speed.", iconURL: POTL_ICON_URL });
+		return embed.setDescription(`Hemomancer predictions for Round ${adventure.room.round + 1}:`).setAuthor({ name: "Combatants may act out of order if they have priority or are tied in speed.", iconURL: POTL_ICON_URL });
 	},
 	(combatant) => {
 		return `Speed: ${combatant.getSpeed(true)}`;

--- a/source/archetypes/knight.js
+++ b/source/archetypes/knight.js
@@ -1,3 +1,4 @@
+const { bold } = require("discord.js");
 const { ArchetypeTemplate } = require("../classes");
 const { listifyEN } = require("../util/textUtil");
 
@@ -13,23 +14,29 @@ module.exports = new ArchetypeTemplate("Knight",
 	},
 	["Lance", "Buckler"],
 	(embed, adventure) => {
-		adventure.room.moves.forEach(({ userReference, targets, name, priority }) => {
+		const currentRoundLines = [];
+		const nextRoundLines = [];
+		adventure.room.moves.forEach(({ userReference, name, targets, priority }) => {
 			if (userReference.team === "enemy") {
 				const enemy = adventure.getCombatant(userReference);
 				if (enemy.hp > 0) {
 					if (name !== "@{clone}") {
-						embed.addFields({ name: enemy.name, value: `Round ${adventure.room.round + 1}: ${name} ${priority != 0 ? "(Priority: " + priority + ") " : ""}(Targets: ${listifyEN(targets.map(targetReference => adventure.getCombatant(targetReference).name), false) || "none"})\nRound ${adventure.room.round + 2}: ${enemy.nextAction}` });
+						currentRoundLines.push(`${bold(enemy.name)}: ${name} (Targets: ${listifyEN(targets.map(targetReference => adventure.getCombatant(targetReference).name), false) || "none"}${priority != 0 ? `, Priority: ${priority}` : ""})`);
+						nextRoundLines.push(`${bold(enemy.name)}: ${enemy.nextAction}`);
 					} else {
-						embed.addFields({ name: enemy.name, value: "Mirror Clones mimic your allies!" })
+						currentRoundLines.push(`${bold(enemy.name)}: Mimic ${adventure.delvers[userReference.index].name}`);
+						nextRoundLines.push(`${bold(enemy.name)}: Mimic ${adventure.delvers[userReference.index].name}`);
 					}
 				}
 			}
 		})
-		return embed.setTitle(`Knight Predictions for Round ${adventure.room.round + 1}`);
+		embed.addFields({ name: `Enemy Moves (Round ${adventure.room.round + 1})`, value: currentRoundLines.join("\n") });
+		embed.addFields({ name: `Enemy Moves (Round ${adventure.room.round + 2})`, value: nextRoundLines.join("\n") });
+		return embed.setDescription(`Knight predictions:`);
 	},
 	(combatant) => {
 		if (combatant.team === "delver") {
-			return "Move in 2 rounds: Ask them";
+			return "";
 		} else {
 			return `Move in 2 rounds: ${combatant.nextAction}`;
 		}

--- a/source/archetypes/legionnaire.js
+++ b/source/archetypes/legionnaire.js
@@ -1,4 +1,5 @@
 const { ArchetypeTemplate } = require("../classes");
+const { ZERO_WIDTH_WHITESPACE } = require("../constants");
 const { listifyEN } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Legionnaire",
@@ -13,8 +14,13 @@ module.exports = new ArchetypeTemplate("Legionnaire",
 	},
 	["Shortsword", "Scutum"],
 	(embed, adventure) => {
-		const eligibleCombatants = adventure.room.enemies.filter(combatant => combatant.hp > 0).concat(adventure.delvers);
-		eligibleCombatants.forEach(combatant => {
+		adventure.room.enemies.filter(combatant => combatant.hp > 0).forEach(combatant => {
+			const individualIndex = adventure.getCombatantIndex(combatant);
+			const move = adventure.room.findCombatantMove({ index: individualIndex, team: combatant.team });
+			embed.addFields({ name: combatant.name, value: `Targets: ${listifyEN(move.targets.map(targetReference => adventure.getCombatant(targetReference).name), false) || "none"}\nCritical Hit: ${combatant.crit ? "💥" : "🚫"}`, inline: true });
+		});
+		embed.addFields({ name: ZERO_WIDTH_WHITESPACE, value: ZERO_WIDTH_WHITESPACE });
+		adventure.delvers.forEach(combatant => {
 			const individualIndex = adventure.getCombatantIndex(combatant);
 			const move = adventure.room.findCombatantMove({ index: individualIndex, team: combatant.team });
 			let targetNames = null;
@@ -22,8 +28,8 @@ module.exports = new ArchetypeTemplate("Legionnaire",
 				targetNames = move.targets.map(targetReference => adventure.getCombatant(targetReference).name);
 			}
 			embed.addFields({ name: combatant.name, value: `Targets: ${targetNames === null ? "undecided" : (listifyEN(targetNames, false) || "none")}\nCritical Hit: ${combatant.crit ? "💥" : "🚫"}` });
-		})
-		return embed.setTitle(`Legionnaire Predictions for Round ${adventure.room.round + 1}`);
+		});
+		return embed.setDescription(`Legionnaire predictions for Round ${adventure.room.round + 1}:`);
 	},
 	(combatant) => {
 		return `Critical Hit: ${combatant.crit ? "💥" : "🚫"}`

--- a/source/archetypes/martialartist.js
+++ b/source/archetypes/martialartist.js
@@ -1,4 +1,6 @@
+const { italic } = require("discord.js");
 const { ArchetypeTemplate } = require("../classes");
+const { ZERO_WIDTH_WHITESPACE } = require("../constants");
 const { generateTextBar } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Martial Artist",
@@ -13,15 +15,14 @@ module.exports = new ArchetypeTemplate("Martial Artist",
 	},
 	["Iron Fist Stance", "Floating Mist Stance"],
 	(embed, adventure) => {
-		const activeCombatants = adventure.room.enemies.filter(enemy => enemy.hp > 0)
-			.concat(adventure.delvers)
-			.sort((first, second) => {
-				return second.getSpeed(true) - first.getSpeed(true);
-			});
-		activeCombatants.forEach(combatant => {
-			embed.addFields({ name: combatant.name, value: `${combatant.isStunned ? "💫 Stunned" : `Stagger: ${generateTextBar(combatant.stagger, combatant.getPoise(), combatant.getPoise())}`}${combatant.team === "enemy" ? `\nRound ${adventure.room.round + 2} Move: ${combatant.nextAction}` : ""}` });
-		})
-		return embed.setTitle(`Martial Artist Predictions for Round ${adventure.room.round + 1}`);
+		adventure.room.enemies.filter(enemy => enemy.hp > 0).forEach(combatant => {
+			embed.addFields({ name: combatant.name, value: `${combatant.isStunned ? "💫 Stunned" : `Stagger: ${generateTextBar(combatant.stagger, combatant.getPoise(), combatant.getPoise())}`}\nRound ${adventure.room.round + 2} Move: ${italic(combatant.nextAction)}`, inline: true });
+		});
+		embed.addFields({ name: ZERO_WIDTH_WHITESPACE, value: ZERO_WIDTH_WHITESPACE });
+		adventure.delvers.forEach(combatant => {
+			embed.addFields({ name: combatant.name, value: `${combatant.isStunned ? "💫 Stunned" : `Stagger: ${generateTextBar(combatant.stagger, combatant.getPoise(), combatant.getPoise())}`}`, inline: true });
+		});
+		return embed.setDescription(`Martial Artist predictions:`);
 	},
 	(combatant) => {
 		if (combatant.isStunned) {

--- a/source/archetypes/ritualist.js
+++ b/source/archetypes/ritualist.js
@@ -15,12 +15,21 @@ module.exports = new ArchetypeTemplate("Ritualist",
 	},
 	["Censer", "Corrosion"],
 	(embed, adventure) => {
-		const eligibleCombatants = adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0)
-		eligibleCombatants.forEach(combatant => {
-			const modifiersText = modifiersToString(combatant, adventure);
-			embed.addFields({ name: combatant.name, value: `${combatant.isStunned ? "💫 Stunned" : `Stagger: ${generateTextBar(combatant.stagger, combatant.getPoise(), combatant.getPoise())}`}\n${modifiersText ? `${modifiersText}` : "No modifiers"}` });
+		embed.addFields({
+			name: "Enemies",
+			value: adventure.room.enemies.filter(combatant => combatant.hp > 0).map(enemy => {
+				const modifiersText = modifiersToString(enemy, adventure);
+				return `${enemy.name}\n${enemy.isStunned ? "💫 Stunned" : `Stagger: ${generateTextBar(enemy.stagger, enemy.getPoise(), enemy.getPoise())}`}\n${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}`;
+			}).join("\n\n")
 		})
-		return embed.setTitle(`Ritualist Predictions for Round ${adventure.room.round}`);
+		embed.addFields({
+			name: "Delvers",
+			value: adventure.delvers.map(delver => {
+				const modifiersText = modifiersToString(delver, adventure);
+				return `${delver.name}\n${delver.isStunned ? "💫 Stunned" : `Stagger: ${generateTextBar(delver.stagger, delver.getPoise(), delver.getPoise())}`}\n${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}`;
+			}).join("\n\n")
+		})
+		return embed.setDescription(`Ritualist predictions for Round ${adventure.room.round}:`);
 	},
 	(combatant) => {
 		return `Has Debuffs: ${Object.keys(combatant.modifiers).some(modifier => isDebuff(modifier)) ? "✅" : "🚫"}`;

--- a/source/buttons/readyitem.js
+++ b/source/buttons/readyitem.js
@@ -21,7 +21,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		const delverArchetypeTemplate = getArchetype(delver.archetype);
 		interaction.reply({
 			embeds: [
-				delverArchetypeTemplate.predict(new EmbedBuilder().setColor(getColor(adventure.room.element)).setAuthor({ name: "Using an item takes your turn and has priority (it'll happen before non-priority actions)", iconURL: POTL_ICON_URL }), adventure)
+				delverArchetypeTemplate.predict(new EmbedBuilder().setColor(getColor(adventure.room.element)).setTitle("Select an Item").setAuthor({ name: "Using an item takes your turn and has priority (it'll happen before non-priority actions)", iconURL: POTL_ICON_URL }), adventure)
 			],
 			components: [
 				new ActionRowBuilder().addComponents(

--- a/source/buttons/readymove.js
+++ b/source/buttons/readymove.js
@@ -19,7 +19,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 		const delverArchetypeTemplate = getArchetype(delver.archetype);
-		const embed = delverArchetypeTemplate.predict(new EmbedBuilder().setColor(getColor(adventure.room.element)), adventure)
+		const embed = delverArchetypeTemplate.predict(new EmbedBuilder().setColor(getColor(adventure.room.element)).setTitle("Select a Move"), adventure)
 		if (!embed.data.author) {
 			embed.setAuthor(randomAuthorTip());
 		}
@@ -157,7 +157,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					}
 					adventure.room.moves.push(newMove);
 
-					confirmationText = `**${collectedInteraction.member.displayName}** ${overwritten ? "switches to ready" : "readies"} **${moveName}**${type !== "none" && type !== "self" ? ` to use on **${targetText}**` : ""}.`;
+					confirmationText = `${bold(collectedInteraction.member.displayName)} ${overwritten ? "switches to ready" : "readies"} **${moveName}**${type !== "none" && type !== "self" ? ` to use on **${targetText}**` : ""}.`;
 				} else {
 					// Add move to round list (overwrite exisiting readied move)
 					const userIndex = adventure.getCombatantIndex(delver);

--- a/source/modifiers/poison.js
+++ b/source/modifiers/poison.js
@@ -1,7 +1,7 @@
 const { ModifierTemplate } = require("../classes");
 
 module.exports = new ModifierTemplate("Poison",
-	"Deals @{stackCount*10} (+@{funnelCount*2} on enemies due to Spiral Funnels) unblockable damage after the sufferer's turn. Lose @{roundDecrement} stack per round.",
+	"Deals @{stackCount*10} (+@{funnelCount*2} on enemies due to Spiral Funnels) unblockable damage after the sufferer's move.",
 	false,
 	true,
 	1

--- a/source/modifiers/regen.js
+++ b/source/modifiers/regen.js
@@ -1,7 +1,7 @@
 const { ModifierTemplate } = require("../classes");
 
 module.exports = new ModifierTemplate("Regen",
-	"Gain @{stackCount*10} HP after the bearer's turn. Lose @{roundDecrement} stack per round.",
+	"Gain @{stackCount*10} HP after the bearer's move.",
 	true,
 	false,
 	1

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -383,7 +383,7 @@ function addProtection(combatants, value) {
 function modifiersToString(combatant, adventure) {
 	let modifiersText = "";
 	for (const modifier in combatant.modifiers) {
-		modifiersText += `*${modifier} x ${combatant.modifiers[modifier]}* - ${getModifierDescription(modifier, combatant.modifiers[modifier], combatant.getPoise(), adventure.getArtifactCount("Spiral Funnel"))}\n`;
+		modifiersText += `${getApplicationEmojiMarkdown(modifier)} ${bold(`x ${combatant.modifiers[modifier]}`)}: ${getModifierDescription(modifier, combatant.modifiers[modifier], combatant.getPoise(), adventure.getArtifactCount("Spiral Funnel"))}\n`;
 	}
 	return modifiersText;
 }


### PR DESCRIPTION
Summary
-------
- fixed Beast Tamer incorrectly noting next Pet move round
- embeds are now labeled with Move/Item selection
- add modifier emoji to Chemist and Ritualist predicts
- skip description on Knight mini-predict for allies
- remove round decrement sentence from Poison and Regen descriptions
- separate predictions by team if not sorted otherwise
- fix martial artist still listing combatants in speed order

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] looked at each predict text in battle

Issue
-----
Closes #396