### PR TITLE
#555: skip state changes on dead enemies

### DIFF
--- a/source/enemies/asteroid.js
+++ b/source/enemies/asteroid.js
@@ -25,7 +25,7 @@ module.exports = new EnemyTemplate("Asteroid",
 				damage *= 2;
 			}
 			changeStagger(targets, ESSENCE_MATCH_STAGGER_FOE);
-			return dealDamage(targets, user, damage, false, user.essence, adventure).concat(dealDamage([user], user, recoilDmg, true, "Unaligned", adventure));
+			return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(dealDamage([user], user, recoilDmg, true, "Unaligned", adventure).resultLines);
 		},
 		selector: selectRandomFoe,
 		next: "random"
@@ -41,7 +41,7 @@ module.exports = new EnemyTemplate("Asteroid",
 			}
 			user.hp = 0;
 			changeStagger(targets, ESSENCE_MATCH_STAGGER_FOE);
-			return [...dealDamage(targets, user, damage, false, user.essence, adventure), `${user.name} is downed.`];
+			return [...dealDamage(targets, user, damage, false, user.essence, adventure).resultLines, `${user.name} is downed.`];
 		},
 		selector: selectAllOtherCombatants,
 		next: "random"

--- a/source/enemies/bloodtailhawk.js
+++ b/source/enemies/bloodtailhawk.js
@@ -23,7 +23,7 @@ module.exports = new EnemyTemplate("Bloodtail Hawk",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "Rake"

--- a/source/enemies/brute.js
+++ b/source/enemies/brute.js
@@ -23,7 +23,7 @@ module.exports = new EnemyTemplate("Brute",
 			// Mark or Mug rolls on [0, 3] then adds 2 for the number of 'The Target' stacks it applies
 			return generateModifierResultLines(addModifier([target], { name: "The Target", stacks: user.roundRns[`Mug or Mark${SAFE_DELIMITER}Mug or Mark`][0] + 2 }));
 		} else {
-			const resultLines = dealDamage([markedTarget], user, 70, false, "Unaligned", adventure);
+			const resultLines = dealDamage([markedTarget], user, 70, false, "Unaligned", adventure).resultLines;
 			changeStagger([markedTarget], user, 3);
 			resultLines.push(`${markedTarget.name} is Staggered.`);
 			resultLines.push(...generateModifierResultLines(removeModifier([markedTarget], { name: "The Target", stacks: 1, force: true })));

--- a/source/enemies/earthlyknight.js
+++ b/source/enemies/earthlyknight.js
@@ -28,7 +28,7 @@ module.exports = new EnemyTemplate("Earthly Knight",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure);
+		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 		for (const target of targets) {
 			const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 			if (targetBuffs.length > 0) {
@@ -52,7 +52,7 @@ module.exports = new EnemyTemplate("Earthly Knight",
 			damage *= 2;
 		}
 		changeStagger(targets, user, 2);
-		return [...dealDamage(targets, user, damage, false, user.essence, adventure), joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered.")];
+		return [...dealDamage(targets, user, damage, false, user.essence, adventure).resultLines, joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered.")];
 	},
 	selector: selectAllFoes,
 	next: "random"

--- a/source/enemies/elkemist.js
+++ b/source/enemies/elkemist.js
@@ -48,7 +48,7 @@ module.exports = new EnemyTemplate("Elkemist",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure);
+		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 		const wrappedProgressReceipt = addModifier([user], { name: "Progress", stacks: user.roundRns[`Trouble${SAFE_DELIMITER}progress`][0] });
 		progressCheck(user, wrappedProgressReceipt, resultLines);
 		return resultLines;
@@ -67,7 +67,7 @@ module.exports = new EnemyTemplate("Elkemist",
 		if (user.crit) {
 			damage *= 2;
 		}
-		return dealDamage(targets, user, damage, false, "Fire", adventure);
+		return dealDamage(targets, user, damage, false, "Fire", adventure).resultLines;
 	},
 	selector: selectAllFoes,
 	next: "random",

--- a/source/enemies/firearrowfrog.js
+++ b/source/enemies/firearrowfrog.js
@@ -19,7 +19,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 	priority: 0,
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 20;
-		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure);
+		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 		return resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 6 : 3 })));
 	},
 	selector: selectRandomFoe,

--- a/source/enemies/geodetortoise.js
+++ b/source/enemies/geodetortoise.js
@@ -24,7 +24,7 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/mechabeedrone.js
+++ b/source/enemies/mechabeedrone.js
@@ -21,7 +21,7 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
 	},
 	selector: selectRandomFoe,
 	next: "Barrel Roll"
@@ -67,7 +67,7 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 		user.hp = 0;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectAllFoes,
 	next: "Sting"

--- a/source/enemies/mechabeesoldier.js
+++ b/source/enemies/mechabeesoldier.js
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
 	},
 	selector: selectRandomFoe,
 	next: "Neurotoxin Strike"
@@ -54,7 +54,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 			pendingStagger += 2;
 		}
 		changeStagger(targets, user, pendingStagger);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "Self-Destruct"
@@ -71,7 +71,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		user.hp = 0;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectAllFoes,
 	next: "Barrel Roll"

