### PR TITLE
#548: adapt Cursed Run to Specializations system

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,7 @@ Other Changes:
 - New Artifact: Add Blocker
 - Gear and Item drop chance from battle increased to 1/4 (from 1/16 and 1/8 respectively)
 - Fix merchant only stocking duplicates of the same item
+- Cursed Run (challenge) now causes found gear to be Cursed for the next 5 rooms, then reward the party with 250g
 ## Prophets of the Labyrinth v0.17.0:
 ### Pets
 Delvers can now bring pets with them on adventure. One of the party's pets will use a supportive move (or Loaf Around) each even round. You pick which pet to bring during the preparation phase or with `/set-favorite pet`. Your pet kennel is tracked per server so you can have different loadouts with different friend groups. Pets can be leveled-up per kennel, which gets them to stop Loafing Around or upgrades their moves.

--- a/source/buttons/ready.js
+++ b/source/buttons/ready.js
@@ -5,8 +5,6 @@ const { getAdventure, nextRoom, fetchRecruitMessage, setAdventure } = require('.
 const { bold, MessageFlags } = require('discord.js');
 const { commandMention } = require('../util/textUtil');
 
-const cursedGearByPurpose = ["Cursed Blade", "Cursed Tome"];
-
 const mainId = "ready";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** check if the delver is ready to start the adventure */
@@ -43,17 +41,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 				const archetypeTemplate = getArchetype(delver.archetype);
 				delver.essence = archetypeTemplate.essence;
-				let cursedIndex;
-				if ("Cursed Run" in adventure.challenges) {
-					cursedIndex = adventure.generateRandomNumber(archetypeTemplate.startingGear.length, "general");
-				}
-				delver.gear = archetypeTemplate.startingGear.map((gearName, index) => {
-					if (index === cursedIndex) {
-						return buildGearRecord(cursedGearByPurpose[index], adventure);
-					} else {
-						return buildGearRecord(gearName, adventure);
-					}
-				});
+				delver.gear = archetypeTemplate.startingGear.map(gearName => buildGearRecord(gearName, adventure));
 				if (delver.hp > delver.getMaxHP()) {
 					delver.hp = delver.getMaxHP();
 				}

--- a/source/challenges/cursedrun.js
+++ b/source/challenges/cursedrun.js
@@ -1,8 +1,18 @@
+const { italic } = require("discord.js");
 const { ChallengeTemplate } = require("../classes");
 
 module.exports = new ChallengeTemplate("Cursed Run",
-	"One of your starting gear pieces is randomly replaced with cursed gear.",
-	1,
+	`For @{duration} rooms, all gear found will be Cursed. Then gain @{reward} gold.`,
+	50,
 	true,
-	false
-).setScoreMultiplier(2);
+	true
+).setDuration(5)
+	.setScoreMultiplier(1.2)
+	.setReward(250)
+	.setCompleteEffect(
+		function (adventure, thread) {
+			const { reward } = adventure.challenges[module.exports.name];
+			adventure.gainGold(reward);
+			thread.send({ content: `Having completed ${italic(module.exports.name)}, the party gains ${reward} gold!` });
+		}
+	);

--- a/source/labyrinths/_labyrinthDictionary.js
+++ b/source/labyrinths/_labyrinthDictionary.js
@@ -82,7 +82,12 @@ function rollItem(adventure) {
  * @param {Adventure} adventure
  */
 function rollGear(tier, adventure) {
-	const pool = adventure.getPartyEssences().flatMap(essence => LABYRINTHS[adventure.labyrinth.toLowerCase()].availableGear[essence][tier]);
+	let pendingTier = tier;
+	const cursedRunDuration = adventure.getChallengeDuration("Cursed Run");
+	if (cursedRunDuration > 0) {
+		pendingTier = "Cursed";
+	}
+	const pool = adventure.getPartyEssences().flatMap(essence => LABYRINTHS[adventure.labyrinth.toLowerCase()].availableGear[essence][pendingTier]);
 	if (pool.length > 0) {
 		return pool[adventure.generateRandomNumber(pool.length, "general")];
 	} else {


### PR DESCRIPTION
Summary
-------
- adapt Cursed Run to Specializations system

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] confirmed only Cursed gear in pool while Cursed Run is active, and normal pool when not

Issue
-----
Closes #548