### PR TITLE
#547: /manual archetype

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 # Prophets of the Labyrinth Change Log
-## Prophets of the Labyrinth v0.17.0:
+## Prophets of the Labyrinth v0.18.0:
 - New Artifact: Add Blocker
 ## Prophets of the Labyrinth v0.17.0:
 ### Pets

--- a/source/archetypes/_archetypeDictionary.js
+++ b/source/archetypes/_archetypeDictionary.js
@@ -22,6 +22,10 @@ for (const file of [
 	ARCHETYPES[archetype.name] = archetype;
 }
 
+function getAllArchetypeNames() {
+	return Object.keys(ARCHETYPES);
+}
+
 /** @param {string} archetypeName */
 function getArchetype(archetypeName) {
 	return ARCHETYPES[archetypeName];
@@ -62,6 +66,7 @@ function getArchetypesCount() {
 }
 
 module.exports = {
+	getAllArchetypeNames,
 	getArchetype,
 	getArchetypeActionName,
 	rollArchetypes,

--- a/source/archetypes/adventurer.js
+++ b/source/archetypes/adventurer.js
@@ -2,7 +2,8 @@ const { ArchetypeTemplate } = require("../classes");
 
 module.exports = new ArchetypeTemplate("Adventurer",
 	["Pirate", "Omenbringer", "Sentinel", "Vanguard"],
-	"They won't be able to predict anything, but have double normal stat growths. Their Shortsword grants them @e{Finesse}.",
+	"An Adventurer doesn't predict anything, but has double normal stat growths.",
+	"Their Shortsword grants them @e{Finesse}.",
 	"Fire",
 	(embed, adventure) => {
 		const descriptions = [

--- a/source/archetypes/beasttamer.js
+++ b/source/archetypes/beasttamer.js
@@ -5,7 +5,8 @@ const { listifyEN, generateTextBar } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Beast Tamer",
 	["Survivalist", "Marauder", "Hunter", "Wildkin"],
-	"They'll be able to predict what moves pets are using, what level the enemies are and how much HP they have. Their Stick inflicts @e{Impotence} on their target.",
+	"A Beast Tamer can predict what moves pets are using, what level the enemies are and how much HP they have.",
+	"Their Stick inflicts @e{Impotence} on their target.",
 	"Earth",
 	(embed, adventure) => {
 		const nextPetOwner = adventure.delvers[adventure.petRNs.delverIndex];

--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -4,7 +4,8 @@ const { getEmoji } = require("../util/essenceUtil.js");
 
 module.exports = new ArchetypeTemplate("Chemist",
 	["Saboteur", "Researcher", "Poisoner", "Druid"],
-	"They'll be able to assess combatant modifiers and which essence to use to counter them. They'll also be able to make items with their Cauldron Stir.",
+	"A Chemist can assess combatant modifiers and which essence to use to counter them.",
+	"They'll also be able to make items with their Cauldron Stir.",
 	"Light",
 	(embed, adventure) => {
 		const eligibleCombatants = adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0);

--- a/source/archetypes/knight.js
+++ b/source/archetypes/knight.js
@@ -3,7 +3,8 @@ const { listifyEN } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Knight",
 	["Templar", "Paladin", "General", "Juggernaut"],
-	"They'll be able to predict who enemies are targeting with which moves and the order combatants will act in. Their Lance will grant them protection.",
+	"A Knight can predict who enemies are targeting with which moves and the order combatants will act in.",
+	"Their Lance will grant them protection.",
 	"Water",
 	(embed, adventure) => {
 		const activeCombatants = adventure.room.enemies.filter(enemy => enemy.hp > 0)

--- a/source/archetypes/martialartist.js
+++ b/source/archetypes/martialartist.js
@@ -4,7 +4,8 @@ const { generateTextBar } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Martial Artist",
 	["Fencer", "Pugilist", "Deadeye", "Ninja"],
-	"They'll be able to assess combatant how much Stagger to Stun each combatant and what moves enemies will be using this and next round. Their Flourish inflicts @e{Distraction} on their target.",
+	"A Martial Artist assess combatant how much Stagger to Stun each combatant and what moves enemies will be using this and next round.",
+	"Their Flourish inflicts @e{Distraction} on their target.",
 	"Darkness",
 	(embed, adventure) => {
 		embed.addFields({

--- a/source/archetypes/ritualist.js
+++ b/source/archetypes/ritualist.js
@@ -4,7 +4,8 @@ const { generateTextBar } = require("../util/textUtil");
 
 module.exports = new ArchetypeTemplate("Ritualist",
 	["Hemomancer", "Warlock", "Illusionist", "Reaper"],
-	"They'll be able to predict the order combatants will act in and assess HP levels. Their Life Drain will allow them to regain HP.",
+	"A Ritualist can predict the order combatants will act in and assess HP levels.",
+	"Their Life Drain will allow them to regain HP.",
 	"Darkness",
 	(embed, adventure) => {
 		const activeCombatants = adventure.room.enemies.filter(enemy => enemy.hp > 0)

--- a/source/archetypes/rogue.js
+++ b/source/archetypes/rogue.js
@@ -5,7 +5,8 @@ const { getEmoji } = require("../util/essenceUtil");
 
 module.exports = new ArchetypeTemplate("Rogue",
 	["Assassin", "Acrobat", "Charlatan", "Juggler"],
-	"They'll be able to predict which combatants will critically hit and which essence to use to counter each combatant. Their Daggers gives them @e{Excellence}.",
+	"A Rogue can predict which combatants will critically hit and which essence to use to counter each combatant.",
+	"Their Daggers gives them @e{Excellence}.",
 	"Fire",
 	(embed, adventure) => {
 		/** @param {Combatant} combatant */

--- a/source/archetypes/tactician.js
+++ b/source/archetypes/tactician.js
@@ -14,7 +14,8 @@ function generateCritAndModifierField(team, adventure) {
 
 module.exports = new ArchetypeTemplate("Tactician",
 	["Spellblade", "Historian", "Infiltrator", "Legionnaire"],
-	"They'll be able to predict which combatants will score Critical Hits and what modifiers they have as well as the party's morale. Their Spear increases party morale on a Critical Hit.",
+	"A Tactician can predict which combatants will score Critical Hits and what modifiers they have as well as the party's morale.",
+	"Their Spear increases party morale on a Critical Hit.",
 	"Light",
 	(embed, adventure) => {
 		embed.addFields(generateCritAndModifierField(adventure.room.enemies.filter(combatant => combatant.hp > 0), adventure));

--- a/source/archetypes/trickster.js
+++ b/source/archetypes/trickster.js
@@ -11,7 +11,8 @@ function createModifierField(combatant) {
 
 module.exports = new ArchetypeTemplate("Trickster",
 	["Bard", "Gambler", "Doomsayer", "Dancer"],
-	"They'll be able to assess combatant modifiers and random outcomes of moves. Their Deck of Cards will inflict a random amount of @e{Misfortune} on their target.",
+	"A Trickster can assess combatant modifiers and random outcomes of moves.",
+	"Their Deck of Cards will inflict a random amount of @e{Misfortune} on their target.",
 	"Wind",
 	(embed, adventure) => {
 		// Separate Enemies and Delvers into different rows

--- a/source/buttons/deploy.js
+++ b/source/buttons/deploy.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, bold } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { getArchetype } = require('../archetypes/_archetypeDictionary');
 const { getPlayer } = require('../orcustrators/playerOrcustrator');
@@ -54,7 +54,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				setAdventure(adventure);
 
 				// Send confirmation text
-				interaction.channel.send(`**${interaction.user.displayName}** ${isSwitching ? "has switched to" : "will be playing as"} **${archetype}**. ${injectApplicationEmojiMarkdown(getArchetype(archetype).description)}`);
+				const { description, archetypeActionSummary } = getArchetype(archetype);
+				interaction.channel.send(`${bold(interaction.user.displayName)} ${isSwitching ? "has switched to" : "will be playing as"} **${archetype}**. ${description} ${injectApplicationEmojiMarkdown(archetypeActionSummary)}`);
 			})
 
 			collector.on("end", () => {

--- a/source/buttons/join.js
+++ b/source/buttons/join.js
@@ -49,13 +49,13 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		// Update game logic
 		const delver = new Delver(interaction.user.id, interaction.user.username, adventureId);
 		const player = getPlayer(interaction.user.id, interaction.guildId);
-		if (player.favoritePet !== "") {
+		if (player.favoritePet) {
 			delver.pet = {
 				type: player.favoritePet,
 				level: player.pets[player.favoritePet]
 			};
 		}
-		if (player.favoriteArchetype !== "") {
+		if (player.favoriteArchetype) {
 			delver.archetype = player.favoriteArchetype;
 		}
 		adventure.delvers.push(delver);

--- a/source/classes/ArchetypeTemplate.js
+++ b/source/classes/ArchetypeTemplate.js
@@ -8,6 +8,7 @@ class ArchetypeTemplate {
 	 * @param {string} nameInput
 	 * @param {string[]} specializationNames
 	 * @param {string} descriptionInput
+	 * @param {string} archetypeActionSummary
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Unaligned"} essenceEnum
 	 * @param {(embed: EmbedBuilder, adventure: Adventure ) => EmbedBuilder} predictFunction
 	 * @param {(combatant: Combatant) => string} miniPredictFunction
@@ -15,10 +16,11 @@ class ArchetypeTemplate {
 	 * @param {string[]} startingGearNames
 	 * @param {{maxHPGrowth: number, powerGrowth: number, speedGrowth: number, critRateGrowth: number, poiseGrowth: number}} growthRates
 	 */
-	constructor(nameInput, specializationNames, descriptionInput, essenceEnum, predictFunction, miniPredictFunction, archetypeActionsMap, startingGearNames, { maxHPGrowth, powerGrowth, speedGrowth, critRateGrowth }) {
+	constructor(nameInput, specializationNames, descriptionInput, archetypeActionSummary, essenceEnum, predictFunction, miniPredictFunction, archetypeActionsMap, startingGearNames, { maxHPGrowth, powerGrowth, speedGrowth, critRateGrowth }) {
 		if (!nameInput) throw new BuildError("Falsy nameInput");
 		if (!specializationNames) throw new BuildError("Falsy specializationNames");
 		if (!descriptionInput) throw new BuildError("Falsy descriptionInput");
+		if (!archetypeActionSummary) throw new BuildError("Falsy archetypeActionSummary");
 		if (!essenceEnum) throw new BuildError("Falsy essenceEnum");
 		if (!predictFunction) throw new BuildError("Falsy predictFunction");
 		if (!miniPredictFunction) throw new BuildError("Falsy miniPredictFunction");
@@ -28,6 +30,7 @@ class ArchetypeTemplate {
 		this.name = nameInput;
 		this.specializations = specializationNames;
 		this.description = descriptionInput;
+		this.archetypeActionSummary = archetypeActionSummary;
 		this.essence = essenceEnum;
 		this.predict = predictFunction;
 		this.miniPredict = miniPredictFunction;

--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -57,7 +57,7 @@ class GearTemplate {
 	/** @type {number} */
 	bonus;
 	/** @type {number} */
-	bonus2;
+	secondBonus;
 	/** @type {{ name: string, stacks: number | { description: string, generator: (user: Combatant) => number } }[]} */
 	modifiers;
 	maxHP = 0;
@@ -158,8 +158,8 @@ class GearTemplate {
 	}
 
 	/** @param {number} integer */
-	setBonus2(integer) {
-		this.bonus2 = integer;
+	setSecondBonus(integer) {
+		this.secondBonus = integer;
 		return this;
 	}
 

--- a/source/commands/delve.js
+++ b/source/commands/delve.js
@@ -51,13 +51,13 @@ module.exports = new CommandWrapper(mainId, "Start a new adventure", PermissionF
 				adventure.messageIds.recruit = recruitMessage.id;
 				const delver = new Delver(interaction.user.id, interaction.member.displayName, thread.id);
 				const player = getPlayer(interaction.user.id, interaction.guildId);
-				if (player.favoritePet !== "") {
+				if (player.favoritePet) {
 					delver.pet = {
 						type: player.favoritePet,
 						level: player.pets[player.favoritePet]
 					};
 				}
-				if (player.favoriteArchetype !== "") {
+				if (player.favoriteArchetype) {
 					delver.archetype = player.favoriteArchetype;
 				}
 				adventure.delvers.push(delver);

--- a/source/commands/manual/index.js
+++ b/source/commands/manual/index.js
@@ -5,6 +5,7 @@ const { createSubcommandMappings } = require('../../util/fileUtil');
 const mainId = "manual";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
 	"beginnersguide.js",
+	"lookuparchetype.js",
 	"lookupartifact.js",
 	"lookupchallenge.js",
 	"lookupenemy.js",

--- a/source/commands/manual/lookuparchetype.js
+++ b/source/commands/manual/lookuparchetype.js
@@ -1,0 +1,64 @@
+const { CommandInteraction, bold } = require("discord.js");
+const { embedTemplate } = require("../../util/embedUtil");
+const { getEmoji, getColor } = require("../../util/essenceUtil");
+const { listifyEN } = require("../../util/textUtil");
+const { getAllArchetypeNames, getArchetype, getArchetypeActionName } = require("../../archetypes/_archetypeDictionary");
+const { buildGearDescription } = require("../../gear/_gearDictionary");
+const { getPlayer } = require("../../orcustrators/playerOrcustrator");
+
+const ARCHETYPE_NAMES = getAllArchetypeNames();
+
+/**
+ * @param {CommandInteraction} interaction
+ * @param {...unknown} args
+ */
+async function executeSubcommand(interaction, ...args) {
+	const archetypeName = interaction.options.getString("archetype-name");
+	const nameInTitleCase = ARCHETYPE_NAMES.find(archetype => archetype.toLowerCase() === archetypeName.toLowerCase());
+	if (!nameInTitleCase) {
+		interaction.reply({ content: `Stats on ${bold(archetypeName)} could not be found. Check for typos!`, ephemeral: true });
+		return;
+	}
+
+	const archetype = getArchetype(nameInTitleCase);
+	const fields = [{ name: "Base Stats", value: `Max HP: ${archetype.maxHP}\nPower: 35\nSpeed: ${archetype.speed}\nCrit Rate: 20%`, inline: true }, { name: "Stat Growths", value: `Max HP: ${archetype.maxHPGrowth}\nPower: ${archetype.powerGrowth}\nSpeed: ${archetype.speedGrowth}\nCrit Rate: ${archetype.critRateGrowth}%`, inline: true }];
+	fields.push(
+		{ name: "Starting Gear", value: listifyEN(archetype.startingGear) },
+		{ name: "Specializations and Archetype Actions", value: `Here are the ${nameInTitleCase} Archetype Actions and Specializations. Drafting ${nameInTitleCase} duplicates unlocks more Specializations (removes the 🔐 icon).` }
+	);
+	const baseArchetypeActionName = getArchetypeActionName(nameInTitleCase, "base");
+	const player = getPlayer(interaction.user.id, interaction.guildId);
+	fields.push({ name: `${player.archetypes[nameInTitleCase]?.specializationsUnlocked > 0 ? "" : "🔐"}Base - ${baseArchetypeActionName}`, value: buildGearDescription(baseArchetypeActionName) });
+	for (let i = 0; i < 4; i++) {
+		const specialization = archetype.specializations[i];
+		const archetypeActionName = getArchetypeActionName(nameInTitleCase, specialization);
+		fields.push({ name: `${player.archetypes[nameInTitleCase]?.specializationsUnlocked > i ? "" : "🔐"}${specialization} - ${archetypeActionName}`, value: buildGearDescription(archetypeActionName) });
+	}
+	console.log(fields);
+	interaction.reply({
+		embeds: [
+			embedTemplate().setColor(getColor(archetype.essence))
+				.setTitle(`${archetype.name} ${getEmoji(archetype.essence)}`)
+				.setDescription(archetype.description)
+				.addFields(fields)
+		],
+		ephemeral: true
+	});
+};
+
+module.exports = {
+	data: {
+		name: "archetype",
+		description: "Look up an Archetype's essence, growth rates, starting gear, and specializations",
+		optionsInput: [
+			{
+				type: "String",
+				name: "archetype-name",
+				description: "Input is case-insensitive",
+				required: true,
+				autocomplete: ARCHETYPE_NAMES.map(name => ({ name, value: name }))
+			}
+		]
+	},
+	executeSubcommand
+};

--- a/source/gear/_gearDictionary.js
+++ b/source/gear/_gearDictionary.js
@@ -401,7 +401,7 @@ function injectGearStats(text, gearName) {
 	return calculateTagContent(text, [
 		"critMultiplier",
 		"bonus",
-		"bonus2",
+		"secondBonus",
 		"healing",
 		"maxHP",
 		"power",

--- a/source/gear/battlestandard-thiefs.js
+++ b/source/gear/battlestandard-thiefs.js
@@ -4,14 +4,14 @@ const { changeStagger, dealDamage } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Thief's Battle Standard",
 	[
-		["use", "Deal @{damage} @{essence} damage to a single foe, gain @{bonus2}g if they're downed"],
+		["use", "Deal @{damage} @{essence} damage to a single foe, gain @{secondBonus}g if they're downed"],
 		["Critical💥", "Damage x @{critMultiplier}, increase the party's morale by @{bonus}"]
 	],
 	"Offense",
 	"Light",
 	350,
 	(targets, user, adventure) => {
-		const { essence, damage, bonus, bonus2 } = module.exports;
+		const { essence, damage, bonus, secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
@@ -30,7 +30,7 @@ module.exports = new GearTemplate("Thief's Battle Standard",
 			}
 		})
 		if (killCount > 0) {
-			const totalBounty = killCount * bonus2;
+			const totalBounty = killCount * secondBonus;
 			adventure.room.addResource("Gold", "Currency", "loot", totalBounty);
 			resultLines.push(`${user.name} pillages ${totalBounty}g.`);
 		}
@@ -42,4 +42,4 @@ module.exports = new GearTemplate("Thief's Battle Standard",
 	.setCooldown(1)
 	.setDamage(40)
 	.setBonus(1) // Morale
-	.setBonus2(30); // Bounty
+	.setSecondBonus(30); // Bounty

--- a/source/gear/battlestandard-tormenting.js
+++ b/source/gear/battlestandard-tormenting.js
@@ -5,14 +5,14 @@ const { changeStagger, dealDamage, generateModifierResultLines, combineModifierR
 
 module.exports = new GearTemplate("Tormenting Battle Standard",
 	[
-		["use", "Deal @{damage} @{essence} damage to a single foe and add @{bonus2} stack to each of their debuffs"],
+		["use", "Deal @{damage} @{essence} damage to a single foe and add @{secondBonus} stack to each of their debuffs"],
 		["Critical💥", "Damage x @{critMultiplier}, increase the party's morale by @{bonus}"]
 	],
 	"Offense",
 	"Light",
 	350,
 	(targets, user, adventure) => {
-		const { essence, damage, bonus, bonus2 } = module.exports;
+		const { essence, damage, bonus, secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
@@ -25,7 +25,7 @@ module.exports = new GearTemplate("Tormenting Battle Standard",
 		for (const target of targets) {
 			for (const modifier in target.modifiers) {
 				if (getModifierCategory(modifier) === "Debuff") {
-					reciepts.push(...addModifier([target], { name: modifier, stacks: bonus2 }));
+					reciepts.push(...addModifier([target], { name: modifier, stacks: secondBonus }));
 				}
 			}
 		}
@@ -41,4 +41,4 @@ module.exports = new GearTemplate("Tormenting Battle Standard",
 	.setCooldown(1)
 	.setDamage(40)
 	.setBonus(1) // Morale
-	.setBonus2(1); // Debuff increment
+	.setSecondBonus(1); // Debuff increment

--- a/source/gear/deckofcards-base.js
+++ b/source/gear/deckofcards-base.js
@@ -5,7 +5,7 @@ const { dealDamage, generateModifierResultLines, addModifier } = require('../uti
 const actionName = "Deck of Cards";
 module.exports = new GearTemplate(actionName,
 	[
-		["use", "Deal @{damage} @{essence} damage and inflict between @{bonus} and @{bonus2} stacks of @{mod0} randomly on a single foe"],
+		["use", "Deal @{damage} @{essence} damage and inflict between @{bonus} and @{secondBonus} stacks of @{mod0} randomly on a single foe"],
 		["Critical💥", "Damage x @{critMultiplier}"]
 	],
 	"Action",
@@ -25,7 +25,7 @@ module.exports = new GearTemplate(actionName,
 	.setDamage(0)
 	.setModifiers({ name: "Misfortune", stacks: 0 })
 	.setBonus(2) // Min stacks
-	.setBonus2(9) // Max stacks
+	.setSecondBonus(9) // Max stacks
 	.setRnConfig({
 		["Deck of Cards"]: 1
 	});

--- a/source/gear/deckofcards-evasive.js
+++ b/source/gear/deckofcards-evasive.js
@@ -5,7 +5,7 @@ const { dealDamage, generateModifierResultLines, addModifier } = require('../uti
 const actionName = "Evasive Deck of Cards";
 module.exports = new GearTemplate(actionName,
 	[
-		["use", "Deal @{damage} @{essence} damage and inflict between @{bonus} and @{bonus2} stacks of @{mod0} randomly and gain @{mod1Stacks} @{mod1} on a single foe"],
+		["use", "Deal @{damage} @{essence} damage and inflict between @{bonus} and @{secondBonus} stacks of @{mod0} randomly and gain @{mod1Stacks} @{mod1} on a single foe"],
 		["Critical💥", "Damage x @{critMultiplier}"]
 	],
 	"Action",
@@ -25,7 +25,7 @@ module.exports = new GearTemplate(actionName,
 	.setDamage(0)
 	.setModifiers({ name: "Misfortune", stacks: 0 }, { name: "Evasion", stacks: 2 })
 	.setBonus(2) // Min stacks
-	.setBonus2(9) // Max stacks
+	.setSecondBonus(9) // Max stacks
 	.setRnConfig({
 		["Deck of Cards"]: 1
 	});

--- a/source/gear/deckofcards-numbing.js
+++ b/source/gear/deckofcards-numbing.js
@@ -5,7 +5,7 @@ const { dealDamage, generateModifierResultLines, addModifier } = require('../uti
 const actionName = "Numbing Deck of Cards";
 module.exports = new GearTemplate(actionName,
 	[
-		["use", "Inflict @{damage} @{essence} damage, @{mod1Stacks} @{mod1}, and between @{bonus} and @{bonus2} stacks of @{mod0} randomly on a single foe"],
+		["use", "Inflict @{damage} @{essence} damage, @{mod1Stacks} @{mod1}, and between @{bonus} and @{secondBonus} stacks of @{mod0} randomly on a single foe"],
 		["Critical💥", "Damage x @{critMultiplier}"]
 	],
 	"Action",
@@ -25,7 +25,7 @@ module.exports = new GearTemplate(actionName,
 	.setDamage(0)
 	.setModifiers({ name: "Misfortune", stacks: 0 }, { name: "Clumsiness", stacks: 1 })
 	.setBonus(2) // Min stacks
-	.setBonus2(9) // Max stacks
+	.setSecondBonus(9) // Max stacks
 	.setRnConfig({
 		["Deck of Cards"]: 1
 	});

--- a/source/gear/deckofcards-omenous.js
+++ b/source/gear/deckofcards-omenous.js
@@ -5,7 +5,7 @@ const { dealDamage, generateModifierResultLines, addModifier, getCombatantCounte
 const actionName = "Omenous Deck of Cards";
 module.exports = new GearTemplate(actionName,
 	[
-		["use", "Inflict @{damage} @{essence} damage and between @{bonus} and @{bonus2} stacks of @{mod0} randomly (doubled if Essence Countering) on a single foe"],
+		["use", "Inflict @{damage} @{essence} damage and between @{bonus} and @{secondBonus} stacks of @{mod0} randomly (doubled if Essence Countering) on a single foe"],
 		["Critical💥", "Damage x @{critMultiplier}"]
 	],
 	"Action",
@@ -32,7 +32,7 @@ module.exports = new GearTemplate(actionName,
 	.setDamage(0)
 	.setModifiers({ name: "Misfortune", stacks: 0 })
 	.setBonus(2) // Min stacks
-	.setBonus2(9) // Max stacks
+	.setSecondBonus(9) // Max stacks
 	.setRnConfig({
 		["Deck of Cards"]: 1
 	});

--- a/source/gear/deckofcards-tormenting.js
+++ b/source/gear/deckofcards-tormenting.js
@@ -6,7 +6,7 @@ const { dealDamage, generateModifierResultLines, addModifier } = require('../uti
 const actionName = "Tormenting Deck of Cards";
 module.exports = new GearTemplate(actionName,
 	[
-		["use", "Deal @{damage} @{essence} damage, increase debuff stacks by 1, and inflict between @{bonus} and @{bonus2} stacks of @{mod0} randomly on a single foe"],
+		["use", "Deal @{damage} @{essence} damage, increase debuff stacks by 1, and inflict between @{bonus} and @{secondBonus} stacks of @{mod0} randomly on a single foe"],
 		["Critical💥", "Damage x @{critMultiplier}"]
 	],
 	"Action",
@@ -35,7 +35,7 @@ module.exports = new GearTemplate(actionName,
 	.setDamage(0)
 	.setModifiers({ name: "Misfortune", stacks: 0 })
 	.setBonus(2) // Min stacks
-	.setBonus2(9) // Max stacks
+	.setSecondBonus(9) // Max stacks
 	.setRnConfig({
 		["Deck of Cards"]: 1
 	});

--- a/source/gear/forbiddenknowledge-base.js
+++ b/source/gear/forbiddenknowledge-base.js
@@ -5,7 +5,7 @@ const { changeStagger } = require('../util/combatantUtil');
 module.exports = new GearTemplate("Forbidden Knowledge",
 	[
 		["use", "Grant a single ally @{bonus} extra level up after combat"],
-		["Critical💥", "Reduce your target's cooldowns by @{bonus2}"]
+		["Critical💥", "Reduce your target's cooldowns by @{secondBonus}"]
 	],
 	"Pact",
 	"Light",
@@ -40,4 +40,4 @@ module.exports = new GearTemplate("Forbidden Knowledge",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setPactCost([2, "Consume @{pactCost} morale"])
 	.setBonus(1) // Level-Ups
-	.setBonus2(1); // Cooldown Reduction
+	.setSecondBonus(1); // Cooldown Reduction

--- a/source/gear/forbiddenknowledge-enticing.js
+++ b/source/gear/forbiddenknowledge-enticing.js
@@ -6,7 +6,7 @@ const { changeStagger } = require('../util/combatantUtil');
 module.exports = new GearTemplate("Enticing Forbidden Knowledge",
 	[
 		["use", "Grant a single ally @{bonus} extra level up after combat and entice their pet to use its first move"],
-		["Critical💥", "Reduce your target's cooldowns by @{bonus2}"]
+		["Critical💥", "Reduce your target's cooldowns by @{secondBonus}"]
 	],
 	"Pact",
 	"Light",
@@ -63,4 +63,4 @@ module.exports = new GearTemplate("Enticing Forbidden Knowledge",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setPactCost([2, "Consume @{pactCost} morale"])
 	.setBonus(1) // Level-Ups
-	.setBonus2(1); // Cooldown Reduction
+	.setSecondBonus(1); // Cooldown Reduction

--- a/source/gear/forbiddenknowledge-soothing.js
+++ b/source/gear/forbiddenknowledge-soothing.js
@@ -5,7 +5,7 @@ const { changeStagger, generateModifierResultLines, addModifier } = require('../
 module.exports = new GearTemplate("Soothing Forbidden Knowledge",
 	[
 		["use", "Grant a single ally @{mod0Stacks} @{mod0} and @{bonus} extra level up after combat"],
-		["Critical💥", "Reduce your target's cooldowns by @{bonus2}"]
+		["Critical💥", "Reduce your target's cooldowns by @{secondBonus}"]
 	],
 	"Pact",
 	"Light",
@@ -41,5 +41,5 @@ module.exports = new GearTemplate("Soothing Forbidden Knowledge",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setPactCost([2, "Consume @{pactCost} morale"])
 	.setBonus(1) // Level-Ups
-	.setBonus2(1) // Cooldown Reduction
+	.setSecondBonus(1) // Cooldown Reduction
 	.setModifiers({ name: "Regeneration", stacks: { description: "2 + Bonus Speed ÷ 20", generator: (user) => 2 + Math.floor(user.getBonusSpeed() / 20) } })

--- a/source/gear/illumination-balanced.js
+++ b/source/gear/illumination-balanced.js
@@ -5,13 +5,13 @@ const { changeStagger, generateModifierResultLines, addModifier } = require('../
 module.exports = new GearTemplate("Balanced Illumination",
 	[
 		["use", "Reduce a single ally's cooldowns by @{bonus} and grant them @{mod0Stacks} @{mod0}"],
-		["Critical💥", "Increase the party's morale by @{bonus2}"]
+		["Critical💥", "Increase the party's morale by @{secondBonus}"]
 	],
 	"Spell",
 	"Light",
 	350,
 	(targets, user, adventure) => {
-		const { essence, bonus, bonus2, modifiers: [finesse] } = module.exports;
+		const { essence, bonus, secondBonus, modifiers: [finesse] } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
@@ -29,7 +29,7 @@ module.exports = new GearTemplate("Balanced Illumination",
 			}
 		}
 		if (user.crit) {
-			adventure.room.morale += bonus2;
+			adventure.room.morale += secondBonus;
 			resultLines.push("The party's morale is increased!");
 		}
 		return resultLines.concat(generateModifierResultLines(addModifier(targets, finesse)));
@@ -37,5 +37,5 @@ module.exports = new GearTemplate("Balanced Illumination",
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setCharges(15)
 	.setBonus(1) // Cooldown reduction
-	.setBonus2(1) // Morale
+	.setSecondBonus(1) // Morale
 	.setModifiers({ name: "Finesse", stacks: 1 });

--- a/source/gear/illumination-base.js
+++ b/source/gear/illumination-base.js
@@ -5,13 +5,13 @@ const { changeStagger } = require('../util/combatantUtil');
 module.exports = new GearTemplate("Illumination",
 	[
 		["use", "Reduce a single ally's cooldowns by @{bonus}"],
-		["Critical💥", "Increase the party's morale by @{bonus2}"]
+		["Critical💥", "Increase the party's morale by @{secondBonus}"]
 	],
 	"Spell",
 	"Light",
 	200,
 	(targets, user, adventure) => {
-		const { essence, bonus, bonus2 } = module.exports;
+		const { essence, bonus, secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
@@ -29,7 +29,7 @@ module.exports = new GearTemplate("Illumination",
 			}
 		}
 		if (user.crit) {
-			adventure.room.morale += bonus2;
+			adventure.room.morale += secondBonus;
 			resultLines.push("The party's morale is increased!");
 		}
 		return resultLines;
@@ -38,4 +38,4 @@ module.exports = new GearTemplate("Illumination",
 	.setUpgrades("Balanced Illumination", "Inspiring Illumination")
 	.setCharges(15)
 	.setBonus(1) // Cooldown reduction
-	.setBonus2(1); // Morale
+	.setSecondBonus(1); // Morale

--- a/source/gear/illumination-inspiring.js
+++ b/source/gear/illumination-inspiring.js
@@ -4,14 +4,14 @@ const { changeStagger } = require('../util/combatantUtil');
 
 module.exports = new GearTemplate("Inspiring Illumination",
 	[
-		["use", "Reduce a single ally's cooldowns by @{bonus} and increase the party's morale by @{bonus2}"],
-		["Critical💥", "Increase the party's morale by @{bonus2}"]
+		["use", "Reduce a single ally's cooldowns by @{bonus} and increase the party's morale by @{secondBonus}"],
+		["Critical💥", "Increase the party's morale by @{secondBonus}"]
 	],
 	"Spell",
 	"Light",
 	350,
 	(targets, user, adventure) => {
-		const { essence, bonus, bonus2 } = module.exports;
+		const { essence, bonus, secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
@@ -29,13 +29,13 @@ module.exports = new GearTemplate("Inspiring Illumination",
 			}
 		}
 		if (user.crit) {
-			adventure.room.morale += bonus2;
+			adventure.room.morale += secondBonus;
 		}
-		adventure.room.morale += bonus2;
+		adventure.room.morale += secondBonus;
 		resultLines.push("The party's morale is increased!");
 		return resultLines;
 	}
 ).setTargetingTags({ type: "single", team: "ally" })
 	.setCharges(15)
 	.setBonus(1) // Cooldown reduction
-	.setBonus2(1); // Morale
+	.setSecondBonus(1); // Morale

--- a/source/gear/medicine-hastening.js
+++ b/source/gear/medicine-hastening.js
@@ -7,13 +7,13 @@ const gearName = "Hastening Medicine";
 module.exports = new GearTemplate(gearName,
 	[
 		["use", "Cure @{bonus} random debuff on a single ally"],
-		["Critical💥", "Debuffs cured x @{critMultiplier}, reduce the target's cooldowns by @{bonus2}"]
+		["Critical💥", "Debuffs cured x @{critMultiplier}, reduce the target's cooldowns by @{secondBonus}"]
 	],
 	"Spell",
 	"Earth",
 	350,
 	([target], user, adventure) => {
-		const { essence, bonus, critMultiplier, bonus2 } = module.exports;
+		const { essence, bonus, critMultiplier, secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
@@ -25,7 +25,7 @@ module.exports = new GearTemplate(gearName,
 			target.gear?.forEach(gear => {
 				if (gear.cooldown > 1) {
 					didCooldown = true;
-					gear.cooldown -= bonus2;
+					gear.cooldown -= secondBonus;
 				}
 			})
 			if (didCooldown) {
@@ -45,4 +45,4 @@ module.exports = new GearTemplate(gearName,
 	.setCharges(15)
 	.setBonus(1) // Debuffs cured
 	.setRnConfig({ debuffs: 2 })
-	.setBonus2(1); // Cooldown reduction
+	.setSecondBonus(1); // Cooldown reduction

--- a/source/gear/spear-hastening.js
+++ b/source/gear/spear-hastening.js
@@ -5,13 +5,13 @@ const { changeStagger, dealDamage } = require('../util/combatantUtil');
 module.exports = new GearTemplate("Hastening Spear",
 	[
 		["use", "Deal @{damage} @{essence} damage to a single foe"],
-		["Critical💥", "Damage x @{critMultiplier}, increase party morale by @{bonus}, reduce your cooldowns by @{bonus2}"]
+		["Critical💥", "Damage x @{critMultiplier}, increase party morale by @{bonus}, reduce your cooldowns by @{secondBonus}"]
 	],
 	"Action",
 	"Light",
 	0,
 	(targets, user, adventure) => {
-		const { essence, critMultiplier, bonus } = module.exports;
+		const { essence, critMultiplier, bonus, secondBonus } = module.exports;
 		let pendingDamage = user.getPower();
 		const resultLines = [];
 		if (user.crit) {
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Hastening Spear",
 			resultLines.push("The party's morale is increased!");
 			user.gear?.forEach(gear => {
 				if (gear.cooldown > 1) {
-					gear.cooldown -= bonus;
+					gear.cooldown -= secondBonus;
 				}
 			})
 			resultLines.push(`${user.name}'s cooldowns are hastened.`);
@@ -33,4 +33,4 @@ module.exports = new GearTemplate("Hastening Spear",
 ).setTargetingTags({ type: "single", team: "foe" })
 	.setDamage(0)
 	.setBonus(1) // Morale
-	.setBonus(1); // Cooldown reduction
+	.setSecondBonus(1); // Cooldown reduction

--- a/source/gear/stick-convalescence.js
+++ b/source/gear/stick-convalescence.js
@@ -3,7 +3,7 @@ const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
 const { removeModifier, dealDamage, generateModifierResultLines, addModifier, combineModifierReceipts, changeStagger } = require('../util/combatantUtil');
 
-const actionName = "Convalecense Stick";
+const actionName = "Convalescence Stick";
 module.exports = new GearTemplate(actionName,
 	[
 		["use", "Inflict @{damage} @{essence} damage and @{mod0Stacks} @{mod0} on a single foe, then shrug off @{bonus} random debuff"],

--- a/source/gear/universalsolution-centering.js
+++ b/source/gear/universalsolution-centering.js
@@ -6,14 +6,14 @@ const { changeStagger, generateModifierResultLines, combineModifierReceipts, add
 const gearName = "Centering Universal Solution";
 module.exports = new GearTemplate(gearName,
 	[
-		["use", "Transfer a random @{bonus} of your debuffs to a single foe and shrug off @{bonus2} Stagger"],
+		["use", "Transfer a random @{bonus} of your debuffs to a single foe and shrug off @{secondBonus} Stagger"],
 		["Critical💥", "Transfer all of your debuffs"]
 	],
 	"Pact",
 	"Water",
 	350,
 	(targets, user, adventure) => {
-		const { essence, bonus, modifiers: [poison], bonus2 } = module.exports;
+		const { essence, bonus, modifiers: [poison], secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
@@ -31,7 +31,7 @@ module.exports = new GearTemplate(gearName,
 				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		}
-		changeStagger([user], bonus2);
+		changeStagger([user], secondBonus);
 		reciepts.push(...addModifier([user], poison));
 		return generateModifierResultLines(combineModifierReceipts(reciepts)).concat(`${user.name} shrugs off some Stagger.`);
 	}
@@ -41,4 +41,4 @@ module.exports = new GearTemplate(gearName,
 	.setBonus(2) // Debuffs transfered
 	.setModifiers({ name: "Poison", stacks: 3 })
 	.setRnConfig({ debuffs: 2 })
-	.setBonus2(2); // Stagger relieved
+	.setSecondBonus(2); // Stagger relieved

--- a/source/gear/universalsolution-tormenting.js
+++ b/source/gear/universalsolution-tormenting.js
@@ -6,14 +6,14 @@ const { changeStagger, generateModifierResultLines, combineModifierReceipts, add
 const gearName = "Tormenting Universal Solution";
 module.exports = new GearTemplate(gearName,
 	[
-		["use", "Transfer a random @{bonus} of your debuffs to a single foe then add @{bonus2} stack to each of their debuffs"],
+		["use", "Transfer a random @{bonus} of your debuffs to a single foe then add @{secondBonus} stack to each of their debuffs"],
 		["Critical💥", "Transfer all of your debuffs"]
 	],
 	"Pact",
 	"Water",
 	350,
 	(targets, user, adventure) => {
-		const { essence, bonus, modifiers: [poison], bonus2 } = module.exports;
+		const { essence, bonus, modifiers: [poison], secondBonus } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
@@ -34,7 +34,7 @@ module.exports = new GearTemplate(gearName,
 		for (const target of targets) {
 			for (const modifier in target.modifiers) {
 				if (getModifierCategory(modifier) === "Debuff") {
-					reciepts.push(...addModifier([target], { name: modifier, stacks: bonus2 }));
+					reciepts.push(...addModifier([target], { name: modifier, stacks: secondBonus }));
 				}
 			}
 		}
@@ -47,4 +47,4 @@ module.exports = new GearTemplate(gearName,
 	.setBonus(2) // Debuffs transfered
 	.setModifiers({ name: "Poison", stacks: 3 })
 	.setRnConfig({ debuffs: 2 })
-	.setBonus2(1); // Debuff stacks incremented
+	.setSecondBonus(1); // Debuff stacks incremented

--- a/source/orcustrators/playerOrcustrator.js
+++ b/source/orcustrators/playerOrcustrator.js
@@ -36,7 +36,7 @@ function getPlayer(playerId, guildId) {
 	if (!playerDictionary.has(playerId)) {
 		const player = new Player(playerId);
 		rollArchetypes(3, false).forEach(archetype => {
-			player.archetypes[archetype] = 0;
+			player.archetypes[archetype] = { specializationsUnlocked: 1, highScore: 0 };
 		})
 		rollPets(1, false).forEach(pet => {
 			player.pets[pet] = 1;


### PR DESCRIPTION
Summary
-------
- add /manual archetype
- rename "bonus2" to "secondBonus" to avoid parsing error
- fix typo in "Convalescence Stick" name
- improve type safety in favorited loadouts
- fix player profiles being generated with incorrect shaped archetype map

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] viewed description text on entering adventure
- [x] viewed new command responses
- [x] regenerated players file to inspect newly generated player shape

Issue
-----
Closes #547