--- a/source/enemies/mechaqueenmech.js
+++ b/source/enemies/mechaqueenmech.js
@@ -107,7 +107,7 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		return dealDamage(targets, user, pendingDamage, false, "Darkness", adventure);
+		return dealDamage(targets, user, pendingDamage, false, "Darkness", adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "Deploy Drone"

--- a/source/enemies/meteorknight.js
+++ b/source/enemies/meteorknight.js
@@ -24,7 +24,7 @@ module.exports = new EnemyTemplate("Meteor Knight",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -36,13 +36,13 @@ module.exports = new EnemyTemplate("Meteor Knight",
 	effect: (targets, user, adventure) => {
 		const baseDamage = user.getPower() + 75;
 		const bonusDamage = 25
-		let results = [];
+		const resultLines = [];
 		for (const target of targets) {
 			const pendingDamage = (user.crit ? 2 : 1) * ((target.protection > 0 ? 0 : bonusDamage) + baseDamage);
-			results.push(...dealDamage([target], user, pendingDamage, false, user.essence, adventure));
+			resultLines.push(...dealDamage([target], user, pendingDamage, false, user.essence, adventure).resultLines);
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return results;
+		return resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/ooze.js
+++ b/source/enemies/ooze.js
@@ -35,7 +35,7 @@ module.exports = new EnemyTemplate("Ooze",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/royalslime.js
+++ b/source/enemies/royalslime.js
@@ -47,7 +47,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectAllFoes,
 	next: "random"
@@ -62,7 +62,7 @@ module.exports = new EnemyTemplate("Royal Slime",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
 	},
 	selector: selectAllFoes,
 	next: "random"

--- a/source/enemies/slime.js
+++ b/source/enemies/slime.js
@@ -22,7 +22,7 @@ module.exports = new EnemyTemplate("Slime",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, adventure.essence, adventure);
+		return dealDamage(targets, user, damage, false, adventure.essence, adventure).resultLines;
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/starryknight.js
+++ b/source/enemies/starryknight.js
@@ -42,9 +42,9 @@ module.exports = new EnemyTemplate("Starry Knight",
 			pendingDamage *= 2;
 		}
 		if (unfinishedChallenges.length > 0) {
-			return [`"Ha! You didn't finish ${bold(unfinishedChallenges[adventure.generateRandomNumber(unfinishedChallenges.length, "battle")])}."`, ...dealDamage([target], user, pendingDamage, false, "Light", adventure)];
+			return [`"Ha! You didn't finish ${bold(unfinishedChallenges[adventure.generateRandomNumber(unfinishedChallenges.length, "battle")])}."`, ...dealDamage([target], user, pendingDamage, false, "Light", adventure).resultLines];
 		} else {
-			return dealDamage([target], user, pendingDamage, false, "Light", adventure);
+			return dealDamage([target], user, pendingDamage, false, "Light", adventure).resultLines;
 		}
 	},
 	selector: selectRandomFoe,
@@ -57,7 +57,7 @@ module.exports = new EnemyTemplate("Starry Knight",
 	effect: (targets, user, adventure) => {
 		let pendingDamage = user.getPower() + 50 * targets.length;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, pendingDamage, false, "Light", adventure)
+		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).resultLines
 			.concat(generateModifierResultLines(combineModifierReceipts(addNewRandomInsults(targets, user.crit ? 2 : 1, adventure))));
 	},
 	selector: selectAllFoes,
@@ -89,7 +89,7 @@ module.exports = new EnemyTemplate("Starry Knight",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).concat(generateModifierResultLines(addModifier(targets, { name: "Distraction", stacks: 4 })));
+		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Distraction", stacks: 4 })));
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/treasureelemental.js
+++ b/source/enemies/treasureelemental.js
@@ -22,7 +22,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			let damage = user.getPower() + 100;
 			addProtection([user], user.crit ? 100 : 50);
 			changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
-			return dealDamage(targets, user, damage, false, user.essence, adventure).concat([`${user.name} gains protection.`]);
+			return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat([`${user.name} gains protection.`]);
 		},
 		selector: selectRandomFoe,
 		next: "random"
@@ -39,7 +39,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
 			const texts = [];
 			for (let i = 0; i < 3; i++) {
-				texts.push(...dealDamage(targets, user, damage, false, user.essence, adventure));
+				texts.push(...dealDamage(targets, user, damage, false, user.essence, adventure).resultLines);
 			}
 			return texts;
 		},

--- a/source/gear/arcanesledge-fatiguing.js
+++ b/source/gear/arcanesledge-fatiguing.js
@@ -16,23 +16,26 @@ module.exports = new GearTemplate(variantName,
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, modifiers: [impotence], scalings: { damage, buffsRemoved, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
-		let pendingBuffRemovals = buffsRemoved;
-		if (user.crit) {
-			pendingBuffRemovals *= critBonus;
-		}
-		const targetBuffs = Object.keys(targets[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		const reciepts = addModifier(targets, { name: impotence.name, stacks: impotence.stacks.calculate(user) });
-		if (targetBuffs.length > 0) {
-			for (let i = 0; i < pendingBuffRemovals; i++) {
-				const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
-				reciepts.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+		if (survivors.length > 0) {
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 			}
+			let pendingBuffRemovals = buffsRemoved;
+			if (user.crit) {
+				pendingBuffRemovals *= critBonus;
+			}
+			const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
+			const reciepts = addModifier(survivors, { name: impotence.name, stacks: impotence.stacks.calculate(user) });
+			if (targetBuffs.length > 0) {
+				for (let i = 0; i < pendingBuffRemovals; i++) {
+					const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
+					reciepts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+				}
+			}
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(reciepts)));
 		}
-		const pendingDamage = damage.calculate(user);
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Kinetic Arcane Sledge")
 	.setCooldown(1)

--- a/source/gear/arcanesledge-kinetic.js
+++ b/source/gear/arcanesledge-kinetic.js
@@ -15,23 +15,26 @@ module.exports = new GearTemplate(variantName,
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, buffsRemoved, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
-		let pendingBuffRemovals = buffsRemoved;
-		if (user.crit) {
-			pendingBuffRemovals *= critBonus;
-		}
-		const targetBuffs = Object.keys(targets[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		const reciepts = [];
-		if (targetBuffs.length > 0) {
-			for (let i = 0; i < pendingBuffRemovals; i++) {
-				const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
-				reciepts.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+		if (survivors.length > 0) {
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 			}
+			let pendingBuffRemovals = buffsRemoved;
+			if (user.crit) {
+				pendingBuffRemovals *= critBonus;
+			}
+			const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
+			const reciepts = [];
+			if (targetBuffs.length > 0) {
+				for (let i = 0; i < pendingBuffRemovals; i++) {
+					const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
+					reciepts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+				}
+			}
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(reciepts)));
 		}
-		const pendingDamage = damage.calculate(user);
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Fatiguing Arcane Sledge")
 	.setCooldown(1)

--- a/source/gear/battlestandard-base.js
+++ b/source/gear/battlestandard-base.js
@@ -19,9 +19,9 @@ module.exports = new GearTemplate("Battle Standard",
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines);
+	return damageResults.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-base.js
+++ b/source/gear/battlestandard-base.js
@@ -19,10 +19,9 @@ module.exports = new GearTemplate("Battle Standard",
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, essence, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines;
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-disenchanting.js
+++ b/source/gear/battlestandard-disenchanting.js
@@ -21,13 +21,13 @@ module.exports = new GearTemplate(actionName,
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	resultLines.unshift(...dealDamage([target], user, pendingDamage, false, essence, adventure));
+	const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (target.hp > 0) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 		resultLines.push(...generateModifierResultLines(removeModifier([target], { name: targetBuffs[user.roundRns[`${actionName}${SAFE_DELIMITER}buffs`][0] % targetBuffs.length], stacks: "all" })));
 	}
-	return resultLines;
+	return resultLines.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-disenchanting.js
+++ b/source/gear/battlestandard-disenchanting.js
@@ -21,13 +21,13 @@ module.exports = new GearTemplate(actionName,
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { resultLines: damageResults } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (target.hp > 0) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 		resultLines.push(...generateModifierResultLines(removeModifier([target], { name: targetBuffs[user.roundRns[`${actionName}${SAFE_DELIMITER}buffs`][0] % targetBuffs.length], stacks: "all" })));
 	}
-	return resultLines.concat(resultLines);
+	return damageResults.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-flanking.js
+++ b/source/gear/battlestandard-flanking.js
@@ -19,10 +19,9 @@ module.exports = new GearTemplate("Flanking Battle Standard",
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, essence, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, exposure)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, exposure)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-flanking.js
+++ b/source/gear/battlestandard-flanking.js
@@ -19,9 +19,9 @@ module.exports = new GearTemplate("Flanking Battle Standard",
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, exposure)));
+	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, exposure)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-hastening.js
+++ b/source/gear/battlestandard-hastening.js
@@ -25,9 +25,9 @@ module.exports = new GearTemplate("Hastening Battle Standard",
 		})
 		resultLines.push(`${user.name}'s cooldowns are hastened.`);
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines);
+	return damageResults.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-hastening.js
+++ b/source/gear/battlestandard-hastening.js
@@ -25,10 +25,9 @@ module.exports = new GearTemplate("Hastening Battle Standard",
 		})
 		resultLines.push(`${user.name}'s cooldowns are hastened.`);
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, essence, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines;
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-weakening.js
+++ b/source/gear/battlestandard-weakening.js
@@ -19,10 +19,9 @@ module.exports = new GearTemplate("Weakening Battle Standard",
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, essence, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, weakness)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, weakness)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/battlestandard-weakening.js
+++ b/source/gear/battlestandard-weakening.js
@@ -19,9 +19,9 @@ module.exports = new GearTemplate("Weakening Battle Standard",
 		adventure.room.morale += morale;
 		resultLines.push("The party's morale is increased!")
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, weakness)));
+	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, weakness)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/bountyfist-base.js
+++ b/source/gear/bountyfist-base.js
@@ -14,16 +14,17 @@ module.exports = new GearTemplate(variantName,
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		const goldUsed = Math.floor(adventure.gold * (pactCost[0] / 100));
 		adventure.gold -= goldUsed;
 		let pendingDamage = damage.calculate(user) + goldUsed;
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(`${user.name}'s ${variantName} consumed ${goldUsed}g.`);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(`${user.name}'s ${variantName} consumed ${goldUsed}g.`);
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Midas's Bounty Fist", "Thirsting Bounty Fist")
 	.setPactCost([10, "@{pactCost}% of party gold"])

--- a/source/gear/bountyfist-midass.js
+++ b/source/gear/bountyfist-midass.js
@@ -14,16 +14,17 @@ module.exports = new GearTemplate(variantName,
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, modifiers: [curseOfMidas] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		const goldUsed = Math.floor(adventure.gold * (pactCost[0] / 100));
 		adventure.gold -= goldUsed;
 		let pendingDamage = damage + user.getPower() + goldUsed;
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(addModifier(targets, curseOfMidas)), `${user.name}'s ${variantName} consumed ${goldUsed}g.`);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(generateModifierResultLines(addModifier(targets, curseOfMidas)), `${user.name}'s ${variantName} consumed ${goldUsed}g.`);
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Thirsting Bounty Fist")
 	.setPactCost([10, "@{pactCost}% of party gold"])

--- a/source/gear/bountyfist-thirsting.js
+++ b/source/gear/bountyfist-thirsting.js
@@ -14,28 +14,21 @@ module.exports = new GearTemplate(variantName,
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus, healing }, pactCost } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		const goldUsed = Math.floor(adventure.gold * (pactCost[0] / 100));
 		adventure.gold -= goldUsed;
 		let pendingDamage = damage.calculate(user) + goldUsed;
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-		let killCount = 0;
-		targets.forEach(target => {
-			if (target.hp < 1) {
-				killCount++
-			}
-		})
-		if (killCount > 0) {
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		if (survivors.length < targets.length) {
 			const pendingHealing = healing.calculate(user);
 			gainHealth(user, pendingHealing, adventure);
 			resultLines.push(`${user.name} regains ${pendingHealing} HP.`);
 		}
-
 		return resultLines.concat(`${user.name}'s ${variantName} consumed ${goldUsed}g.`);
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Midas's Bounty Fist")

--- a/source/gear/cauldronstir-base.js
+++ b/source/gear/cauldronstir-base.js
@@ -22,10 +22,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, element, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines;
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-base.js
+++ b/source/gear/cauldronstir-base.js
@@ -22,9 +22,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines);
+	return damageResults.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-incompatible.js
+++ b/source/gear/cauldronstir-incompatible.js
@@ -22,10 +22,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, element, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines;
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-incompatible.js
+++ b/source/gear/cauldronstir-incompatible.js
@@ -22,9 +22,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines);
+	return damageResults.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-innovative.js
+++ b/source/gear/cauldronstir-innovative.js
@@ -26,9 +26,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines);
+	return damageResults.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-innovative.js
+++ b/source/gear/cauldronstir-innovative.js
@@ -26,10 +26,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, element, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines;
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-sabotaging.js
+++ b/source/gear/cauldronstir-sabotaging.js
@@ -23,11 +23,10 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, element, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	const rolledVulnerability = essenceList(["Unaligned"])[user.roundRns[`${variantName}${SAFE_DELIMITER}vulnerabilities`][0]];
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, { name: `${rolledVulnerability} Vulnerability`, stacks: vulnerability.stacks })));
+	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, { name: `${rolledVulnerability} Vulnerability`, stacks: vulnerability.stacks })));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-sabotaging.js
+++ b/source/gear/cauldronstir-sabotaging.js
@@ -23,10 +23,10 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	const rolledVulnerability = essenceList(["Unaligned"])[user.roundRns[`${variantName}${SAFE_DELIMITER}vulnerabilities`][0]];
-	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, { name: `${rolledVulnerability} Vulnerability`, stacks: vulnerability.stacks })));
+	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, { name: `${rolledVulnerability} Vulnerability`, stacks: vulnerability.stacks })));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-toxic.js
+++ b/source/gear/cauldronstir-toxic.js
@@ -22,10 +22,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	resultLines.unshift(...dealDamage(targets, user, pendingDamage, false, element, adventure));
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, poison)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, poison)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/cauldronstir-toxic.js
+++ b/source/gear/cauldronstir-toxic.js
@@ -22,9 +22,9 @@ module.exports = new GearTemplate(variantName,
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
 		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
+	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, element, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(resultLines, generateModifierResultLines(addModifier(survivors, poison)));
+	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, poison)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/daggers-attuned.js
+++ b/source/gear/daggers-attuned.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Attuned Daggers",
 	if (user.crit) {
 		pendingDamge *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamge, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamge, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user], excellence).concat(addModifier([user], attunement)))));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/daggers-balanced.js
