### PR TITLE
#485: Beast Tamer can predict pet targets

### DIFF
--- a/source/archetypes/beasttamer.js
+++ b/source/archetypes/beasttamer.js
@@ -2,6 +2,7 @@ const { bold, italic } = require("discord.js");
 const { ArchetypeTemplate } = require("../classes");
 const { getPlayer } = require("../orcustrators/playerOrcustrator");
 const { getPetMoveDescription } = require("../pets/_petDictionary");
+const { listifyEN } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Beast Tamer",
 	"They'll be able to predict what moves enemies and pets are using. They'll also be able to entice an ally's pet to act with their Carrot.",
@@ -29,10 +30,10 @@ module.exports = new ArchetypeTemplate("Beast Tamer",
 			}
 		})
 		embed.addFields({ name: `Enemy Moves (Round ${adventure.room.round + 1})`, value: moveLines.join("\n") });
-		const nextPetOwner = adventure.delvers[adventure.nextPet];
+		const nextPetOwner = adventure.delvers[adventure.petRNs.delverIndex];
 		const ownerPlayer = getPlayer(nextPetOwner.id, adventure.guildId);
-		const [moveName, moveDescription] = getPetMoveDescription(nextPetOwner.pet, adventure.petRNs[0], ownerPlayer.pets[nextPetOwner.pet]);
-		return embed.setDescription("Beast Tamer predictions:").addFields({ name: `Next Pet Move (Round ${2 + adventure.room.round - (adventure.room.round % 2)})`, value: `${nextPetOwner.name}'s ${nextPetOwner.pet} will use ${bold(moveName)}\n${italic(moveDescription)}` });
+		const [moveName, moveDescription] = getPetMoveDescription(nextPetOwner.pet, adventure.petRNs.moveIndex, ownerPlayer.pets[nextPetOwner.pet]);
+		return embed.setDescription("Beast Tamer predictions:").addFields({ name: `Next Pet Move (Round ${2 + adventure.room.round - (adventure.room.round % 2)})`, value: `${nextPetOwner.name}'s ${nextPetOwner.pet} will use ${bold(moveName)}${adventure.petRNs.targetReferences.length > 0 ? ` on ${listifyEN(adventure.petRNs.targetReferences.map(reference => italic(adventure.getCombatant(reference).name)))}` : ""}\n${italic(moveDescription)}` });
 	},
 	(combatant) => {
 		if (combatant.pet) {

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -58,10 +58,8 @@ class Adventure {
 	depth = 1;
 	/** @type {Room} */
 	room = {};
-	/** @type {number} the index of the delver whos pet will act next */
-	nextPet = 0;
-	/** @type {number []} */
-	petRNs = [];
+	/** @type {{delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}} */
+	petRNs = { delverIndex: 0, moveIndex: 0, targetReferences: [], extras: [] };
 	/** @type {{[candidate: string]: {voterIds: string[], isHidden: boolean}}} */
 	roomCandidates = {};
 	lives = 2;

--- a/source/classes/PetTemplate.js
+++ b/source/classes/PetTemplate.js
@@ -19,8 +19,8 @@ class PetMoveTemplate {
 	/**
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
-	 * @param {(owner: Delver, petRNs: number[]) => CombatantReference[]} selectorFunction
-	 * @param {(targets: Combatant[], owner: Delver, adventure: Adventure, petRNs: number[]) => string[]} effectFunction
+	 * @param {(owner: Delver, petRNs: {delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}) => CombatantReference[]} selectorFunction
+	 * @param {(targets: Combatant[], owner: Delver, adventure: Adventure, petRNs: {delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}) => string[]} effectFunction
 	 */
 	constructor(nameInput, descriptionInput, selectorFunction, effectFunction) {
 		this.name = nameInput;

--- a/source/gear/carrot-base.js
+++ b/source/gear/carrot-base.js
@@ -1,4 +1,4 @@
-const { GearTemplate } = require('../classes');
+const { GearTemplate, CombatantReference } = require('../classes');
 const { ELEMENT_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPlayer } = require('../orcustrators/playerOrcustrator');
 const { getPetMove } = require('../pets/_petDictionary');
@@ -23,10 +23,11 @@ module.exports = new GearTemplate("Carrot",
 		}
 		addProtection([user], protection);
 		const resultLines = [`${user.name} gains protection.`];
-		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: adventure.getCombatantIndex(target) });
+		const ownerIndex = adventure.getCombatantIndex(target);
+		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 		if (owner.pet) {
-			const petRNs = [0];
-			const petMoveTemplate = getPetMove(owner.pet, petRNs, getPlayer(owner.id, adventure.guildId).pets[owner.pet]);
+			const petMoveTemplate = getPetMove(owner.pet, 0, getPlayer(owner.id, adventure.guildId).pets[owner.pet]);
+			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
 			petMoveTemplate.rnConfig.forEach(rnType => {
 				switch (rnType) {
 					case "enemyIndex":
@@ -36,10 +37,10 @@ module.exports = new GearTemplate("Carrot",
 								livingEnemyIndices.push(i);
 							}
 						}
-						petRNs.push(livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]);
+						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
 						break;
 					default:
-						petRNs.push(adventure.generateRandomNumber(rnType, "battle"));
+						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 				}
 			})
 			resultLines.push(`${target.name}'s ${owner.pet} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));

--- a/source/gear/carrot-devoted.js
+++ b/source/gear/carrot-devoted.js
@@ -1,4 +1,4 @@
-const { GearTemplate } = require('../classes');
+const { GearTemplate, CombatantReference } = require('../classes');
 const { ELEMENT_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPlayer } = require('../orcustrators/playerOrcustrator');
 const { getPetMove } = require('../pets/_petDictionary');
@@ -23,10 +23,11 @@ module.exports = new GearTemplate("Devoted Carrot",
 		}
 		addProtection([target], protection);
 		const resultLines = [`${target.name} gains protection.`];
-		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: adventure.getCombatantIndex(target) });
+		const ownerIndex = adventure.getCombatantIndex(target);
+		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 		if (owner.pet) {
-			const petRNs = [0];
-			const petMoveTemplate = getPetMove(owner.pet, petRNs, getPlayer(owner.id, adventure.guildId).pets[owner.pet]);
+			const petMoveTemplate = getPetMove(owner.pet, 0, getPlayer(owner.id, adventure.guildId).pets[owner.pet]);
+			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
 			petMoveTemplate.rnConfig.forEach(rnType => {
 				switch (rnType) {
 					case "enemyIndex":
@@ -36,10 +37,10 @@ module.exports = new GearTemplate("Devoted Carrot",
 								livingEnemyIndices.push(i);
 							}
 						}
-						petRNs.push(livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]);
+						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
 						break;
 					default:
-						petRNs.push(adventure.generateRandomNumber(rnType, "battle"));
+						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 				}
 			})
 			resultLines.push(`${target.name}'s ${owner.pet} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));

--- a/source/gear/carrot-reinforced.js
+++ b/source/gear/carrot-reinforced.js
@@ -1,4 +1,4 @@
-const { GearTemplate } = require('../classes');
+const { GearTemplate, CombatantReference } = require('../classes');
 const { ELEMENT_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPlayer } = require('../orcustrators/playerOrcustrator');
 const { getPetMove } = require('../pets/_petDictionary');
@@ -23,10 +23,11 @@ module.exports = new GearTemplate("Reinforced Carrot",
 		}
 		addProtection([user], protection);
 		const resultLines = [`${user.name} gains protection.`];
-		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: adventure.getCombatantIndex(target) });
+		const ownerIndex = adventure.getCombatantIndex(target);
+		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 		if (owner.pet) {
-			const petRNs = [0];
-			const petMoveTemplate = getPetMove(owner.pet, petRNs, getPlayer(owner.id, adventure.guildId).pets[owner.pet]);
+			const petMoveTemplate = getPetMove(owner.pet, 0, getPlayer(owner.id, adventure.guildId).pets[owner.pet]);
+			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
 			petMoveTemplate.rnConfig.forEach(rnType => {
 				switch (rnType) {
 					case "enemyIndex":
@@ -36,10 +37,10 @@ module.exports = new GearTemplate("Reinforced Carrot",
 								livingEnemyIndices.push(i);
 							}
 						}
-						petRNs.push(livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]);
+						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
 						break;
 					default:
-						petRNs.push(adventure.generateRandomNumber(rnType, "battle"));
+						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 				}
 			})
 			resultLines.push(`${target.name}'s ${owner.pet} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -737,10 +737,10 @@ function newRound(adventure, thread, lastRoundText) {
 
 	if (adventure.room.round % 2 === 1) {
 		// Generate pet move
-		const owner = adventure.delvers[adventure.nextPet];
+		const owner = adventure.delvers[adventure.petRNs.delverIndex];
 		if (owner.pet) {
-			const petMoveTemplate = getPetMove(owner.pet, adventure.petRNs, getPlayer(owner.id, thread.guildId).pets[owner.pet]);
-			const petMove = new Move(petMoveTemplate.name, "pet", { team: "delver", index: adventure.nextPet })
+			const petMoveTemplate = getPetMove(owner.pet, adventure.petRNs.moveIndex, getPlayer(owner.id, thread.guildId).pets[owner.pet]);
+			const petMove = new Move(petMoveTemplate.name, "pet", { team: "delver", index: adventure.petRNs.delverIndex })
 				.setSpeedByValue(100);
 			petMoveTemplate.selector(owner, adventure.petRNs).forEach(reference => {
 				petMove.addTarget(reference);
@@ -817,7 +817,7 @@ function resolveMove(move, adventure) {
 			}
 			case "pet":
 				headline = `${user.name}'s ${bold(user.pet)} `;
-				effect = getPetMove(user.pet, adventure.petRNs, getPlayer(user.id, adventure.guildId).pets[user.pet]).effect;
+				effect = getPetMove(user.pet, adventure.petRNs.moveIndex, getPlayer(user.id, adventure.guildId).pets[user.pet]).effect;
 				break;
 		}
 
