### PR TITLE
#532: add support for Modifier stacks scaling

### DIFF
--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -58,7 +58,7 @@ class GearTemplate {
 	bonus;
 	/** @type {number} */
 	bonus2;
-	/** @type {{name: string, stacks: number}[]} */
+	/** @type {{ name: string, stacks: number | { description: string, generator: (user: Combatant) => number } }[]} */
 	modifiers;
 	maxHP = 0;
 	power = 0;
@@ -163,7 +163,7 @@ class GearTemplate {
 		return this;
 	}
 
-	/** @param {...{name: string, stacks: number}} modifiersArray */
+	/** @param {...{ name: string, stacks: number | { description: string, generator: (user: Combatant) => number } }} modifiersArray */
 	setModifiers(...modifiersArray) {
 		this.modifiers = modifiersArray;
 		return this;

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -128,6 +128,17 @@ function buildGearDescription(gearName) {
 		.replace(/@{protection}/g, `(${getGearProperty(gearName, "protection")} + Max HP / 5)`)
 		.replace(/@{bonusSpeed}/g, "(Speed over 100)");
 
+	getGearProperty(gearName, "modifiers")?.forEach((modifier, index) => {
+		if (!modifier.name.startsWith("unparsed")) {
+			text = text.replace(new RegExp(`@{mod${index}}`, "g"), getApplicationEmojiMarkdown(modifier.name));
+		}
+		if (typeof modifier.stacks === "number") {
+			text = text.replace(new RegExp(`@{mod${index}Stacks}`, "g"), modifier.stacks);
+		} else {
+			text = text.replace(new RegExp(`@{mod${index}Stacks}`, "g"), `(${modifier.stacks.description})`);
+		}
+	})
+
 	return injectGearStats(text, gearName);
 }
 
@@ -191,6 +202,17 @@ function buildGearDescriptionWithHolderStats(gearName, gearIndex, holder) {
 	const bonusSpeed = holder.getSpeed(true) - 100;
 	text = text.replace(/@{bonusSpeed}/g, `[${Math.max(0, bonusSpeed)}]`);
 
+	getGearProperty(gearName, "modifiers")?.forEach((modifier, index) => {
+		if (!modifier.name.startsWith("unparsed")) {
+			text = text.replace(new RegExp(`@{mod${index}}`, "g"), getApplicationEmojiMarkdown(modifier.name));
+		}
+		if (typeof modifier.stacks === "number") {
+			text = text.replace(new RegExp(`@{mod${index}Stacks}`, "g"), modifier.stacks);
+		} else {
+			text = text.replace(new RegExp(`@{mod${index}Stacks}`, "g"), `[${modifier.stacks.generator(holder)}]`);
+		}
+	})
+
 	return injectGearStats(text, gearName);
 }
 
@@ -199,12 +221,6 @@ function buildGearDescriptionWithHolderStats(gearName, gearIndex, holder) {
  * @param {string} gearName
  */
 function injectGearStats(text, gearName) {
-	getGearProperty(gearName, "modifiers")?.forEach((modifier, index) => {
-		if (!modifier.name.startsWith("unparsed")) {
-			text = text.replace(new RegExp(`@{mod${index}}`, "g"), getApplicationEmojiMarkdown(modifier.name));
-		}
-		text = text.replace(new RegExp(`@{mod${index}Stacks}`, "g"), modifier.stacks);
-	})
 	text = text.replace(/@{essence}/g, getEmoji(getGearProperty(gearName, "essence")))
 	return calculateTagContent(text, [
 		"critMultiplier",

--- a/source/gear/tornadoformation-base.js
+++ b/source/gear/tornadoformation-base.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Tornado Formation",
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const resultLines = dealDamage(targets, user, damage + user.getPower(), false, essence, adventure);
-		const pendingSwiftness = { ...swiftness };
+		const pendingSwiftness = { name: swiftness.name, stacks: swiftness.stacks.generator(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 		if (user.crit) {
 			pendingSwiftness.stacks *= critMultiplier;
@@ -32,4 +32,4 @@ module.exports = new GearTemplate("Tornado Formation",
 	.setUpgrades("Charging Storm Formation", "Supportive Storm Formation")
 	.setMoraleRequirement(1)
 	.setDamage(40)
-	.setModifiers({ name: "Swiftness", stacks: 2 });
+	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed / 5", generator: (user) => 2 + Math.floor((user.getSpeed(true) - 100) / 5) } });

--- a/source/gear/tornadoformation-charging.js
+++ b/source/gear/tornadoformation-charging.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Charging Tornado Formation",
 		}
 		const resultLines = dealDamage(targets, user, damage + user.getPower(), false, essence, adventure);
 		const reciepts = [];
-		const pendingSwiftness = { ...swiftness };
+		const pendingSwiftness = { name: swiftness.name, stacks: swiftness.stacks.generator(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 		if (user.crit) {
 			pendingSwiftness.stacks *= critMultiplier;
@@ -33,4 +33,4 @@ module.exports = new GearTemplate("Charging Tornado Formation",
 	.setSidegrades("Supportive Storm Formation")
 	.setMoraleRequirement(1)
 	.setDamage(40)
-	.setModifiers({ name: "Swiftness", stacks: 2 }, { name: "Empowerment", stacks: 25 });
+	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed / 5", generator: (user) => 2 + Math.floor((user.getSpeed(true) - 100) / 5) } }, { name: "Empowerment", stacks: 25 });

--- a/source/gear/tornadoformation-supportive.js
+++ b/source/gear/tornadoformation-supportive.js
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Supportive Tornado Formation",
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const resultLines = dealDamage(targets, user, damage + user.getPower(), false, essence, adventure);
-		const pendingStagger = { ...swiftness };
+		const pendingStagger = { name: swiftness.name, stacks: swiftness.stacks.generator(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 		if (user.crit) {
 			pendingStagger.stacks *= critMultiplier;
@@ -34,5 +34,5 @@ module.exports = new GearTemplate("Supportive Tornado Formation",
 	.setSidegrades("Charging Storm Formation")
 	.setMoraleRequirement(1)
 	.setDamage(40)
-	.setModifiers({ name: "Swiftness", stacks: 2 })
+	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed / 5", generator: (user) => 2 + Math.floor((user.getSpeed(true) - 100) / 5) } })
 	.setBonus(2); // Stagger relieved


### PR DESCRIPTION
Summary
-------
- add support for modifier stacks scaling
- add Bonus Speed scaling to Tornado Formation Swiftness

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] checked Tornado Formation's swiftness descriptions with /manual gear

Issue
-----
Closes #532