+++ b/source/gear/daggers-balanced.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Balanced Daggers",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user], excellence).concat(addModifier([user], finesse)))));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/daggers-base.js
+++ b/source/gear/daggers-base.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Daggers",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(generateModifierResultLines(addModifier([user], excellence)));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/daggers-centering.js
+++ b/source/gear/daggers-centering.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Centering Daggers",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	changeStagger([user], user, selfStagger);
 	return resultLines.concat(generateModifierResultLines(addModifier([user], excellence)), `${user.name} shrugs off some Stagger.`);
 }, { type: "single", team: "foe" })

--- a/source/gear/daggers-distracting.js
+++ b/source/gear/daggers-distracting.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Distracting Daggers",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user], excellence).concat(addModifier(targets, distraction)))));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/deckofcards-base.js
+++ b/source/gear/deckofcards-base.js
@@ -17,9 +17,8 @@ module.exports = new GearTemplate(variantName,
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) })));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) })));
 }, { type: "single", team: "foe" })
 	.setModifiers(deckOfCardsMisfortune(variantName))
 	.setScalings({

--- a/source/gear/deckofcards-evasive.js
+++ b/source/gear/deckofcards-evasive.js
@@ -17,9 +17,8 @@ module.exports = new GearTemplate(variantName,
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }).concat(addModifier([user], evasion))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }).concat(addModifier([user], evasion))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/deckofcards-numbing.js
+++ b/source/gear/deckofcards-numbing.js
@@ -17,9 +17,8 @@ module.exports = new GearTemplate(variantName,
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }).concat(addModifier(stillLivingTargets, clumsiness))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }).concat(addModifier(survivors, clumsiness))));
 }, { type: "single", team: "foe" })
 	.setModifiers(deckOfCardsMisfortune(variantName), { name: "Clumsiness", stacks: 1 })
 	.setScalings({

--- a/source/gear/deckofcards-omenous.js
+++ b/source/gear/deckofcards-omenous.js
@@ -17,14 +17,13 @@ module.exports = new GearTemplate(variantName,
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	if (stillLivingTargets.length > 0) {
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	if (survivors.length > 0) {
 		let misfortuneStacks = misfortune.stacks.calculate(user);
-		if (getCombatantCounters(targets[0]).includes(essence)) {
+		if (getCombatantCounters(survivors[0]).includes(essence)) {
 			misfortuneStacks *= 2;
 		}
-		resultLines.push(...generateModifierResultLines(addModifier(stillLivingTargets, { name: misfortune.name, stacks: misfortuneStacks })))
+		resultLines.push(...generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortuneStacks })))
 	}
 	return resultLines;
 }, { type: "single", team: "foe" })

