### PR TITLE
#402: clones use own rolled random targets and target whole delver team instead of pure counterpart target copying

### DIFF
--- a/source/labyrinths/debugdungeon.js
+++ b/source/labyrinths/debugdungeon.js
@@ -6,8 +6,8 @@ const RARITIES = ["Cursed", "Common", "Rare"];
 module.exports = new LabyrinthTemplate("Debug Dungeon",
 	"Untyped",
 	"This labyrinth contains whatever the devs were testing most recently. Balance not guaranteed!",
-	5,
-	[5],
+	10,
+	[10],
 	Object.fromEntries(["Darkness", "Earth", "Fire", "Light", "Water", "Wind", "Untyped"].map(element => [element, [
 		"Creative Acorn",
 		"Flexigrass",
@@ -74,7 +74,7 @@ module.exports = new LabyrinthTemplate("Debug Dungeon",
 		"Event": ["Apple Pie Wishing Well", "Door 1 or Door 2?", "Free Gold?", "Gear Collector", "Imp Contract Faire", "The Score Beggar", "Twin Pedestals", "Workshop", "Merchant", "Rest Site", "Library", "Treasure"],
 		"Battle": ["Hawk Fight", "Frog Ranch", "Wild Fire-Arrow Frogs", "Mechabee Fight", "Slime Fight", "Tortoise Fight", "Meteor Knight Fight"],
 		"Artifact Guardian": ["Brute Convention"],
-		"Final Battle": ["A Northern Laboratory", "Hall of Mirrors", "The Hexagon: Bee Mode", "The Hexagon: Mech Mode", "Confronting the Top Celestial Knight"],
+		"Final Battle": ["Hall of Mirrors"],
 		...standardLabyrinthInfrastructure
 	}
 );

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -970,9 +970,39 @@ function endRound(adventure, thread) {
 			move.type = counterpartMove.type;
 			move.name = counterpartMove.name;
 			move.setPriority(counterpartMove.priority);
-			move.targets = counterpartMove.targets.map(target => {
-				return { team: target.team === "enemy" ? "delver" : "enemy", index: target.index };
-			})
+			const [gearName, gearIndex] = counterpartMove.name.split(SAFE_DELIMITER);
+			const targetingTags = getGearProperty(gearName, "targetingTags");
+			if (targetingTags.type === "single" || targetingTags.type.startsWith("blast")) {
+				move.targets = counterpartMove.targets.map(target => {
+					return { team: target.team === "enemy" ? "delver" : "enemy", index: target.index };
+				})
+			} else if (targetingTags.type === "all") {
+				if (targetingTags.team === "ally") {
+					for (let i = 0; i < adventure.room.enemies; i++) {
+						if (adventure.room.enemies[i].hp > 0) {
+							move.addTarget(new CombatantReference("enemy", i));
+						}
+					}
+				} else {
+					for (let i = 0; i < adventure.delvers.length; i++) {
+						move.addTarget(new CombatantReference("delver", i));
+					}
+				}
+			} else if (targetingTags.type.startsWith("random")) {
+				const { [`${gearName}${SAFE_DELIMITER}allies`]: cachedAllies, [`${gearName}${SAFE_DELIMITER}foes`]: cachedFoes } = cacheRoundRn(adventure, user, gearName, getGearProperty(gearName, "rnConfig"));
+				if (cachedAllies) {
+					for (let i = 0; i < cachedAllies.length; i++) {
+						move.addTarget(new CombatantReference("delver", cachedAllies[i]));
+					}
+				}
+				if (cachedFoes) {
+					for (let i = 0; i < cachedFoes.length; i++) {
+						move.addTarget(new CombatantReference("enemy", cachedFoes[i]));
+					}
+				}
+			} else if (targetingTags.type === "self") {
+				move.targets = [{ team: "enemy", index: move.userReference.index }];
+			}
 		}
 	}
 


### PR DESCRIPTION
Summary
-------
- clones use own rolled random targets and target whole delver team instead of pure counterpart target copying

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] clones use own randomly rolled moves (Firecracker)
- [x] clones target full delver team if copying "all foes" and a clone is dead

Issue
-----
Closes #402