### PR TITLE
#511: fix merchant only stocking duplicates of the same item

### DIFF
--- a/source/classes/RoomTemplate.js
+++ b/source/classes/RoomTemplate.js
@@ -7,22 +7,19 @@ class RoomTemplate {
 	 * @param {string} titleText room titles double as the id, so must be unique
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Unaligned" | "@{adventure}" | "@{adventureOpposite}" | "@{adventureCounter}"} essenceEnum
 	 * @param {string} descriptionInput
-	 * @param {ResourceTemplate[]} resourceArray
-	 * @param {(adventure: Adventure) => Record<string, string[]>} initializeFunction
+	 * @param {(adventure: Adventure) => ({ type: "Gear" | "Item", count: number, visibility: "always" | "interal" | "loot", forSale: boolean, uiGroup?: string }[])} initializeFunction
 	 * @param {(roomEmbed: EmbedBuilder, adventure: Adventure) => {embeds: EmbedBuilder[], components: ActionRowBuilder[]}} buildRoomFunction
 	 */
-	constructor(titleText, essenceEnum, descriptionInput, resourceArray, initializeFunction, buildRoomFunction) {
+	constructor(titleText, essenceEnum, descriptionInput, initializeFunction, buildRoomFunction) {
 		if (!titleText) throw new BuildError("Falsy titleText");
 		if (!essenceEnum) throw new BuildError("Falsy essenceEnum");
 		if (!descriptionInput) throw new BuildError("Falsy descriptionInput");
-		if (!resourceArray) throw new BuildError("Falsy resourceArray");
 		if (!initializeFunction) throw new BuildError("Falsy buildHistoryFunction");
 		if (!buildRoomFunction) throw new BuildError("Falsy buildRoomFunction");
 
 		this.title = titleText;
 		this.essence = essenceEnum;
 		this.description = descriptionInput;
-		this.resourceList = resourceArray;
 		this.init = initializeFunction;
 		this.buildRoom = buildRoomFunction;
 	}
@@ -36,51 +33,4 @@ class RoomTemplate {
 	}
 };
 
-class ResourceTemplate {
-	/** This read-only data class that defines resources available for placement in rooms
-	 * @param {string} countExpression
-	 * @param {"loot" | "always" | "internal"} visibilityInput "loot" only shows in end of room loot, "always" always shows in ui, "internal" never shows in ui
-	 * @param {"Gear" | "Artifact" | "Currency" | "challenge" | "Item" | string} typeInput categories (eg "Item", "Gear") are random rolls, specific names allowed
-	 */
-	constructor(countExpression, visibilityInput, typeInput) {
-		if (!countExpression) throw new BuildError("Falsy countExpression");
-		if (!visibilityInput) throw new BuildError("Falsy visibilityInput");
-		if (!typeInput) throw new BuildError("Falsy typeInput");
-
-		this.count = countExpression;
-		this.visibility = visibilityInput;
-		if (visibilityInput === "loot") {
-			this.costExpression = "0";
-		} else {
-			this.costExpression = "n";
-		}
-		this.type = typeInput;
-	}
-	/** @type {"Cursed" | "Common" | "Rare" | "?"} */
-	tier = null;
-	/** @type {string} */
-	uiGroup = null;
-
-	/** @param {"Cursed" | "Common" | "Rare" | "?"} tierEnum */
-	setTier(tierEnum) {
-		this.tier = tierEnum;
-		return this;
-	}
-
-	/** @param {string} costExpressionInput */
-	setCostExpression(costExpressionInput) {
-		this.costExpression = costExpressionInput;
-		return this;
-	}
-
-	/** @param {string} groupName for UI with multiple selects (eg merchants) */
-	setUIGroup(groupName) {
-		this.uiGroup = groupName;
-		return this;
-	}
-};
-
-module.exports = {
-	RoomTemplate,
-	ResourceTemplate
-};
+module.exports = { RoomTemplate };

--- a/source/classes/index.js
+++ b/source/classes/index.js
@@ -14,7 +14,7 @@ const { ModifierTemplate, ModifierReceipt } = require("./ModifierTemplate");
 const { CombatantReference, Move } = require("./Move");
 const { PetTemplate, PetMoveTemplate } = require("./PetTemplate");
 const { Player } = require("./Player");
-const { ResourceTemplate, RoomTemplate } = require("./RoomTemplate");
+const { RoomTemplate } = require("./RoomTemplate");
 
 module.exports = {
 	Adventure,
@@ -43,7 +43,6 @@ module.exports = {
 	PetMoveTemplate,
 	PetTemplate,
 	Player,
-	ResourceTemplate,
 	Room,
 	RoomTemplate,
 	SelectWrapper,

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -256,8 +256,8 @@ function getGearProperty(gearName, propertyName) {
 function buildGearRecord(gearName, adventure) {
 	const template = GEAR[gearName.toLowerCase()];
 	let charges = template.maxCharges;
-	const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Craftsmanship");
-	const shoddyDuration = adventure.getChallengeDuration("Shoddy Craftsmanship");
+	const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Spellcraft");
+	const shoddyDuration = adventure.getChallengeDuration("Shoddy Spellcraft");
 	if (shoddyPenalty > 0 && shoddyDuration > 0) {
 		charges = Math.ceil(charges * (100 - shoddyPenalty) / 100);
 	}

--- a/source/rooms/_room_blueprint.js
+++ b/source/rooms/_room_blueprint.js
@@ -1,4 +1,4 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { pathVoteField } = require("../util/messageComponentUtil");
 
 const enemies = [["name", "countExpression"], ["name", "countExpression"]];
@@ -6,9 +6,6 @@ const enemies = [["name", "countExpression"], ["name", "countExpression"]];
 module.exports = new RoomTemplate("name",
 	"essence",
 	"description",
-	[
-		new ResourceTemplate("countExpression", "visibility", "type")
-	],
 	function (adventure) {
 		adventure.room.actions = 0;
 

--- a/source/rooms/artifactguardian-bruteconvention.js
+++ b/source/rooms/artifactguardian-bruteconvention.js
@@ -1,16 +1,19 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { rollArtifact } = require("../artifacts/_artifactDictionary");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Brute", "n*2"]];
 
 module.exports = new RoomTemplate("Brute Convention",
 	"Unaligned",
 	"You're greeted by a book table with popular hits including: \"Stat-Checking for Dummies\", \"Sharp Objects: An Investment in Your Brute Career\", and \"Violence Gets You Everywhere\".\n\nAs you venture further into the convention hall, the keynote brute interrupts their presentation on \"How to be Faceless\" to highlight that a prime opportunity to practice mugging skills has just arrived.",
-	[
-		new ResourceTemplate("3", "internal", "levelsGained"),
-		new ResourceTemplate("1", "loot", "Artifact"),
-		new ResourceTemplate(`${enemies[0][1]}*75`, "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 3);
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "loot", 1);
+		const goldCount = Math.ceil(parseExpression(`${enemies[0][1]}*75`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/artifactguardian-royalslime.js
+++ b/source/rooms/artifactguardian-royalslime.js
@@ -1,16 +1,19 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
+const { rollArtifact } = require("../artifacts/_artifactDictionary");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Royal Slime", "0.5*n"]];
 
 module.exports = new RoomTemplate("A Slimy Throneroom",
 	"@{adventure}",
 	"Off to the side of the room lays a knocked over thone and crown. As the party approaches it, slime gushes from the ceiling, engulfing the objects. The slime collects stands itself up into a teardrop shape, suspending the throne inside it and the crown atop it, then begins rolling in the direction of the party.",
-	[
-		new ResourceTemplate("3", "internal", "levelsGained"),
-		new ResourceTemplate("1", "loot", "Artifact"),
-		new ResourceTemplate(`${enemies[0][1]}*100`, "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 3);
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "loot", 1);
+		const goldCount = Math.ceil(parseExpression(`${enemies[0][1]}*100`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/artifactguardian-treasureelemental.js
+++ b/source/rooms/artifactguardian-treasureelemental.js
@@ -1,4 +1,5 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
+const { rollArtifact } = require("../artifacts/_artifactDictionary");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
 const enemies = [["Treasure Elemental", "1"]];
@@ -6,11 +7,12 @@ const enemies = [["Treasure Elemental", "1"]];
 module.exports = new RoomTemplate("A windfall of treasure!",
 	"Earth",
 	"Floor to ceiling, gold coins, gems and other valuables are stacked in massive piles. Out of the corner of your eyes, you notice a mass of treasure meld together...",
-	[
-		new ResourceTemplate("3", "internal", "levelsGained"),
-		new ResourceTemplate("1", "loot", "Artifact"),
-		new ResourceTemplate("75", "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 3);
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "loot", 1);
+		const goldCount = Math.ceil(75 * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder(["greed"])
 ).setEnemies(enemies);

--- a/source/rooms/battle-bloodtailhawks.js
+++ b/source/rooms/battle-bloodtailhawks.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Bloodtail Hawk", "1.5*n"]];
 
 module.exports = new RoomTemplate("Hawk Fight",
 	"Wind",
 	"A flock of birds of prey swoop down looking for a meal.",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression(`${enemies[0][1]}*35`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-frogranch.js
+++ b/source/rooms/battle-frogranch.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Mechabee Soldier", "1"], ["Fire-Arrow Frog", "0.5*n"], ["Mechabee Soldier", "1"]];
 
 module.exports = new RoomTemplate("Frog Ranch",
 	"Earth",
 	"Two Mechabee Soldiers are interrupted while escorting a set of domesticated Fire-Arrow Frogs to another pasture.",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate(`${enemies[1][1]}*25+35`, "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression(`${enemies[1][1]}*25+35`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-mechabees.js
+++ b/source/rooms/battle-mechabees.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Mechabee Drone", "n*0.25"], ["Mechabee Soldier", "1"], ["Mechabee Drone", "n*0.25"]];
 
 module.exports = new RoomTemplate("Mechabee Fight",
 	"Earth",
 	"Some mechabees charge at you. In addition to starting a fight, it prompts you to wonder if mechabees are more mech or more bee.",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("25*n+35", "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression("25*n+35", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-meteorknight.js
+++ b/source/rooms/battle-meteorknight.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Earthly Knight", "0.5*n"], ["Meteor Knight", "1"], ["Asteroid", "0.25*n-1"]];
 
 module.exports = new RoomTemplate("Meteor Knight Fight",
 	"Fire",
 	"You are halted by a company of knights. By the time a Earthly Knight has advanced one step towards you, the Meteor Knight has recklessly charged across most of the gap!",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("45*n", "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression("45*n", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-slimes.js
+++ b/source/rooms/battle-slimes.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Slime", "0.5*n"], ["Ooze", "0.5*n"]];
 
 module.exports = new RoomTemplate("Slime Fight",
 	"@{adventure}",
 	"Some slimes and oozes approach...",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("35*n", "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression("35*n", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-tortoises.js
+++ b/source/rooms/battle-tortoises.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Geode Tortoise", "2"]];
 
 module.exports = new RoomTemplate("Tortoise Fight",
 	"Earth",
 	"The rocky terrain rises up to reveal a pair of shelled menaces.",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate("40*n", "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression("40*n", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/battle-wildfirearrowfrogs.js
+++ b/source/rooms/battle-wildfirearrowfrogs.js
@@ -1,15 +1,17 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
+const { parseExpression } = require("../util/textUtil");
 
 const enemies = [["Fire-Arrow Frog", "n"]];
 
 module.exports = new RoomTemplate("Wild Fire-Arrow Frogs",
 	"Fire",
 	"A blaze of orange and red in the muck outs itself as a warning sign to a blast of heated mud and venom.",
-	[
-		new ResourceTemplate("1", "internal", "levelsGained"),
-		new ResourceTemplate(`${enemies[0][1]}*35`, "loot", "Currency")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
+		const goldCount = Math.ceil(parseExpression(`${enemies[0][1]}*35`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/empty.js
+++ b/source/rooms/empty.js
@@ -6,8 +6,9 @@ const { pathVoteField } = require("../util/messageComponentUtil");
 module.exports = new RoomTemplate("Empty Room",
 	"Unaligned",
 	"This room is empty. Lucky you?",
-	[],
-	function (adventure) { },
+	function (adventure) {
+		return [];
+	},
 	function (roomEmbed, adventure) {
 		return {
 			embeds: [roomEmbed.addFields(pathVoteField)],

--- a/source/rooms/event-applepiewishingwell.js
+++ b/source/rooms/event-applepiewishingwell.js
@@ -6,12 +6,12 @@ const { EMPTY_SELECT_OPTION_SET } = require("../constants");
 module.exports = new RoomTemplate("Apple Pie Wishing Well",
 	"Light",
 	"In the center of the room sits a wishing well with a glowing crystal core. Pinned to a post in front of the well are instructions indicating that tossing an item into the well will float it back as a delicious apple pie.",
-	[],
 	function (adventure) {
 		adventure.room.history = {
 			"Items tossed": [],
 			"Core thief": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		let wellLabel, wellOptions, isWellDisabled, stealEmoji, stealLabel, isStealDisabled;

--- a/source/rooms/event-artifactdupe.js
+++ b/source/rooms/event-artifactdupe.js
@@ -8,13 +8,13 @@ const { generateRoutingRow, pathVoteField } = require("../util/messageComponentU
 module.exports = new RoomTemplate("Twin Pedestals",
 	"@{adventure}",
 	"There are two identical pedestals in this room. If you place an artifact on one, it'll duplicate onto the other.",
-	[],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Duped artifact": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		let duperLabel, duperOptions, isDuperDisabled, pillageLabel, pillageEmoji, isPillageDisabled;

--- a/source/rooms/event-door1ordoor2.js
+++ b/source/rooms/event-door1ordoor2.js
@@ -7,7 +7,6 @@ const { generateRoutingRow, partyStatsButton, pathVoteField } = require("../util
 module.exports = new RoomTemplate("Door 1 or Door 2?",
 	"@{adventureOpposite}",
 	"There are four doors in this room. Two of them are labelled with numbers \"Door 1\" and \"Door 2\" and have coin insert slots. The other two doors are the entrance and exit.",
-	[],
 	function (adventure) {
 		const ownedArtifacts = Object.keys(adventure.artifacts);
 		const door1Artifact = ownedArtifacts.length > 0 ? ownedArtifacts[adventure.generateRandomNumber(ownedArtifacts.length, "general")] : null;
@@ -16,6 +15,7 @@ module.exports = new RoomTemplate("Door 1 or Door 2?",
 			"Artifacts": [door1Artifact, door2Artifact],
 			"Option Picked": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		const partyHasNoArtifacts = adventure.room.history.Artifacts[0] === null;

--- a/source/rooms/event-freegoldonfire.js
+++ b/source/rooms/event-freegoldonfire.js
@@ -1,18 +1,17 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { SAFE_DELIMITER } = require("../constants");
 
 module.exports = new RoomTemplate("Free Gold?",
 	"Fire",
 	"A large pile of gold sits quietly in the middle of the room, seemingly alone.",
-	[
-		new ResourceTemplate("300", "internal", "Currency")
-	],
 	function (adventure) {
+		adventure.room.addResource("Gold", "Currency", "internal", 300);
 		adventure.room.history = {
 			"Burned": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		let reward = 300;

--- a/source/rooms/event-gearcollector.js
+++ b/source/rooms/event-gearcollector.js
@@ -1,20 +1,20 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 const { getNumberEmoji } = require("../util/textUtil");
+const { rollArtifact } = require("../artifacts/_artifactDictionary");
 
 module.exports = new RoomTemplate("Gear Collector",
 	"@{adventure}",
 	"The Gear Collector excitedly rushes past a mysterious black box to offer you gold to help complete their collection.",
-	[
-		new ResourceTemplate("1", "internal", "Artifact")
-	],
 	function (adventure) {
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "internal", 1);
 		adventure.room.actions = Math.ceil(adventure.delvers.length / 2);
 
 		adventure.room.history = {
 			"Traded for box": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		return {

--- a/source/rooms/event-impcontractfaire.js
+++ b/source/rooms/event-impcontractfaire.js
@@ -6,11 +6,11 @@ const { getEmoji } = require("../util/essenceUtil");
 module.exports = new RoomTemplate("Imp Contract Faire",
 	"@{adventureCounter}",
 	"The next room contains several stalls with imps hawking suspicious contracts. One imp offers a lucrative opportunity (*given you allow your essence to be changed to @{roomEssence}). Another offers a sketcy procedure for improving party health.",
-	[],
 	function (adventure) {
 		adventure.room.history = {
 			"HP Donor": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		let swapEmoji, swapLabel, isSwapDisabled, shareEmoji, shareLabel, isShareDisabled;

--- a/source/rooms/event-scorebeggar.js
+++ b/source/rooms/event-scorebeggar.js
@@ -6,11 +6,11 @@ const { SAFE_DELIMITER } = require("../constants");
 module.exports = new RoomTemplate("The Score Beggar",
 	"Water",
 	"In the center of the room sits a desolate beggar.\n\"Score... more score... I need it! I'll give you this.\"\nThe beggar motions to a flask of questionable liquid.",
-	[],
 	function (adventure) {
 		adventure.room.history = {
 			"Traded for Flask": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		const tradeButtons = new ActionRowBuilder();

--- a/source/rooms/finalbattle-elkemist.js
+++ b/source/rooms/finalbattle-elkemist.js
@@ -1,4 +1,4 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
 const enemies = [["Elkemist", "1"]];
@@ -6,9 +6,9 @@ const enemies = [["Elkemist", "1"]];
 module.exports = new RoomTemplate("A Northern Laboratory",
 	"Water",
 	"Flasks, beakers, vials and a myriad unknown substances line the innumerable tables and shelves of this room. An elk wanders from table to whiteboard to shelf, muttering various alchemical formuae to itself and taking absolutely no notice of the party.",
-	[
-		new ResourceTemplate("5", "internal", "levelsGained")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 5);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-mechaqueenbee.js
+++ b/source/rooms/finalbattle-mechaqueenbee.js
@@ -1,4 +1,4 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
 const enemies = [["Mecha Queen: Mech Mode", "1"], ["Mechabee Drone", "n"]];
@@ -6,9 +6,9 @@ const enemies = [["Mecha Queen: Mech Mode", "1"], ["Mechabee Drone", "n"]];
 module.exports = new RoomTemplate("The Hexagon: Mech Mode",
 	"Darkness",
 	"Myriad six-sided holograms flicker on as you enter the room displaying formations, statistics, and supply information. An alarm blares, and some mechabees (and their queen!) charge you. It dawns on you: they are in fact, more mech than bee.",
-	[
-		new ResourceTemplate("5", "internal", "levelsGained")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 5);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-mechaqueenmech.js
+++ b/source/rooms/finalbattle-mechaqueenmech.js
@@ -1,4 +1,4 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
 const enemies = [["Mecha Queen: Bee Mode", "1"], ["Mechabee Drone", "n"]];
@@ -6,9 +6,9 @@ const enemies = [["Mecha Queen: Bee Mode", "1"], ["Mechabee Drone", "n"]];
 module.exports = new RoomTemplate("The Hexagon: Bee Mode",
 	"Earth",
 	"Myriad six-sided holograms flicker on as you enter the room displaying formations, statistics, and supply information. An alarm blares, and some mechabees (and their queen!) charge you. It dawns on you: they are in fact, more bee than mech.",
-	[
-		new ResourceTemplate("5", "internal", "levelsGained")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 5);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-mirrors.js
+++ b/source/rooms/finalbattle-mirrors.js
@@ -1,4 +1,4 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
 const enemies = [["Mirror Clone", "n"]];
@@ -6,9 +6,9 @@ const enemies = [["Mirror Clone", "n"]];
 module.exports = new RoomTemplate("Hall of Mirrors",
 	"Unaligned",
 	"A long hall of wavy mirrors sits silently between the party and the door... until a bunch of shadows step out of the mirror and attack the party!",
-	[
-		new ResourceTemplate("5", "internal", "levelsGained")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 5);
+		return [];
+	},
 	generateCombatRoomBuilder([])
 ).setEnemies(enemies);

--- a/source/rooms/finalbattle-starryknight.js
+++ b/source/rooms/finalbattle-starryknight.js
@@ -1,4 +1,4 @@
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 
 const enemies = [["Starry Knight", "1"]];
@@ -6,9 +6,9 @@ const enemies = [["Starry Knight", "1"]];
 module.exports = new RoomTemplate("Confronting the Top Celestial Knight",
 	"Light",
 	"Sitting by fireside, the Starry Knight looks up at the party, interrupted amidst perusing the memoirs of his own accolades. 'Oh, I didn't see you there! You're just in time to be added to the list of my glorious victories in combat!'",
-	[
-		new ResourceTemplate("5", "internal", "levelsGained")
-	],
-	function (adventure) { },
+	function (adventure) {
+		adventure.room.addResource("levelsGained", "levelsGained", "internal", 5);
+		return [];
+	},
 	generateCombatRoomBuilder(["appease"])
 ).setEnemies(enemies);

--- a/source/rooms/service-guildstop.js
+++ b/source/rooms/service-guildstop.js
@@ -1,18 +1,20 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { pathVoteField, generateRoutingRow } = require("../util/messageComponentUtil");
 const { SAFE_DELIMITER } = require("../constants");
+const { rollChallenges } = require("../challenges/_challengeDictionary");
 
 module.exports = new RoomTemplate("Guildstop: For All Your Adventuring Needs",
 	"@{adventure}",
 	"The Adventurer's Guild has a contact point setup inside the dungeon. Specialization and Pet switching services are offered formally, while the gathering of other adventurers provides the opportunity to take on new challenges.",
-	[
-		new ResourceTemplate("2", "internal", "challenge")
-	],
 	function (adventure) {
+		rollChallenges(2, adventure).forEach(challenge => {
+			adventure.room.addResource(challenge, "challenge", "internal", 1);
+		})
 		adventure.room.history = {
 			"New challenges": []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		const specializationSwitchCost = 50;

--- a/source/rooms/service-library.js
+++ b/source/rooms/service-library.js
@@ -7,11 +7,11 @@ const { ordinalSuffixEN } = require("../util/textUtil");
 module.exports = new RoomTemplate("A Serene Library",
 	"@{adventure}",
 	"A quick stop at the library gives the party the chance to recharge Spells and research foes in the area.",
-	[],
 	function (adventure) {
 		adventure.room.history = {
 			Rechargers: []
 		};
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		const rechargeCost = 50;

--- a/source/rooms/service-merchant.js
+++ b/source/rooms/service-merchant.js
@@ -1,8 +1,8 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { getGearProperty } = require("../gear/_gearDictionary");
-const { getArtifact } = require("../artifacts/_artifactDictionary");
+const { getArtifact, rollArtifact } = require("../artifacts/_artifactDictionary");
 const { getItem } = require("../items/_itemDictionary");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
 
@@ -11,15 +11,19 @@ const uiGroups = [`gear${SAFE_DELIMITER}?`, "artifact", "item"];
 module.exports = new RoomTemplate("Mysterious Merchant",
 	"@{adventure}",
 	"A masked figure sits in front of a a line up of flasks, vials, trinkets, and weapons. \"Care to trade?\"",
-	[
-		new ResourceTemplate("2*n", "always", "Gear").setTier("?").setUIGroup(uiGroups[0]),
-		new ResourceTemplate("n+1", "always", "Artifact").setUIGroup(uiGroups[1]),
-		new ResourceTemplate("n+1", "always", "Item").setUIGroup(uiGroups[2])
-	],
 	function (adventure) {
+		const labyrinthResourceOrders = [];
+		for (let i = 0; i < 2 * adventure.delvers.length; i++) {
+			labyrinthResourceOrders.push({ type: "Gear", count: 1, visibility: "always", forSale: true, uiGroup: uiGroups[0] });
+		}
+		for (let i = 0; i < adventure.delvers.length + 1; i++) {
+			adventure.room.addResource(rollArtifact(adventure), "Artifact", "always", 1, uiGroups[1], 300);
+			labyrinthResourceOrders.push({ type: "Item", count: 1, visibility: "always", forSale: true, uiGroup: uiGroups[2] });
+		}
 		adventure.room.history = {
 			"Cap boosters": []
 		};
+		return labyrinthResourceOrders;
 	},
 	function (roomEmbed, adventure) {
 		const gearOptions = [];
@@ -32,19 +36,30 @@ module.exports = new RoomTemplate("Mysterious Merchant",
 					case uiGroups[0]: { // gear
 						const cost = adventure.room.resources[name].cost;
 						/** @type {number} */
-						const maxCharges = getGearProperty(name, "maxCharges");
-						gearOptions.push({
-							label: `${cost}g: ${name}`,
-							description: `Gear${![0, Infinity].includes(maxCharges) ? ` (${maxCharges} charges)` : ""}`,
-							value: `${name}${SAFE_DELIMITER}${i}`
-						});
+						let charges = getGearProperty(name, "maxCharges");
+						const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Spellcraft");
+						const shoddyDuration = adventure.getChallengeDuration("Shoddy Spellcraft");
+						if (shoddyPenalty > 0 && shoddyDuration > 0) {
+							charges = Math.ceil(charges * (100 - shoddyPenalty) / 100);
+						}
+						if (![0, Infinity].includes(charges)) {
+							gearOptions.push({
+								label: `${cost}g: ${name}`,
+								description: `${charges} Charges`,
+								value: `${name}${SAFE_DELIMITER}${i}`
+							});
+						} else {
+							gearOptions.push({
+								label: `${cost}g: ${name}`,
+								value: `${name}${SAFE_DELIMITER}${i}`
+							});
+						}
 						break;
 					}
 					case uiGroups[1]: { // artifacts
 						const artifact = getArtifact(name);
 						artifactOptions.push({
 							label: "${artifact.cost}g: ${name}",
-							description: "Artifact",
 							value: name
 						})
 						break;
@@ -52,8 +67,7 @@ module.exports = new RoomTemplate("Mysterious Merchant",
 					case uiGroups[2]: { // items
 						const item = getItem(name);
 						itemOptions.push({
-							label: `${item.cost}g: ${name}`,
-							description: "Item",
+							label: `${item.cost}g: ${name} (${adventure.room.resources[name].count} left)`,
 							value: `${name}${SAFE_DELIMITER}${i}`
 						})
 						break;

--- a/source/rooms/service-restsite.js
+++ b/source/rooms/service-restsite.js
@@ -6,7 +6,6 @@ const { generateRoutingRow, inspectSelfButton, pathVoteField } = require("../uti
 module.exports = new RoomTemplate("Rest Site & Training Dummy",
 	"@{adventure}",
 	"The room contains a campfire and a training dummy.",
-	[],
 	function (adventure) {
 		adventure.room.actions = adventure.delvers.length;
 

--- a/source/rooms/service-workshop.js
+++ b/source/rooms/service-workshop.js
@@ -5,7 +5,6 @@ const { generateRoutingRow, pathVoteField } = require("../util/messageComponentU
 module.exports = new RoomTemplate("Abandoned Forge",
 	"@{adventure}",
 	"The forge in this room could be used to modify some of your upgraded gear to change its form.",
-	[],
 	function (adventure) {
 		let pendingActions = adventure.delvers.length;
 		const hammerCount = adventure.getArtifactCount("Best-in-Class Hammer");

--- a/source/rooms/treasure-artifactvsgear.js
+++ b/source/rooms/treasure-artifactvsgear.js
@@ -1,23 +1,22 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
+const { rollArtifact } = require("../artifacts/_artifactDictionary");
 
 module.exports = new RoomTemplate("Treasure! Artifact or Gear?",
 	"@{adventure}",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
-	[
-		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0")
-	],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Treasure picked": []
 		};
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "always", 1);
+		return Array(2).fill(null).map(() => ({ type: "Gear", count: 1, visibility: "always", forSale: false }));
 	},
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {

--- a/source/rooms/treasure-artifactvsgold.js
+++ b/source/rooms/treasure-artifactvsgold.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
@@ -9,16 +9,16 @@ const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 module.exports = new RoomTemplate("Treasure! Artifact or Gold?",
 	"@{adventure}",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Gold' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
-	[
-		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
-		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0")
-	],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Treasure picked": []
 		};
+		const goldCount = Math.ceil(parseExpression("250*n", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "always", goldCount);
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "always", 1);
+		return [];
 	},
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {

--- a/source/rooms/treasure-artifactvsitems.js
+++ b/source/rooms/treasure-artifactvsitems.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 
 const { EMPTY_SELECT_OPTION_SET, SAFE_DELIMITER } = require("../constants");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
@@ -9,16 +9,14 @@ const { listifyEN, getNumberEmoji } = require("../util/textUtil");
 module.exports = new RoomTemplate("Treasure! Artifact or Items?",
 	"@{adventure}",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Artifact' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
-	[
-		new ResourceTemplate("1", "always", "Artifact").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
-	],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Treasure picked": []
 		};
+		adventure.room.addResource(rollArtifact(adventure), "Artifact", "always", 1);
+		return [{ type: "Item", count: 2 + adventure.delvers.length, visibility: "always", forSale: false }];
 	},
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {

--- a/source/rooms/treasure-gearvsitems.js
+++ b/source/rooms/treasure-gearvsitems.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { listifyEN, getNumberEmoji } = require("../util/textUtil");
@@ -9,16 +9,15 @@ const { generateRoutingRow, pathVoteField } = require("../util/messageComponentU
 module.exports = new RoomTemplate("Treasure! Gear or Items?",
 	"@{adventure}",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gear' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
-	[
-		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
-	],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Treasure picked": []
 		};
+		return [{ type: "Item", count: 2 + adventure.delvers.length, visibility: "always", forSale: false }].concat(
+			Array(2).fill(null).map(() => ({ type: "Gear", count: 1, visibility: "always", forSale: false }))
+		);
 	},
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {

--- a/source/rooms/treasure-goldvsgear.js
+++ b/source/rooms/treasure-goldvsgear.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { listifyEN, getNumberEmoji } = require("../util/textUtil");
@@ -9,16 +9,15 @@ const { generateRoutingRow, pathVoteField } = require("../util/messageComponentU
 module.exports = new RoomTemplate("Treasure! Gold or Gear?",
 	"@{adventure}",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Gear' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
-	[
-		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "Gear").setTier("?").setCostExpression("0")
-	],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Treasure picked": []
 		};
+		const goldCount = Math.ceil(parseExpression("250*n", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "always", goldCount);
+		return Array(2).fill(null).map(() => ({ type: "Gear", count: 1, visibility: "always", forSale: false }));
 	},
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {

--- a/source/rooms/treasure-goldvsitems.js
+++ b/source/rooms/treasure-goldvsitems.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 
-const { RoomTemplate, ResourceTemplate } = require("../classes");
+const { RoomTemplate } = require("../classes");
 const { SAFE_DELIMITER, EMPTY_SELECT_OPTION_SET } = require("../constants");
 
 const { listifyEN, getNumberEmoji } = require("../util/textUtil");
@@ -9,16 +9,15 @@ const { generateRoutingRow, pathVoteField } = require("../util/messageComponentU
 module.exports = new RoomTemplate("Treasure! Gold or Items?",
 	"@{adventure}",
 	"Two treasure boxes sit on opposite ends of a seesaw suspended above pits of molten rock. They are labled 'Gold' and 'Item Bundle' respectively, and it looks as if taking one will surely cause the other to plummet into the pit below.",
-	[
-		new ResourceTemplate("250*n", "always", "Currency").setCostExpression("0"),
-		new ResourceTemplate("2", "always", "Item").setCostExpression("0")
-	],
 	function (adventure) {
 		adventure.room.actions = 1;
 
 		adventure.room.history = {
 			"Treasure picked": []
 		};
+		const goldCount = Math.ceil(parseExpression("250*n", adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
+		adventure.room.addResource("Gold", "Currency", "always", goldCount);
+		return [{ type: "Item", count: 2 + adventure.delvers.length, visibility: "always", forSale: false }];
 	},
 	function (roomEmbed, adventure) {
 		if (adventure.room.actions > 0) {

--- a/source/selects/buygear.js
+++ b/source/selects/buygear.js
@@ -32,7 +32,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 		const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
 		let charges = getGearProperty(name, "maxCharges");
 		const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Spellcraft");
-		const shoddyDuration = adventure.getChallengeDuration("Shoddy Craftsmanship");
+		const shoddyDuration = adventure.getChallengeDuration("Shoddy Spellcraft");
 		if (shoddyPenalty > 0 && shoddyDuration > 0) {
 			charges = Math.ceil(charges * (100 - shoddyPenalty) / 100);
 		}

--- a/source/selects/loot.js
+++ b/source/selects/loot.js
@@ -45,7 +45,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 				const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
 				let charges = getGearProperty(name, "maxCharges");
 				const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Spellcraft");
-				const shoddyDuration = adventure.getChallengeDuration("Shoddy Craftsmanship");
+				const shoddyDuration = adventure.getChallengeDuration("Shoddy Spellcraft");
 				if (shoddyPenalty > 0 && shoddyDuration > 0) {
 					charges = Math.ceil(charges * (100 - shoddyPenalty) / 100);
 				}

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -59,7 +59,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 				const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
 				let charges = getGearProperty(name, "maxCharges");
 				const shoddyPenalty = adventure.getChallengeIntensity("Shoddy Spellcraft");
-				const shoddyDuration = adventure.getChallengeDuration("Shoddy Craftsmanship");
+				const shoddyDuration = adventure.getChallengeDuration("Shoddy Spellcraft");
 				if (shoddyPenalty > 0 && shoddyDuration > 0) {
 					charges = Math.ceil(charges * (100 - shoddyPenalty) / 100);
 				}

--- a/source/util/roomUtil.js
+++ b/source/util/roomUtil.js
@@ -1,4 +1,6 @@
 const { Enemy, EnemyTemplate, Adventure } = require("../classes");
+const { RN_TABLE_BASE } = require("../constants");
+const { anyDieSucceeds } = require("./mathUtil");
 
 /**
  * @param {EnemyTemplate} enemyTemplate can't do fetch inline due to circular dependency in enemies spawning enemies as moves
@@ -17,6 +19,24 @@ function spawnEnemy(enemyTemplate, adventure, includeCoward = false) {
 	}
 }
 
+/** @param {Adventure} adventure */
+function rollGearTier(adventure) {
+	const cloverCount = adventure.getArtifactCount("Negative-One Leaf Clover");
+	const baseUpgradeChance = 1 / 8;
+	const max = RN_TABLE_BASE ** 2;
+	const threshold = max * anyDieSucceeds(baseUpgradeChance, cloverCount);
+	adventure.updateArtifactStat("Negative-One Leaf Clover", "Expected Extra Rare Gear", (threshold / max) - baseUpgradeChance);
+	const roll = adventure.generateRandomNumber(max, "general");
+	if (roll >= 7 / 8 * max) {
+		return "Cursed";
+	} else if (roll < threshold) {
+		return "Rare";
+	} else {
+		return "Common";
+	}
+}
+
 module.exports = {
-	spawnEnemy
+	spawnEnemy,
+	rollGearTier
 };


### PR DESCRIPTION
Summary
-------
- fix merchant only stocking duplicates of the same item
- increased items in Treasure item bundle to 2 + delver count
- moved non-labyrinth specific resource generation into room's init function
- decomissioned ResourceTemplate class, most of its logic has been deprecated
- fixed Shoddy Spellcraft duration checks using wrong name
- applied Shoddy Spellcraft to merchant stock

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] confirmed UI generation in merchant and treasure rooms

Issue
-----
Closes #511