--- a/source/gear/deckofcards-tormenting.js
+++ b/source/gear/deckofcards-tormenting.js
@@ -18,17 +18,16 @@ module.exports = new GearTemplate(variantName,
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	const reciepts = [];
-	for (const target of targets) {
+	for (const target of survivors) {
 		for (const modifier in target.modifiers) {
 			if (getModifierCategory(modifier) === "Debuff") {
 				reciepts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 			}
 		}
 	}
-	reciepts.push(...addModifier(stillLivingTargets, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
+	reciepts.push(...addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
 	return resultLines.concat(generateModifierResultLines(reciepts));
 }, { type: "single", team: "foe" })
 	.setModifiers(deckOfCardsMisfortune(variantName))

--- a/source/gear/feverbreak-fatiguing.js
+++ b/source/gear/feverbreak-fatiguing.js
@@ -16,9 +16,6 @@ module.exports = new GearTemplate("Fatiguing Fever Break",
 			return ["...but the party didn't have enough morale to pull it off."];
 		}
 
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let poisonDamage = 10;
 		let frailDamage = 20;
 		if (user.team === "delver") {
@@ -28,17 +25,24 @@ module.exports = new GearTemplate("Fatiguing Fever Break",
 			frailDamage += FUNNEL_BUFF * funnelCount;
 		}
 		const resultLines = [];
+		const survivors = [];
 		const receipts = [];
 		for (const target of targets) {
 			const poisonStacks = target.getModifierStacks("Poison");
 			const frailtyStacks = target.getModifierStacks("Frailty");
 			const pendingDamage = poisonDamage * (poisonStacks ** 2 + poisonStacks) / 2 + frailDamage * frailtyStacks;
-			resultLines.push(...dealDamage([target], user, pendingDamage, false, essence, adventure));
-			if (!user.crit && target.hp > 0) {
-				receipts.push(...removeModifier([target], { name: "Poison", stacks: "all" }).concat(removeModifier([target], { name: "Frailty", stacks: "all" })));
+			resultLines.push(...dealDamage([target], user, pendingDamage, false, essence, adventure).resultLines);
+			if (target.hp > 0) {
+				survivors.push(target);
+				if (!user.crit) {
+					receipts.push(...removeModifier([target], { name: "Poison", stacks: "all" }).concat(removeModifier([target], { name: "Frailty", stacks: "all" })));
+				}
 			}
 		}
-		receipts.push(...addModifier(targets, modifiers[2]));
+		receipts.push(...addModifier(survivors, modifiers[2]));
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: "all", team: "foe" })
 	.setSidegrades("Unstoppable Fever Break")

--- a/source/gear/feverbreak-unstoppable.js
+++ b/source/gear/feverbreak-unstoppable.js
@@ -18,9 +18,6 @@ module.exports = new GearTemplate("Unstoppable Fever Break",
 			return ["...but the party didn't have enough morale to pull it off."];
 		}
 
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let poisonDamage = 10;
 		let frailDamage = 20;
 		if (user.team === "delver") {
@@ -30,15 +27,22 @@ module.exports = new GearTemplate("Unstoppable Fever Break",
 			frailDamage += FUNNEL_BUFF * funnelCount;
 		}
 		const resultLines = [];
+		const survivors = [];
 		const receipts = [];
 		for (const target of targets) {
 			const poisonStacks = target.getModifierStacks("Poison");
 			const frailtyStacks = target.getModifierStacks("Frailty");
 			const pendingDamage = poisonDamage * (poisonStacks ** 2 + poisonStacks) / 2 + frailDamage * frailtyStacks;
-			resultLines.push(...dealDamage([target], user, pendingDamage, true, essence, adventure));
-			if (!user.crit && target.hp > 0) {
-				receipts.push(...removeModifier([target], { name: "Poison", stacks: "all" }).concat(removeModifier([target], { name: "Frailty", stacks: "all" })));
+			resultLines.push(...dealDamage([target], user, pendingDamage, true, essence, adventure).resultLines);
+			if (target.hp > 0) {
+				survivors.push(target);
+				if (!user.crit) {
+					receipts.push(...removeModifier([target], { name: "Poison", stacks: "all" }).concat(removeModifier([target], { name: "Frailty", stacks: "all" })));
+				}
 			}
+		}
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: "all", team: "foe" })

--- a/source/gear/flail-base.js
+++ b/source/gear/flail-base.js
@@ -14,17 +14,17 @@ module.exports = new GearTemplate("Flail",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, stagger } = module.exports;
-		let pendingStagger = stagger;
-		if (user.essence === essence) {
-			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
-		}
-		changeStagger(targets, user, pendingStagger);
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure)
-			.concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		let pendingStagger = stagger;
+		if (user.essence === essence) {
+			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
+		}
+		changeStagger(survivors, user, pendingStagger);
+		return resultLines.concat(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Bouncing Flail", "Incompatible Flail")
 	.setCooldown(1)

--- a/source/gear/flail-bouncing.js
+++ b/source/gear/flail-bouncing.js
@@ -15,17 +15,17 @@ module.exports = new GearTemplate("Bouncing Flail",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, stagger } = module.exports;
-		let pendingStagger = stagger;
-		if (user.essence === essence) {
-			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
-		}
-		changeStagger(targets, user, pendingStagger);
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure)
-			.concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		let pendingStagger = stagger;
+		if (user.essence === essence) {
+			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
+		}
+		changeStagger(survivors, user, pendingStagger);
+		return resultLines.concat(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
 	.setSidegrades("Incompatible Flail")
 	.setCooldown(1)

--- a/source/gear/flail-incompatible.js
+++ b/source/gear/flail-incompatible.js
@@ -14,20 +14,20 @@ module.exports = new GearTemplate("Incompatible Flail",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, stagger, modifiers: [torpidity] } = module.exports;
-		let pendingStagger = stagger;
-		if (user.essence === essence) {
-			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
-		}
-		changeStagger(targets, user, pendingStagger);
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure)
-			.concat(
-				joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."),
-				generateModifierResultLines(addModifier(targets, torpidity))
-			);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		let pendingStagger = stagger;
+		if (user.essence === essence) {
+			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
+		}
+		changeStagger(survivors, user, pendingStagger);
+		return resultLines.concat(
+			joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."),
+			generateModifierResultLines(addModifier(survivors, torpidity))
+		);
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Slowing Flail")
 	.setCooldown(1)

--- a/source/gear/flamescythes-base.js
+++ b/source/gear/flamescythes-base.js
@@ -13,19 +13,19 @@ module.exports = new GearTemplate("Flame Scythes",
 ).setCost(200)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 		if (target.hp > (user.getDamageCap() / 2)) {
 			target.hp = 0;
 			const { extraLines } = downedCheck(target, adventure);
 			return [`${target.name} meets the reaper!`].concat(extraLines);
 		} else {
+			if (user.essence === essence) {
+				changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
+			}
 			return resultLines;
 		}
 	}, { type: "single", team: "foe" })

--- a/source/gear/flamescythes-thiefs.js
+++ b/source/gear/flamescythes-thiefs.js
@@ -13,14 +13,11 @@ module.exports = new GearTemplate("Thief's Flame Scythes",
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, critBonus, bounty } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 		if (target.hp > (user.getDamageCap() / 2)) {
 			target.hp = 0;
 			const { extraLines } = downedCheck(target, adventure);
@@ -28,6 +25,9 @@ module.exports = new GearTemplate("Thief's Flame Scythes",
 			extraLines.push(`${user.name} pillages ${bounty}g.`);
 			return [`${target.name} meets the reaper!`].concat(extraLines);
 		} else {
+			if (user.essence === essence) {
+				changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
+			}
 			return resultLines;
 		}
 	}, { type: "single", team: "foe" })

--- a/source/gear/flamescythes-toxic.js
+++ b/source/gear/flamescythes-toxic.js
@@ -13,19 +13,19 @@ module.exports = new GearTemplate("Toxic Flame Scythes",
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, modifiers: [poison] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage + user.getPower();
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 		if (target.hp > (user.getDamageCap() / 2)) {
 			target.hp = 0;
 			const { extraLines } = downedCheck(target, adventure);
 			return [`${target.name} meets the reaper!`].concat(extraLines);
 		} else {
+			if (user.essence === essence) {
+				changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
+			}
 			return resultLines.concat(generateModifierResultLines(addModifier([target], poison)));
 		}
 	}, { type: "single", team: "foe" })

--- a/source/gear/flourish-base.js
+++ b/source/gear/flourish-base.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Flourish",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, distraction)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/flourish-bouncing.js
+++ b/source/gear/flourish-bouncing.js
@@ -17,10 +17,9 @@ module.exports = new GearTemplate("Bouncing Flourish",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, distraction)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
 }, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/flourish-shattering.js