@@ -1051,7 +1051,7 @@ function endRound(adventure, thread) {
 
 	if (adventure.room.round % 2 === 1) {
 		// Generate pet move prediction
-		adventure.nextPet = (adventure.nextPet + 1) % adventure.delvers.length;
+		adventure.petRNs.delverIndex = (adventure.petRNs.delverIndex + 1) % adventure.delvers.length;
 		generatePetRNs(adventure);
 	}
 
@@ -1119,9 +1119,9 @@ function checkEndCombat(adventure, thread, lastRoundText) {
 /** The round ends when all combatants have readied all their moves
  * @param {Adventure} adventure
  */
-function checkNextRound({ nextPet, room, delvers }) {
+function checkNextRound({ petRNs, room, delvers }) {
 	const readiedMoves = room.moves.length;
-	const petMoves = delvers[nextPet].pet !== "" ? room.round % 2 : 0;
+	const petMoves = delvers[petRNs.delverIndex].pet !== "" ? room.round % 2 : 0;
 	const movesThisRound = room.enemies.length + delvers.length + petMoves;
 	return readiedMoves === movesThisRound;
 }

--- a/source/pets/friendlyslime.js
+++ b/source/pets/friendlyslime.js
@@ -8,14 +8,14 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 	[
 		[
 			new PetMoveTemplate("Toxin Spray", "Inflict @{mod0Stacks} @{mod0} on a random foe",
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const thisMove = module.exports.moves[0][0];
 					return generateModifierResultLines(addModifier(targets, thisMove.modifiers[0]));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Poison", stacks: 2 }),
 			new PetMoveTemplate("Sticky Toxin Spray", "Inflict @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} on a random foe",
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const thisMove = module.exports.moves[0][1];
 					const receipts = addModifier(targets, thisMove.modifiers[0]);
@@ -27,7 +27,7 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 		[
 			new PetMoveTemplate("Amateur Alchemy", "Add a random Potion to loot 1/5 of the time", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-					const [_, success, potionIndex] = petRNs;
+					const [success, potionIndex] = petRNs.extras;
 					if (success === 0) {
 						const rolledPotion = rollablePotions[potionIndex];
 						adventure.room.addResource(rolledPotion, "Item", "loot", 1);
@@ -38,7 +38,7 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 				}).setRnConfig([6, rollablePotions.length]),
 			new PetMoveTemplate("Not-So-Amateur Alchemy", "Add a random Potion to loot 1/4 of the time", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-					const [_, success, potionIndex] = petRNs;
+					const [success, potionIndex] = petRNs.extras;
 					if (success === 0) {
 						const rolledPotion = rollablePotions[potionIndex];
 						adventure.room.addResource(rolledPotion, "Item", "loot", 1);

--- a/source/pets/redtailedraptor.js
+++ b/source/pets/redtailedraptor.js
@@ -8,7 +8,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 	[
 		[
 			new PetMoveTemplate("Rake", `Deal 15 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [quicken] } = module.exports.moves[0][0];
 					const resultLines = dealDamage(targets, owner, 15, false, "Wind", adventure);
@@ -16,7 +16,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Quicken", stacks: 2 }),
 			new PetMoveTemplate("Secret Maneuver: Rake of the Heavens", `Deal 25 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [quicken] } = module.exports.moves[0][1];
 					const resultLines = dealDamage(targets, owner, 25, false, "Wind", adventure);
@@ -26,7 +26,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 		],
 		[
 			new PetMoveTemplate("Rake", `Deal 15 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [quicken] } = module.exports.moves[1][0];
 					const resultLines = dealDamage(targets, owner, 15, false, "Wind", adventure);
@@ -34,7 +34,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Quicken", stacks: 2 }),
 			new PetMoveTemplate("World-Cleaving Rake: The Forbidden Technique", `Deal 25 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [quicken] } = module.exports.moves[1][1];
 					const resultLines = dealDamage(targets, owner, 25, false, "Wind", adventure);

--- a/source/pets/shieldgoblin.js
+++ b/source/pets/shieldgoblin.js
@@ -9,23 +9,23 @@ module.exports = new PetTemplate(petName, Colors.Green,
 		[
 			new PetMoveTemplate("Prospect", "Find a random amount between 0-5g for the party", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-					adventure.gainGold(petRNs[1]);
-					return [`${owner.name}'s Shield Goblin finds ${petRNs[1]}g for the party.`];
+					adventure.gainGold(petRNs.extras[0]);
+					return [`${owner.name}'s Shield Goblin finds ${petRNs.extras[0]}g for the party.`];
 				}).setRnConfig([11]),
 			new PetMoveTemplate("Prospect+", "Find a random amount between 0-10g for the party", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-					adventure.gainGold(petRNs[1]);
-					return [`${owner.name}'s Shield Goblin finds ${petRNs[1]}g for the party.`];
+					adventure.gainGold(petRNs.extras[0]);
+					return [`${owner.name}'s Shield Goblin finds ${petRNs.extras[0]}g for the party.`];
 				}).setRnConfig([21])
 		],
 		[
 			new PetMoveTemplate("Shield Tackle", `Deal owner's protection in ${getEmoji("Earth")} damage to a random foe`,
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure);
 				}).setRnConfig(["enemyIndex"]),
 			new PetMoveTemplate("Shield Avalanche", `Deal owner's protection in ${getEmoji("Earth")} damage and 1 Stagger to a random foe`,
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					changeStagger(targets, null, 1);
 					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure);

--- a/source/pets/shinystone.js
+++ b/source/pets/shinystone.js
@@ -8,14 +8,14 @@ module.exports = new PetTemplate(petName, Colors.LightGrey,
 	[
 		[
 			new PetMoveTemplate("Eye-Catcher", "Inflict a random foe with @{mod0Stacks} @{mod0}",
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const [distracted] = module.exports.moves[0][0].modifiers;
 					return generateModifierResultLines(addModifier(targets, distracted));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Distracted", stacks: 2 }),
 			new PetMoveTemplate("Extra Eye-Catcher", "Inflict a random foe with @{mod0Stacks} @{mod0} and 1 Stagger",
-				(owner, petRNs) => [new CombatantReference(owner.team === "delver" ? "enemy" : "delver", petRNs[1])],
+				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const [distracted] = module.exports.moves[0][1].modifiers;
 					return generateModifierResultLines(addModifier(targets, distracted)).concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));


### PR DESCRIPTION
Summary
-------
- Beast Tamer can predict pet targets (gaining info to not snipe pets is Beast Tamer predict value)

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Beast Tamer can predict pet targets
- [x] Carrot still activates pet moves without regression

Issue
-----
Closes #485