### PR TITLE
#540: add damage cap and essence counter damage to inspect self

### DIFF
--- a/source/archetypes/_archetypeDictionary.js
+++ b/source/archetypes/_archetypeDictionary.js
@@ -32,7 +32,7 @@ function getArchetype(archetypeName) {
  * @param {string} specialzation
  */
 function getArchetypeActionName(archetype, specialzation) {
-	return ARCHETYPES[archetype].archetypeActions[specialzation].name;
+	return ARCHETYPES[archetype].archetypeActions[specialzation];
 }
 
 /**

--- a/source/archetypes/beasttamer.js
+++ b/source/archetypes/beasttamer.js
@@ -1,7 +1,7 @@
 const { bold, italic } = require("discord.js");
 const { ArchetypeTemplate } = require("../classes");
 const { getPetMoveDescription } = require("../pets/_petDictionary");
-const { listifyEN } = require("../util/textUtil");
+const { listifyEN, generateTextBar } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Beast Tamer",
 	["Survivalist", "Marauder", "Hunter", "Wildkin"],

--- a/source/classes/Combatant.js
+++ b/source/classes/Combatant.js
@@ -151,7 +151,7 @@ class Delver extends Combatant {
 			} else {
 				return totalCritRate;
 			}
-		}, 0)) / 100);
+		}, 0)));
 	}
 
 	getPoise() {

--- a/source/gear/arcanesledge-fatiguing.js
+++ b/source/gear/arcanesledge-fatiguing.js
@@ -38,4 +38,4 @@ module.exports = new GearTemplate(gearName,
 	.setDamage(40)
 	.setBonus(1) // Buffs removed
 	.setRnConfig({ buffs: 2 })
-	.setModifiers({ name: "Impotence", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed / 10) } });
+	.setModifiers({ name: "Impotence", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed / 10) } });

--- a/source/gear/carrot-balanced.js
+++ b/source/gear/carrot-balanced.js
@@ -48,5 +48,5 @@ module.exports = new GearTemplate("Balanced Carrot",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Guarding Carrot", "Balanced Carrot")
 	.setCooldown(1)
-	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed / 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } }, { name: "Finesse", stacks: 1 })
+	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed ÷ 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } }, { name: "Finesse", stacks: 1 })
 	.setCritMultiplier(1);

--- a/source/gear/carrot-base.js
+++ b/source/gear/carrot-base.js
@@ -48,5 +48,5 @@ module.exports = new GearTemplate("Carrot",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Guarding Carrot", "Balanced Carrot")
 	.setCooldown(1)
-	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed / 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })
+	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed ÷ 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })
 	.setCritMultiplier(1);

--- a/source/gear/carrot-guarding.js
+++ b/source/gear/carrot-guarding.js
@@ -49,6 +49,6 @@ module.exports = new GearTemplate("Guarding Carrot",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setUpgrades("Guarding Carrot", "Balanced Carrot")
 	.setCooldown(1)
-	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed / 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })
+	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed ÷ 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })
 	.setCritMultiplier(1)
 	.setProtection(50);

--- a/source/gear/cloak-accurate.js
+++ b/source/gear/cloak-accurate.js
@@ -26,5 +26,5 @@ module.exports = new GearTemplate("Accurate Cloak",
 ).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Accurate Cloak", "Powerful Cloak")
 	.setCooldown(1)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } })
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } })
 	.setCritRate(10);

--- a/source/gear/cloak-base.js
+++ b/source/gear/cloak-base.js
@@ -24,4 +24,4 @@ module.exports = new GearTemplate("Cloak",
 ).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Accurate Cloak", "Powerful Cloak")
 	.setCooldown(1)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });

--- a/source/gear/cloak-powerful.js
+++ b/source/gear/cloak-powerful.js
@@ -26,5 +26,5 @@ module.exports = new GearTemplate("Powerful Cloak",
 ).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Accurate Cloak", "Powerful Cloak")
 	.setCooldown(1)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } })
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } })
 	.setPower(10);

--- a/source/gear/conjuredicepillar-base.js
+++ b/source/gear/conjuredicepillar-base.js
@@ -24,4 +24,4 @@ module.exports = new GearTemplate("Conjured Ice Pillar",
 ).setTargetingTags({ type: "self", team: "ally" })
 	.setUpgrades("Devoted Conjured Ice Pillar", "Taunting Conjured Ice Pillar")
 	.setCharges(15)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } }, { name: "Vigilance", stacks: 1 });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } }, { name: "Vigilance", stacks: 1 });

--- a/source/gear/conjuredicepillar-devoted.js
+++ b/source/gear/conjuredicepillar-devoted.js
@@ -24,4 +24,4 @@ module.exports = new GearTemplate("Devoted Conjured Ice Pillar",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setSidegrades("Taunting Conjured Ice Pillar")
 	.setCharges(15)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } }, { name: "Vigilance", stacks: 1 });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } }, { name: "Vigilance", stacks: 1 });

--- a/source/gear/conjuredicepillar-taunting.js
+++ b/source/gear/conjuredicepillar-taunting.js
@@ -31,4 +31,4 @@ module.exports = new GearTemplate("Taunting Conjured Ice Pillar",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Devoted Conjured Ice Pillar")
 	.setCharges(15)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } }, { name: "Vigilance", stacks: 1 });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } }, { name: "Vigilance", stacks: 1 });

--- a/source/gear/enchantmentsiphon-flanking.js
+++ b/source/gear/enchantmentsiphon-flanking.js
@@ -33,4 +33,4 @@ module.exports = new GearTemplate("Flanking Enchantment Siphon",
 	.setSidegrades("Tormenting Enchantment Siphon")
 	.setCooldown(1)
 	.setProtection(0)
-	.setModifiers({ name: "Exposure", stacks: { description: "1 + Bonus Speed / 10", generator: (user) => 1 + Math.floor(user.getBonusSpeed() / 10) } });
+	.setModifiers({ name: "Exposure", stacks: { description: "1 + Bonus Speed ÷ 10", generator: (user) => 1 + Math.floor(user.getBonusSpeed() / 10) } });

--- a/source/gear/encouragement-base.js
+++ b/source/gear/encouragement-base.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Encouragement",
 	.setCharges(15)
 	.setModifiers({
 		name: "Excellence", stacks: {
-			description: "2 + Bonus Speed / 10",
+			description: "2 + Bonus Speed ÷ 10",
 			generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10)
 		}
 	}, {

--- a/source/gear/encouragement-rallying.js
+++ b/source/gear/encouragement-rallying.js
@@ -29,7 +29,7 @@ module.exports = new GearTemplate("Rallying Encouragement",
 	.setCharges(15)
 	.setModifiers({
 		name: "Excellence", stacks: {
-			description: "2 + Bonus Speed / 10",
+			description: "2 + Bonus Speed ÷ 10",
 			generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10)
 		}
 	}, {

--- a/source/gear/encouragement-vigorous.js
+++ b/source/gear/encouragement-vigorous.js
@@ -28,7 +28,7 @@ module.exports = new GearTemplate("Vigorous Encouragement",
 	.setCharges(15)
 	.setModifiers({
 		name: "Excellence", stacks: {
-			description: "2 + Bonus Speed / 10",
+			description: "2 + Bonus Speed ÷ 10",
 			generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10)
 		}
 	}, {

--- a/source/gear/forbiddenknowledge-soothing.js
+++ b/source/gear/forbiddenknowledge-soothing.js
@@ -42,4 +42,4 @@ module.exports = new GearTemplate("Soothing Forbidden Knowledge",
 	.setPactCost([2, "Consume @{pactCost} morale"])
 	.setBonus(1) // Level-Ups
 	.setBonus2(1) // Cooldown Reduction
-	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed / 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })
+	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed ÷ 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })

--- a/source/gear/shadowofconfusion-base.js
+++ b/source/gear/shadowofconfusion-base.js
@@ -30,4 +30,4 @@ module.exports = new GearTemplate("Shadow of Confusion",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Incompatible Shadow of Confusion", "Shattering Shadow of Confusion")
 	.setCharges(15)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });

--- a/source/gear/shadowofconfusion-incompatible.js
+++ b/source/gear/shadowofconfusion-incompatible.js
@@ -30,5 +30,5 @@ module.exports = new GearTemplate("Incompatible Shadow of Confusion",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Shattering Shadow of Confusion")
 	.setCharges(15)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } },
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } },
 		{ name: "Incompatible", stacks: 3 });

--- a/source/gear/shadowofconfusion-shattering.js
+++ b/source/gear/shadowofconfusion-shattering.js
@@ -30,5 +30,5 @@ module.exports = new GearTemplate("Shattering Shadow of Confusion",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Incompatible Shadow of Confusion")
 	.setCharges(15)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } },
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } },
 		{ name: "Frailty", stacks: 3 });

--- a/source/gear/smokescreen-base.js
+++ b/source/gear/smokescreen-base.js
@@ -25,4 +25,4 @@ module.exports = new GearTemplate("Smokescreen",
 ).setTargetingTags({ type: `random${SAFE_DELIMITER}${bounceCount}`, team: "ally" })
 	.setUpgrades("Chaining Smokescreen", "Double Smokescreen")
 	.setCooldown(1)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });

--- a/source/gear/smokescreen-chaining.js
+++ b/source/gear/smokescreen-chaining.js
@@ -25,4 +25,4 @@ module.exports = new GearTemplate("Chaining Smokescreen",
 ).setTargetingTags({ type: `random${SAFE_DELIMITER}${bounceCount}`, team: "ally" })
 	.setSidegrades("Double Smokescreen")
 	.setCooldown(0)
-	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP / 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });
+	.setModifiers({ name: "Evasion", stacks: { description: "2 + Bonus HP ÷ 50", generator: (user) => 2 + Math.floor(user.getBonusHP() / 50) } });

--- a/source/gear/smokescreen-double.js
+++ b/source/gear/smokescreen-double.js
@@ -25,4 +25,4 @@ module.exports = new GearTemplate("Double Smokescreen",
 ).setTargetingTags({ type: `random${SAFE_DELIMITER}${bounceCount}`, team: "ally" })
 	.setUpgrades("Chaining Smokescreen", "Double Smokescreen")
 	.setCooldown(1)
-	.setModifiers({ name: "Evasion", stacks: { description: "1 + Bonus HP / 50", generator: (user) => 1 + Math.floor(user.getBonusHP() / 50) } });
+	.setModifiers({ name: "Evasion", stacks: { description: "1 + Bonus HP ÷ 50", generator: (user) => 1 + Math.floor(user.getBonusHP() / 50) } });

--- a/source/gear/tornadoformation-base.js
+++ b/source/gear/tornadoformation-base.js
@@ -32,4 +32,4 @@ module.exports = new GearTemplate("Tornado Formation",
 	.setUpgrades("Charging Storm Formation", "Supportive Storm Formation")
 	.setMoraleRequirement(1)
 	.setDamage(40)
-	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } });
+	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } });

--- a/source/gear/tornadoformation-charging.js
+++ b/source/gear/tornadoformation-charging.js
@@ -33,4 +33,4 @@ module.exports = new GearTemplate("Charging Tornado Formation",
 	.setSidegrades("Supportive Storm Formation")
 	.setMoraleRequirement(1)
 	.setDamage(40)
-	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } }, { name: "Empowerment", stacks: 25 });
+	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } }, { name: "Empowerment", stacks: 25 });

--- a/source/gear/tornadoformation-supportive.js
+++ b/source/gear/tornadoformation-supportive.js
@@ -34,5 +34,5 @@ module.exports = new GearTemplate("Supportive Tornado Formation",
 	.setSidegrades("Charging Storm Formation")
 	.setMoraleRequirement(1)
 	.setDamage(40)
-	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } })
+	.setModifiers({ name: "Swiftness", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } })
 	.setBonus(2); // Stagger relieved

--- a/source/gear/warcry-flanking.js
+++ b/source/gear/warcry-flanking.js
@@ -28,5 +28,5 @@ module.exports = new GearTemplate("Flanking War Cry",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Weakening Warcry")
 	.setCooldown(1)
-	.setModifiers({ name: "Distraction", stacks: 0 }, { name: "Exposure", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } })
+	.setModifiers({ name: "Distraction", stacks: 0 }, { name: "Exposure", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } })
 	.setStagger(2);

--- a/source/gear/watersstillness-accelerating.js
+++ b/source/gear/watersstillness-accelerating.js
@@ -28,4 +28,4 @@ module.exports = new GearTemplate("Accelerating Water's Stillness",
 	.setSidegrades("Cleansing Water's Stillness")
 	.setCharges(15)
 	.setStagger(-2)
-	.setModifiers({ name: "Vigilance", stacks: 0 }, { name: "Swiftness", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } });
+	.setModifiers({ name: "Vigilance", stacks: 0 }, { name: "Swiftness", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } });

--- a/source/gear/windburst-base.js
+++ b/source/gear/windburst-base.js
@@ -24,4 +24,4 @@ module.exports = new GearTemplate("Wind Burst",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setUpgrades("Inspiring Wind Burst", "Toxic Wind Burst")
 	.setCharges(15)
-	.setModifiers({ name: "Distraction", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } });
+	.setModifiers({ name: "Distraction", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } });

--- a/source/gear/windburst-inspiring.js
+++ b/source/gear/windburst-inspiring.js
@@ -25,5 +25,5 @@ module.exports = new GearTemplate("Inspiring Wind Burst",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Toxic Wind Burst")
 	.setCharges(15)
-	.setModifiers({ name: "Distraction", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } })
+	.setModifiers({ name: "Distraction", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } })
 	.setBonus(1);

--- a/source/gear/windburst-toxic.js
+++ b/source/gear/windburst-toxic.js
@@ -24,4 +24,4 @@ module.exports = new GearTemplate("Toxic Wind Burst",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setSidegrades("Inspiring Wind Burst")
 	.setCharges(15)
-	.setModifiers({ name: "Distraction", stacks: { description: "2 + Bonus Speed / 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } }, { name: "Poison", stacks: 3 });
+	.setModifiers({ name: "Distraction", stacks: { description: "2 + Bonus Speed ÷ 10", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 10) } }, { name: "Poison", stacks: 3 });


### PR DESCRIPTION
Summary
-------
- add damage cap and essence counter damage to inspect self
- reorganize inspect self payload
- fix crashes on inspect self and beast tamer predict
- replace / with ÷ in scaling descriptions

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] viewed inspect self payload

Issue
-----
Closes #540