+++ b/source/gear/flourish-shattering.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Shattering Flourish",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, distraction).concat(addModifier(stillLivingTargets, frailty))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction).concat(addModifier(survivors, frailty))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/flourish-staggering.js
+++ b/source/gear/flourish-staggering.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Staggering Flourish",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE + stagger);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, distraction)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE + stagger);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/flourish-urgent.js
+++ b/source/gear/flourish-urgent.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Urgent Flourish",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, distraction)));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/greatsword-base.js
+++ b/source/gear/greatsword-base.js
@@ -13,14 +13,15 @@ module.exports = new GearTemplate("Greatsword",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setUpgrades("Chaining Greatsword", "Distracting Greatsword")
 	.setCooldown(2)

--- a/source/gear/greatsword-chaining.js
+++ b/source/gear/greatsword-chaining.js
@@ -13,14 +13,15 @@ module.exports = new GearTemplate("Chaining Greatsword",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setSidegrades("Distracting Greatsword")
 	.setCooldown(1)

--- a/source/gear/greatsword-distracting.js
+++ b/source/gear/greatsword-distracting.js
@@ -13,14 +13,15 @@ module.exports = new GearTemplate("Distracting Greatsword",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, modifiers: [distraction] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, distraction))));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, distraction))));
 	}, { type: `blast${SAFE_DELIMITER}1`, team: "foe" })
 	.setSidegrades("Chaining Greatsword")
 	.setCooldown(2)

--- a/source/gear/lance-accelerating.js
+++ b/source/gear/lance-accelerating.js
@@ -17,8 +17,9 @@ module.exports = new GearTemplate("Accelerating Lance",
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return dealDamage(targets, user, damage.calculate(user), false, essence, adventure).concat(`${user.name} gains protection.`, generateModifierResultLines(addModifier([user], swiftness)));
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(`${user.name} gains protection.`, generateModifierResultLines(addModifier([user], swiftness)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/lance-base.js
+++ b/source/gear/lance-base.js
@@ -17,8 +17,9 @@ module.exports = new GearTemplate("Lance",
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return dealDamage(targets, user, damage.calculate(user), false, essence, adventure).concat(`${user.name} gains protection.`);
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(`${user.name} gains protection.`);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/lance-bashing.js
+++ b/source/gear/lance-bashing.js
@@ -17,8 +17,9 @@ module.exports = new GearTemplate("Bashing Lance",
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return dealDamage(targets, user, damage.calculate(user), false, essence, adventure).concat(`${user.name} gains protection.`);
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(`${user.name} gains protection.`);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: { description: "Power + protection", calculate: (user) => user.getPower() + user.protection },

--- a/source/gear/lance-juggernauts.js
+++ b/source/gear/lance-juggernauts.js
@@ -18,8 +18,9 @@ module.exports = new GearTemplate("Juggernaut's Lance",
 	}
 	addProtection([user], pendingProtection);
 	addProtection([user], pendingProtection);
-	changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return dealDamage(targets, user, damage.calculate(user), false, essence, adventure).concat(`${user.name} gains protection.`);
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(`${user.name} gains protection.`);
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/lance-taunting.js
+++ b/source/gear/lance-taunting.js
@@ -17,13 +17,16 @@ module.exports = new GearTemplate("Taunting Lance",
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-	const resultLines = dealDamage([target], user, damage.calculate(user), false, essence, adventure).concat(`${user.name} gains protection.`);
-	const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
-	const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
-	if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
-		targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-		resultLines.push(`${target.name} falls for the provocation.`);
+	const { resultLines, survivors } = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
+	resultLines.push(`${user.name} gains protection.`);
+	if (survivors.length > 0) {
+		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
+		const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
+		const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
+		if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
+			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
+			resultLines.push(`${target.name} falls for the provocation.`);
+		}
 	}
 	return resultLines;
 }, { type: "single", team: "foe" })

--- a/source/gear/lifedrain-base.js
+++ b/source/gear/lifedrain-base.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Life Drain",
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(gainHealth(user, pendingHealing, adventure));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/lifedrain-fatiguing.js
+++ b/source/gear/lifedrain-fatiguing.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Fatiguing Life Drain",
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier(stillLivingTargets, impotence)), gainHealth(user, pendingHealing, adventure));
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier(survivors, impotence)), gainHealth(user, pendingHealing, adventure));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/lifedrain-furious.js
+++ b/source/gear/lifedrain-furious.js
@@ -15,9 +15,8 @@ module.exports = new GearTemplate("Furious Life Drain",
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(gainHealth(user, pendingHealing, adventure));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/lifedrain-reapers.js
+++ b/source/gear/lifedrain-reapers.js
@@ -16,13 +16,13 @@ module.exports = new GearTemplate("Reaper's Life Drain",
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const resultLines = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
+	const { resultLines } = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
 	if (target.hp > (user.getDamageCap() / 2)) {
 		target.hp = 0;
 		const { extraLines } = downedCheck(target, adventure);
 		return [`${target.name} meets the reaper!`].concat(extraLines, gainHealth(user, pendingHealing, adventure));
 	} else {
-		changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		return resultLines.concat(gainHealth(user, pendingHealing, adventure));
 	}
 }, { type: "single", team: "foe" })

--- a/source/gear/lifedrain-thirsting.js
+++ b/source/gear/lifedrain-thirsting.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Thirsting Life Drain",
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	if (stillLivingTargets.length < targets.length) {
+	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	if (survivors.length < targets.length) {
 		pendingHealing += thirstingHealing.calculate(user);
 	}
 	return resultLines.concat(gainHealth(user, pendingHealing, adventure));

--- a/source/gear/lightningstaff-base.js
+++ b/source/gear/lightningstaff-base.js
@@ -13,14 +13,15 @@ module.exports = new GearTemplate("Lightning Staff",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
 	.setUpgrades("Disenchanting Lightning Staff", "Hexing Lightning Staff")
 	.setCooldown(2)

--- a/source/gear/lightningstaff-disenchanting.js
+++ b/source/gear/lightningstaff-disenchanting.js
@@ -14,15 +14,16 @@ module.exports = new GearTemplate("Disenchanting Lightning Staff",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus, buffRemovals } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
 		const reciepts = [];
-		for (const target of targets) {
+		for (const target of survivors) {
 			const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 			if (targetBuffs.length > 0) {
 				for (let i = 0; i < buffRemovals; i++) {
@@ -31,7 +32,7 @@ module.exports = new GearTemplate("Disenchanting Lightning Staff",
 				}
 			}
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
 	.setSidegrades("Hexing Lightning Staff")
 	.setCooldown(2)

--- a/source/gear/lightningstaff-hexing.js
+++ b/source/gear/lightningstaff-hexing.js
@@ -13,14 +13,15 @@ module.exports = new GearTemplate("Hexing Lightning Staff",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, modifiers: [misfortune] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(addModifier(targets, misfortune));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(addModifier(survivors, misfortune));
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
 	.setSidegrades("Disenchanting Lightning Staff")
 	.setCooldown(2)

--- a/source/gear/longsword-base.js
+++ b/source/gear/longsword-base.js
@@ -13,21 +13,15 @@ module.exports = new GearTemplate("Longsword",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus, levelUps } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-		let killCount = 0;
-		targets.forEach(target => {
-			if (target.hp < 1) {
-				killCount++
-			}
-		})
-		if (killCount > 0) {
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		if (survivors.length < targets.length) {
 			adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(user)}`, "levelsGained", "loot", levelUps);
 			resultLines.push(`${user.name} gains a level.`);
 		}

--- a/source/gear/longsword-lethal.js
+++ b/source/gear/longsword-lethal.js
@@ -13,21 +13,15 @@ module.exports = new GearTemplate("Lethal Longsword",
 	350,
 ).setEffect((targets, user, adventure) => {
 	const { essence, scalings: { damage, critBonus, levelUps } } = module.exports;
-	if (user.essence === essence) {
-		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-	}
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	let killCount = 0;
-	targets.forEach(target => {
-		if (target.hp < 1) {
-			killCount++
-		}
-	})
-	if (killCount > 0) {
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	if (user.essence === essence) {
+		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	}
+	if (survivors.length < targets.length) {
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(user)}`, "levelsGained", "loot", levelUps);
 		resultLines.push(`${user.name} gains a level.`);
 	}

--- a/source/gear/musket-base.js
+++ b/source/gear/musket-base.js
@@ -14,10 +14,10 @@ module.exports = new GearTemplate(variantName,
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage }, cooldown } = module.exports;
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.crit && user.gear) {
 			const move = adventure.room.findCombatantMove({ team: user.team, index: adventure.getCombatantIndex(user) });
 			const [_, gearIndex] = move.name.split(SAFE_DELIMITER);

--- a/source/gear/musket-discounted.js
+++ b/source/gear/musket-discounted.js
@@ -16,10 +16,10 @@ module.exports = new GearTemplate(variantName,
 ).setCost(100)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage }, cooldown } = module.exports;
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.crit && user.gear) {
 			const move = adventure.room.findCombatantMove({ team: user.team, index: adventure.getCombatantIndex(user) });
 			const [_, gearIndex] = move.name.split(SAFE_DELIMITER);

--- a/source/gear/musket-hunters.js
+++ b/source/gear/musket-hunters.js
@@ -14,17 +14,11 @@ module.exports = new GearTemplate(variantName,
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage }, cooldown, modifiers: [empowerment] } = module.exports;
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
-		let killCount = 0;
-		targets.forEach(target => {
-			if (target.hp < 1) {
-				killCount++
-			}
-		})
-		if (killCount > 0) {
+		if (survivors.length < targets.length) {
 			resultLines.push(...generateModifierResultLines(addModifier([user], empowerment)));
 		}
 		if (user.crit && user.gear) {

--- a/source/gear/netlauncher-base.js
+++ b/source/gear/netlauncher-base.js
@@ -14,21 +14,22 @@ module.exports = new GearTemplate("Net Launcher",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, modifiers: [torpidity] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
-		let torpidityTargets = targets;
 		if (user.crit) {
 			pendingDamage *= critBonus;
+		}
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		let torpidityTargets = survivors;
+		if (user.crit) {
 			if (user.team === "delver") {
-				torpidityTargets = adventure.room.enemies;
+				torpidityTargets = adventure.room.enemies.filter(target => target.hp > 0);
 			} else {
 				torpidityTargets = adventure.delvers;
 			}
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-		torpidityTargets = torpidityTargets.filter(target => target.hp > 0);
 		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) }))));
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Tormenting Net Launcher", "Thief's Net Launcher")

--- a/source/gear/overburnexplosion-accurate.js
+++ b/source/gear/overburnexplosion-accurate.js
@@ -17,14 +17,14 @@ module.exports = new GearTemplate("Accurate Overburn Explosion",
 		(targets, user, adventure) => {
 			const { essence, modifiers: [targetModifier], scalings: { damage, critBonus }, pactCost } = module.exports;
 			const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-			if (user.essence === essence) {
-				changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-			}
 			let pendingDamage = damage.calculate(user);
 			if (user.crit) {
 				pendingDamage *= critBonus;
 			}
-			const resultLines = dealDamage(allTargets, user, pendingDamage, false, essence, adventure);
+			const { resultLines, survivors } = dealDamage(allTargets, user, pendingDamage, false, essence, adventure);
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
 			if (user.gear) {
 				for (const gear of user.gear) {
 					gear.cooldown += pactCost[0];

--- a/source/gear/overburnexplosion-base.js
+++ b/source/gear/overburnexplosion-base.js
@@ -14,14 +14,14 @@ module.exports = new GearTemplate("Overburn Explosion",
 	.setEffect((targets, user, adventure) => {
 		const { essence, modifiers: [targetModifier], scalings: { damage, critBonus }, pactCost } = module.exports;
 		const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-		if (user.essence === essence) {
-			changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(allTargets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(allTargets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
 		if (user.gear) {
 			for (const gear of user.gear) {
 				gear.cooldown += pactCost[0];

--- a/source/gear/overburnexplosion-unstoppable.js
+++ b/source/gear/overburnexplosion-unstoppable.js
@@ -17,14 +17,14 @@ module.exports = new GearTemplate("Unstoppable Overburn Explosion",
 		(targets, user, adventure) => {
 			const { essence, modifiers: [targetModifier], scalings: { damage, critBonus }, pactCost } = module.exports;
 			const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-			if (user.essence === essence) {
-				changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-			}
 			let pendingDamage = damage.calculate(user);
 			if (user.crit) {
 				pendingDamage *= critBonus;
 			}
-			const resultLines = dealDamage(allTargets, user, pendingDamage, true, essence, adventure);
+			const { resultLines, survivors } = dealDamage(allTargets, user, pendingDamage, true, essence, adventure);
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
 			if (user.gear) {
 				for (const gear of user.gear) {
 					gear.cooldown += pactCost[0];

--- a/source/gear/shortsword-base.js
+++ b/source/gear/shortsword-base.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Shortsword",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse)));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/shortsword-flanking.js
+++ b/source/gear/shortsword-flanking.js
@@ -17,10 +17,9 @@ module.exports = new GearTemplate("Flanking Shortsword",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-		const stillLivingTargets = targets.filter(target => target.hp > 0);
-		changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(stillLivingTargets, exposure))));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(survivors, exposure))));
 	}, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/shortsword-hexing.js
+++ b/source/gear/shortsword-hexing.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Hexing Shortsword",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(stillLivingTargets, misfortune))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(survivors, misfortune))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/shortsword-midass.js
+++ b/source/gear/shortsword-midass.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Midas's Shortsword",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(stillLivingTargets, curseOfMidas))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(survivors, curseOfMidas))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/shortsword-vigilant.js
+++ b/source/gear/shortsword-vigilant.js
@@ -16,9 +16,8 @@ module.exports = new GearTemplate("Vigilant Shortsword",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier([user], vigilance))));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/spikedshield-base.js
+++ b/source/gear/spikedshield-base.js
@@ -14,15 +14,16 @@ module.exports = new GearTemplate("Spiked Shield",
 	.setEffect(
 		(targets, user, adventure) => {
 			const { essence, scalings: { protection, critBonus } } = module.exports;
-			if (user.essence === essence) {
-				changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-			}
 			addProtection([user], protection.calculate(user));
 			let pendingDamage = user.protection;
 			if (user.crit) {
 				pendingDamage *= critBonus;
 			}
-			return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+			const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
+			return resultLines;
 		}, { type: "single", team: "foe" })
 	.setUpgrades("Furious Spiked Shield", "Reinforced Spiked Shield")
 	.setCooldown(2)

--- a/source/gear/spikedshield-furious.js
+++ b/source/gear/spikedshield-furious.js
@@ -13,16 +13,17 @@ module.exports = new GearTemplate("Furious Spiked Shield",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { protection, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		addProtection([user], protection.calculate(user));
 		const furiousness = 1.5 - (user.hp / user.getMaxHP() / 2);
 		let pendingDamage = user.protection * furiousness;
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Reinforced Spiked Shield")
 	.setCooldown(2)

--- a/source/gear/spikedshield-reinforced.js
+++ b/source/gear/spikedshield-reinforced.js
@@ -13,15 +13,16 @@ module.exports = new GearTemplate("Reinforced Spiked Shield",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { protection, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		addProtection([user], protection.calculate(user));
 		let pendingDamage = user.protection;
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Furious Spiked Shield")
 	.setCooldown(2)

--- a/source/gear/stick-base.js
+++ b/source/gear/stick-base.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Stick",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(stillLivingTargets, impotence))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, impotence))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/stick-convalescence.js
+++ b/source/gear/stick-convalescence.js
@@ -18,10 +18,9 @@ module.exports = new GearTemplate(actionName,
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	const reciepts = addModifier(stillLivingTargets, impotence);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	const reciepts = addModifier(survivors, impotence);
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 	reciepts.push(...removeModifier([user], { name: userDebuffs[user.roundRns[`${actionName}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
 	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));

--- a/source/gear/stick-flanking.js
+++ b/source/gear/stick-flanking.js
@@ -16,10 +16,9 @@ module.exports = new GearTemplate("Flanking Stick",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(stillLivingTargets, impotence), addModifier(stillLivingTargets, exposure))));
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, impotence), addModifier(survivors, exposure))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/stick-hunters.js
+++ b/source/gear/stick-hunters.js
@@ -16,14 +16,13 @@ module.exports = new GearTemplate("Hunter's Stick",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	const reciepts = [];
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	if (stillLivingTargets.length < targets.length) {
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	if (survivors.length < targets.length) {
 		reciepts.push(...addModifier([user], empowerment));
 	}
-	reciepts.push(...addModifier(stillLivingTargets, impotence));
+	reciepts.push(...addModifier(survivors, impotence));
 	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
 }, { type: "single", team: "foe" })
 	.setScalings({

--- a/source/gear/stick-thiefs.js
+++ b/source/gear/stick-thiefs.js
@@ -16,13 +16,12 @@ module.exports = new GearTemplate("Thief's Stick",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const stillLivingTargets = targets.filter(target => target.hp > 0);
-	changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-	if (stillLivingTargets.length < targets.length) {
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+	if (survivors.length < targets.length) {
 		adventure.room.addResource("Gold", "Currency", "loot", bounty);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(stillLivingTargets, impotence))));
+	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, impotence))));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/tempestuouswrath-base.js
+++ b/source/gear/tempestuouswrath-base.js
@@ -14,15 +14,16 @@ module.exports = new GearTemplate("Tempestuous Wrath",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, modifiers: [empowerment], scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		const resultLines = generateModifierResultLines(addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) }));
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return resultLines.concat(dealDamage(targets, user, pendingDamage, false, essence, adventure), payHP(user, user.modifiers.Empowerment, adventure));
+		const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(damageResults, payHP(user, user.modifiers.Empowerment, adventure));
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Flanking Tempestuous Wrath", "Opportunist's Tempestuous Wrath")
 	.setPactCost([0, "(Empowerment stacks) HP after move"])

--- a/source/gear/tempestuouswrath-flanking.js
+++ b/source/gear/tempestuouswrath-flanking.js
@@ -14,15 +14,16 @@ module.exports = new GearTemplate("Flanking Tempestuous Wrath",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, modifiers: [empowerment, exposure], scalings: { damage, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		const resultLines = generateModifierResultLines(addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) }));
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return resultLines.concat(dealDamage(targets, user, pendingDamage, false, essence, adventure), generateModifierResultLines(addModifier(targets, exposure)), payHP(user, user.modifiers.Empowerment, adventure));
+		const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(damageResults, generateModifierResultLines(addModifier(survivors, exposure)), payHP(user, user.modifiers.Empowerment, adventure));
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Opportunist's Tempestuous Wrath")
 	.setPactCost([0, "(Empowerment stacks) HP after move"])

--- a/source/gear/tempestuouswrath-opportunists.js
+++ b/source/gear/tempestuouswrath-opportunists.js
@@ -15,15 +15,16 @@ module.exports = new GearTemplate("Opportunist's Tempestuous Wrath",
 	.setEffect((targets, user, adventure) => {
 		const { essence, modifiers: [empowerment, targetModifier], scalings: { damage, critBonus } } = module.exports;
 		const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-		if (user.essence === essence) {
-			changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		const resultLines = generateModifierResultLines(addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) }));
 		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return resultLines.concat(dealDamage(allTargets, user, pendingDamage, false, essence, adventure), payHP(user, user.modifiers.Empowerment, adventure));
+		const { resultLines: damageResults, survivors } = dealDamage(allTargets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(damageResults, payHP(user, user.modifiers.Empowerment, adventure));
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Flanking Tempestuous Wrath")
 	.setPactCost([0, "(Empowerment stacks) HP after move"])

--- a/source/gear/tornadoformation-base.js
+++ b/source/gear/tornadoformation-base.js
@@ -18,10 +18,10 @@ module.exports = new GearTemplate("Tornado Formation",
 			return ["...but the party didn't have enough morale to pull it off."];
 		}
 
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		const pendingSwiftness = { name: swiftness.name, stacks: swiftness.stacks.calculate(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 		if (user.crit) {

--- a/source/gear/tornadoformation-charging.js
+++ b/source/gear/tornadoformation-charging.js
@@ -18,10 +18,10 @@ module.exports = new GearTemplate("Charging Tornado Formation",
 			return ["...but the party didn't have enough morale to pull it off."];
 		}
 
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		const reciepts = [];
 		const pendingSwiftness = { name: swiftness.name, stacks: swiftness.stacks.calculate(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);

--- a/source/gear/tornadoformation-supportive.js
+++ b/source/gear/tornadoformation-supportive.js
@@ -19,10 +19,10 @@ module.exports = new GearTemplate("Supportive Tornado Formation",
 			return ["...but the party didn't have enough morale to pull it off."];
 		}
 
+		const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const resultLines = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 		const pendingStagger = { name: swiftness.name, stacks: swiftness.stacks.calculate(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 		if (user.crit) {

--- a/source/gear/trident-base.js
+++ b/source/gear/trident-base.js
@@ -19,10 +19,9 @@ module.exports = new GearTemplate(variantName,
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 		if (user.essence === essence) {
-			const stillLivingTargets = targets.filter(target => target.hp > 0);
-			changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		return resultLines.concat(generateModifierResultLines(removeModifier([user], { name: userDebuffs[user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" })));

--- a/source/gear/trident-kinetic.js
+++ b/source/gear/trident-kinetic.js
@@ -19,10 +19,9 @@ module.exports = new GearTemplate(variantName,
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 		if (user.essence === essence) {
-			const stillLivingTargets = targets.filter(target => target.hp > 0);
-			changeStagger(stillLivingTargets, user, ESSENCE_MATCH_STAGGER_FOE);
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		return resultLines.concat(generateModifierResultLines(removeModifier([user], { name: userDebuffs[user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" })));

--- a/source/gear/trident-staggering.js
+++ b/source/gear/trident-staggering.js
@@ -19,14 +19,13 @@ module.exports = new GearTemplate(variantName,
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const resultLines = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-		const stillLivingTargets = targets.filter(target => target.hp > 0);
-		if (stillLivingTargets.length > 0) {
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (survivors.length > 0) {
 			let pendingStagger = stagger;
 			if (user.essence === essence) {
 				pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 			}
-			changeStagger(stillLivingTargets, user, pendingStagger);
+			changeStagger(survivors, user, pendingStagger);
 		}
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		return resultLines.concat(generateModifierResultLines(removeModifier([user], { name: userDebuffs[user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" })));

--- a/source/gear/vacuumimplosion-base.js
+++ b/source/gear/vacuumimplosion-base.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Vacuum Implosion",
 ).setCost(200)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, duelistsBonus, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		// Duelist's check
 		const userIndex = adventure.getCombatantIndex(user);
@@ -26,7 +23,11 @@ module.exports = new GearTemplate("Vacuum Implosion",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage([target], user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Shattering Vacuum Implosion", "Urgent Vacuum Implosion")
 	.setCharges(15)

--- a/source/gear/vacuumimplosion-shattering.js
+++ b/source/gear/vacuumimplosion-shattering.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Shattering Vacuum Implosion",
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, duelistsBonus, critBonus }, modifiers: [frailty] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		// Duelist's check
 		const userIndex = adventure.getCombatantIndex(user);
@@ -26,7 +23,11 @@ module.exports = new GearTemplate("Shattering Vacuum Implosion",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage([target], user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(addModifier([target], frailty)));
+		const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines.concat(generateModifierResultLines(addModifier([target], frailty)));
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Urgent Vacuum Implosion")
 	.setCharges(15)

--- a/source/gear/vacuumimplosion-urgent.js
+++ b/source/gear/vacuumimplosion-urgent.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Urgent Vacuum Implosion",
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, duelistsBonus, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		// Duelist's check
 		const userIndex = adventure.getCombatantIndex(user);
@@ -26,7 +23,11 @@ module.exports = new GearTemplate("Urgent Vacuum Implosion",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage([target], user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Shattering Vacuum Implosion")
 	.setCharges(15)

--- a/source/gear/vengefulvoid-base.js
+++ b/source/gear/vengefulvoid-base.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Vengeful Void",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, reactiveBonus, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 		const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(targets[0]), team: targets[0].team });
@@ -26,7 +23,11 @@ module.exports = new GearTemplate("Vengeful Void",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Hexing Vengeful Void", "Numbing Vengeful Void")
 	.setCharges(15)

--- a/source/gear/vengefulvoid-hexing.js
+++ b/source/gear/vengefulvoid-hexing.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Hexing Vengeful Void",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, reactiveBonus, critBonus }, modifiers: [misfortune] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 		const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(targets[0]), team: targets[0].team });
@@ -26,7 +23,14 @@ module.exports = new GearTemplate("Hexing Vengeful Void",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(addModifier(targets, misfortune)));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (survivors.length > 0) {
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
+			resultLines.push(...generateModifierResultLines(addModifier(survivors, misfortune)));
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Numbing Vengeful Void")
 	.setCharges(15)

--- a/source/gear/vengefulvoid-numbing.js
+++ b/source/gear/vengefulvoid-numbing.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Numbing Vengeful Void",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, reactiveBonus, critBonus }, modifiers: [clumsiness] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 		const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(targets[0]), team: targets[0].team });
@@ -26,7 +23,14 @@ module.exports = new GearTemplate("Numbing Vengeful Void",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(addModifier(targets, clumsiness)));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (survivors.length > 0) {
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
+			resultLines.push(...generateModifierResultLines(addModifier(survivors, clumsiness)));
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Numbing Vengeful Void")
 	.setCharges(15)

--- a/source/gear/warhammer-base.js
+++ b/source/gear/warhammer-base.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Warhammer",
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, awesomeBonus, critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (targets[0].isStunned) {
 			pendingDamage += awesomeBonus;
@@ -23,7 +20,11 @@ module.exports = new GearTemplate("Warhammer",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (user.essence === essence) {
+			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Fatiguing Warhammer", "Toxic Warhammer")
 	.setCooldown(1)

--- a/source/gear/warhammer-fatiguing.js
+++ b/source/gear/warhammer-fatiguing.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Fatiguing Warhammer",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, awesomeBonus, critBonus }, modifiers: [impotence] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (targets[0].isStunned) {
 			pendingDamage += awesomeBonus;
@@ -23,7 +20,14 @@ module.exports = new GearTemplate("Fatiguing Warhammer",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(addModifier(targets, impotence)));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (survivors.length > 0) {
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
+			resultLines.push(...generateModifierResultLines(addModifier(survivors, impotence)));
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Toxic Warhammer")
 	.setCooldown(1)

--- a/source/gear/warhammer-toxic.js
+++ b/source/gear/warhammer-toxic.js
@@ -13,9 +13,6 @@ module.exports = new GearTemplate("Toxic Warhammer",
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
 		const { essence, scalings: { damage, awesomeBonus, critBonus }, modifiers: [poison] } = module.exports;
-		if (user.essence === essence) {
-			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		}
 		let pendingDamage = damage.calculate(user);
 		if (targets[0].isStunned) {
 			pendingDamage += awesomeBonus;
@@ -23,7 +20,14 @@ module.exports = new GearTemplate("Toxic Warhammer",
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		return dealDamage(targets, user, pendingDamage, false, essence, adventure).concat(generateModifierResultLines(addModifier(targets, poison)));
+		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+		if (survivors.length > 0) {
+			if (user.essence === essence) {
+				changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
+			}
+			resultLines.push(...generateModifierResultLines(addModifier(survivors, poison)));
+		}
+		return resultLines;
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Fatiguing Warhammer")
 	.setCooldown(1)

--- a/source/gear/wavecrash-base.js
+++ b/source/gear/wavecrash-base.js
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Wave Crash",
 		}
 		const resultLines = generateModifierResultLines(addModifier(targets, incompatibility));
 		if (user.crit) {
-			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure));
+			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
 		}
 		return resultLines;
 	}, { type: "single", team: "foe" })

--- a/source/gear/wavecrash-disenchanting.js
+++ b/source/gear/wavecrash-disenchanting.js
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Disenchanting Wave Crash",
 		}
 		const resultLines = generateModifierResultLines(combineModifierReceipts(reciepts));
 		if (user.crit) {
-			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure));
+			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
 		}
 		return resultLines;
 	}, { type: "single", team: "foe" })

--- a/source/gear/wavecrash-fatiguing.js
+++ b/source/gear/wavecrash-fatiguing.js
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Fatiguing Wave Crash",
 		}
 		const resultLines = generateModifierResultLines(addModifier(targets, incompatibility).concat(addModifier(targets, impotence)));
 		if (user.crit) {
-			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure));
+			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
 		}
 		return resultLines;
 	}, { type: "single", team: "foe" })

--- a/source/items/explosionpotion.js
+++ b/source/items/explosionpotion.js
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Explosion Potion",
 	30,
 	selectAllFoes,
 	(targets, user, adventure) => {
-		return dealDamage(targets, user, 75, false, "Unaligned", adventure);
+		return dealDamage(targets, user, 75, false, "Unaligned", adventure).resultLines;
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*Not to be confused with __Fiery Potion__. DO NOT apply to self.*" });

--- a/source/pets/redtailedraptor.js
+++ b/source/pets/redtailedraptor.js
@@ -11,7 +11,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [swiftness] } = module.exports.moves[0][0];
-					const resultLines = dealDamage(targets, owner, 15, false, "Wind", adventure);
+					const { resultLines } = dealDamage(targets, owner, 15, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 2 }),
@@ -19,7 +19,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [swiftness] } = module.exports.moves[0][1];
-					const resultLines = dealDamage(targets, owner, 25, false, "Wind", adventure);
+					const { resultLines } = dealDamage(targets, owner, 25, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 3 }),
@@ -29,7 +29,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [swiftness] } = module.exports.moves[1][0];
-					const resultLines = dealDamage(targets, owner, 15, false, "Wind", adventure);
+					const { resultLines } = dealDamage(targets, owner, 15, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 2 }),
@@ -37,7 +37,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					const { modifiers: [swiftness] } = module.exports.moves[1][1];
-					const resultLines = dealDamage(targets, owner, 25, false, "Wind", adventure);
+					const { resultLines } = dealDamage(targets, owner, 25, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 3 }),

--- a/source/pets/shieldgoblin.js
+++ b/source/pets/shieldgoblin.js
@@ -22,13 +22,13 @@ module.exports = new PetTemplate(petName, Colors.Green,
 			new PetMoveTemplate("Shield Tackle", `Deal owner's protection in ${getEmoji("Earth")} damage to a random foe`,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
-					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure);
+					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).resultLines;
 				}).setRnConfig(["enemyIndex"]),
 			new PetMoveTemplate("Shield Avalanche", `Deal owner's protection in ${getEmoji("Earth")} damage and 1 Stagger to a random foe`,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, petRNs) => {
 					changeStagger(targets, null, 1);
-					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure);
+					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).resultLines;
 				}).setRnConfig(["enemyIndex"])
 		]
 	]


### PR DESCRIPTION
Summary
-------
- `dealDamage()` returns survivors for use in skipping state changes on dead enemies

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)

Issue
-----
Closes #555