### PR TITLE
#546: random outcomes bug fixes

### DIFF
--- a/source/archetypes/_archetypeDictionary.js
+++ b/source/archetypes/_archetypeDictionary.js
@@ -55,7 +55,7 @@ function rollArchetypes(count, allowDupes) {
 				results.push(archetype);
 			}
 		} else {
-			results.push(pool.splice(randomIndex, 1));
+			results.push(pool.splice(randomIndex, 1)[0]);
 		}
 	}
 	return results;

--- a/source/archetypes/trickster.js
+++ b/source/archetypes/trickster.js
@@ -3,24 +3,24 @@ const { POTL_ICON_URL, ZERO_WIDTH_WHITESPACE } = require("../constants");
 const { getCombatantCounters, modifiersToString } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
-/** @param {Combatant} combatant */
-function createModifierField(combatant) {
-	const modifiersText = modifiersToString(combatant, adventure);
-	embed.addFields({ name: combatant.name, value: modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states", inline: true });
-}
-
 module.exports = new ArchetypeTemplate("Trickster",
 	["Bard", "Gambler", "Doomsayer", "Dancer"],
 	"A Trickster can assess combatant modifiers and random outcomes of moves.",
 	"Their Deck of Cards will inflict a random amount of @e{Misfortune} on their target.",
 	"Wind",
 	(embed, adventure) => {
+		/** @param {Combatant} combatant */
+		function createModifierField(combatant) {
+			const modifiersText = modifiersToString(combatant, adventure);
+			embed.addFields({ name: combatant.name, value: modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states", inline: true });
+		}
+
 		// Separate Enemies and Delvers into different rows
 		adventure.room.enemies.filter(combatant => combatant.hp > 0).forEach(createModifierField);
 		embed.addFields({ name: ZERO_WIDTH_WHITESPACE, value: ZERO_WIDTH_WHITESPACE });
 		adventure.delvers.forEach(createModifierField);
-		if (adventure.room.detectivePredicts.length > 0) {
-			embed.addFields({ name: "Random Outcomes", value: `- ${adventure.room.detectivePredicts.join("\n- ")}` });
+		if (adventure.room.randomOutcomesPredicts.length > 0) {
+			embed.addFields({ name: "Random Outcomes", value: `- ${adventure.room.randomOutcomesPredicts.join("\n- ")}` });
 		}
 		return embed.setDescription(`Trickster predictions for Round ${adventure.room.round}:`).setAuthor({ name: "Random outcomes from moves are predicted as if they are the first move to happen.", iconURL: POTL_ICON_URL });
 	},

--- a/source/gear/arcanesledge-base.js
+++ b/source/gear/arcanesledge-base.js
@@ -25,14 +25,14 @@ module.exports = new GearTemplate(variantName,
 				pendingBuffRemovals *= critBonus;
 			}
 			const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-			const reciepts = [];
+			const receipts = [];
 			if (targetBuffs.length > 0) {
 				for (let i = 0; i < pendingBuffRemovals; i++) {
-					const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
-					reciepts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+					const [selectedBuff] = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
+					receipts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
 				}
 			}
-			resultLines.push(...generateModifierResultLines(combineModifierReceipts(reciepts)));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 		}
 		return resultLines;
 	}, { type: "single", team: "foe" })

--- a/source/gear/arcanesledge-fatiguing.js
+++ b/source/gear/arcanesledge-fatiguing.js
@@ -26,14 +26,14 @@ module.exports = new GearTemplate(variantName,
 				pendingBuffRemovals *= critBonus;
 			}
 			const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-			const reciepts = addModifier(survivors, { name: impotence.name, stacks: impotence.stacks.calculate(user) });
+			const receipts = addModifier(survivors, { name: impotence.name, stacks: impotence.stacks.calculate(user) });
 			if (targetBuffs.length > 0) {
 				for (let i = 0; i < pendingBuffRemovals; i++) {
-					const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
-					reciepts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+					const [selectedBuff] = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
+					receipts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
 				}
 			}
-			resultLines.push(...generateModifierResultLines(combineModifierReceipts(reciepts)));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 		}
 		return resultLines;
 	}, { type: "single", team: "foe" })

--- a/source/gear/arcanesledge-kinetic.js
+++ b/source/gear/arcanesledge-kinetic.js
@@ -25,14 +25,14 @@ module.exports = new GearTemplate(variantName,
 				pendingBuffRemovals *= critBonus;
 			}
 			const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-			const reciepts = [];
+			const receipts = [];
 			if (targetBuffs.length > 0) {
 				for (let i = 0; i < pendingBuffRemovals; i++) {
-					const selectedBuff = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
-					reciepts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+					const [selectedBuff] = targetBuffs.splice(user.roundRns(`${variantName}${SAFE_DELIMITER}buffs`), 1);
+					receipts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
 				}
 			}
-			resultLines.push(...generateModifierResultLines(combineModifierReceipts(reciepts)));
+			resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 		}
 		return resultLines;
 	}, { type: "single", team: "foe" })

--- a/source/gear/deckofcards-tormenting.js
+++ b/source/gear/deckofcards-tormenting.js
@@ -19,16 +19,16 @@ module.exports = new GearTemplate(variantName,
 		pendingDamage *= critBonus;
 	}
 	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const reciepts = [];
+	const receipts = [];
 	for (const target of survivors) {
 		for (const modifier in target.modifiers) {
 			if (getModifierCategory(modifier) === "Debuff") {
-				reciepts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+				receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 			}
 		}
 	}
-	reciepts.push(...addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
-	return resultLines.concat(generateModifierResultLines(reciepts));
+	receipts.push(...addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
+	return resultLines.concat(generateModifierResultLines(receipts));
 }, { type: "single", team: "foe" })
 	.setModifiers(deckOfCardsMisfortune(variantName))
 	.setScalings({

--- a/source/gear/enchantmentsiphon-tormenting.js
+++ b/source/gear/enchantmentsiphon-tormenting.js
@@ -24,16 +24,16 @@ module.exports = new GearTemplate("Tormenting Enchantment Siphon",
 			pendingProtection *= critBonus;
 		}
 		addProtection([user], pendingProtection);
-		const reciepts = [];
+		const receipts = [];
 		for (const modifier in target.modifiers) {
 			if (getModifierCategory(modifier) === "Debuff") {
-				reciepts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+				receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 			}
 		}
 		if (stolenProtection > 0) {
-			return [`${user.name} steals ${target.name}'s protection.`].concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+			return [`${user.name} steals ${target.name}'s protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 		} else {
-			return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+			return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 		}
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Flanking Enchantment Siphon")

--- a/source/gear/flail-bouncing.js
+++ b/source/gear/flail-bouncing.js
@@ -33,4 +33,5 @@ module.exports = new GearTemplate("Bouncing Flail",
 		damage: damageScalingGenerator(20),
 		critBonus: 2
 	})
+	.setRnConfig({ foes: bounceCount })
 	.setStagger(2);

--- a/source/gear/flourish-bouncing.js
+++ b/source/gear/flourish-bouncing.js
@@ -25,4 +25,5 @@ module.exports = new GearTemplate("Bouncing Flourish",
 		damage: archetypeActionDamageScaling,
 		critBonus: 2
 	})
+	.setRnConfig({ foes: bounceCount })
 	.setModifiers({ name: "Distraction", stacks: 3 });

--- a/source/gear/heatweaken-base.js
+++ b/source/gear/heatweaken-base.js
@@ -25,4 +25,5 @@ module.exports = new GearTemplate("Heat Weaken",
 	.setUpgrades("Numbing Heat Weaken", "Staggering Heat Weaken")
 	.setCharges(15)
 	.setModifiers({ name: "Frailty", stacks: 2 })
-	.setScalings({ critBonus: 2 });
+	.setScalings({ critBonus: 2 })
+	.setRnConfig({ foes: bounceCount });

--- a/source/gear/heatweaken-numbing.js
+++ b/source/gear/heatweaken-numbing.js
@@ -25,4 +25,5 @@ module.exports = new GearTemplate("Numbing Heat Weaken",
 	.setSidegrades("Staggering Heat Weaken")
 	.setCharges(15)
 	.setModifiers({ name: "Frailty", stacks: 2 }, { name: "Clumsiness", stacks: 1 })
-	.setScalings({ critBonus: 2 });
+	.setScalings({ critBonus: 2 })
+	.setRnConfig({ foes: bounceCount });

--- a/source/gear/heatweaken-staggering.js
+++ b/source/gear/heatweaken-staggering.js
@@ -28,4 +28,5 @@ module.exports = new GearTemplate("Staggering Heat Weaken",
 	.setSidegrades("Numbing Heat Weaken")
 	.setCharges(15)
 	.setModifiers({ name: "Frailty", stacks: 2 })
-	.setStagger(2);
+	.setStagger(2)
+	.setRnConfig({ foes: bounceCount });

--- a/source/gear/lightningstaff-disenchanting.js
+++ b/source/gear/lightningstaff-disenchanting.js
@@ -22,17 +22,17 @@ module.exports = new GearTemplate("Disenchanting Lightning Staff",
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const reciepts = [];
+		const receipts = [];
 		for (const target of survivors) {
 			const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 			if (targetBuffs.length > 0) {
 				for (let i = 0; i < buffRemovals; i++) {
-					const selectedBuff = targetBuffs.splice(user.roundRns(`${gearName}${SAFE_DELIMITER}buffs`), 1);
-					reciepts.push(...removeModifier([target], { name: selectedBuff, stacks: "all" }));
+					const [selectedBuff] = targetBuffs.splice(user.roundRns(`${gearName}${SAFE_DELIMITER}buffs`), 1);
+					receipts.push(...removeModifier([target], { name: selectedBuff, stacks: "all" }));
 				}
 			}
 		}
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
 	.setSidegrades("Hexing Lightning Staff")
 	.setCooldown(2)

--- a/source/gear/medicine-base.js
+++ b/source/gear/medicine-base.js
@@ -22,12 +22,12 @@ module.exports = new GearTemplate(variantName,
 			pendingCures *= critBonus;
 		}
 		const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-		const reciepts = [];
+		const receipts = [];
 		for (let i = 0; i < pendingCures; i++) {
-			const selectedDebuff = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
-			reciepts.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
+			const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}Medicine`][i] % targetDebuffs.length, 1);
+			receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 		}
-		return generateModifierResultLines(combineModifierReceipts(reciepts));
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}, { type: "single", team: "ally" })
 	.setUpgrades("Hastening Medicine", "Urgent Medicine")
 	.setCharges(15)
@@ -35,4 +35,4 @@ module.exports = new GearTemplate(variantName,
 		debuffsCured: 1,
 		critBonus: 2
 	})
-	.setRnConfig({ debuffs: 2 });
+	.setRnConfig({ Medicine: 2 });

--- a/source/gear/medicine-hastening.js
+++ b/source/gear/medicine-hastening.js
@@ -33,12 +33,12 @@ module.exports = new GearTemplate(variantName,
 			}
 		}
 		const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-		const reciepts = [];
+		const receipts = [];
 		for (let i = 0; i < pendingCures; i++) {
-			const selectedDebuff = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
-			reciepts.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
+			const [selectedDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}Medicine`][i] % targetDebuffs.length, 1);
+			receipts.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
 		}
-		return generateModifierResultLines(combineModifierReceipts(reciepts)).concat(resultLines);
+		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
 	}, { type: "single", team: "ally" })
 	.setSidegrades("Urgent Medicine")
 	.setCharges(15)
@@ -47,4 +47,4 @@ module.exports = new GearTemplate(variantName,
 		critBonus: 2,
 		cooldownReduction: 1
 	})
-	.setRnConfig({ debuffs: 2 });
+	.setRnConfig({ Medicine: 2 });

--- a/source/gear/medicine-urgent.js
+++ b/source/gear/medicine-urgent.js
@@ -22,12 +22,12 @@ module.exports = new GearTemplate(variantName,
 			pendingCures *= critBonus;
 		}
 		const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-		const reciepts = [];
+		const receipts = [];
 		for (let i = 0; i < pendingCures; i++) {
-			const selectedDebuff = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
-			reciepts.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
+			const [selectedDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}Medicine`][i] % targetDebuffs.length, 1);
+			receipts.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
 		}
-		return generateModifierResultLines(combineModifierReceipts(reciepts));
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}, { type: "single", team: "ally" })
 	.setSidegrades("Hastening Medicine")
 	.setCharges(15)
@@ -36,4 +36,4 @@ module.exports = new GearTemplate(variantName,
 		critBonus: 2,
 		priority: 1
 	})
-	.setRnConfig({ debuffs: 2 });
+	.setRnConfig({ Medicine: 2 });

--- a/source/gear/medicskit-base.js
+++ b/source/gear/medicskit-base.js
@@ -44,4 +44,4 @@ module.exports = new GearTemplate(variantName,
 		debuffsCured: 1,
 		morale: 1
 	})
-	.setRnConfig({ debuffs: 2 });
+	.setRnConfig({ debuffs: 1 });

--- a/source/gear/medicskit-base.js
+++ b/source/gear/medicskit-base.js
@@ -22,13 +22,8 @@ module.exports = new GearTemplate(variantName,
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 			const debuffsToRemove = Math.min(targetDebuffs.length, debuffsCured);
 			for (let i = 0; i < debuffsToRemove; i++) {
-				const debuffIndex = user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][0] % targetDebuffs.length;
-				const rolledDebuff = targetDebuffs[debuffIndex];
-				const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
-				receipts.push(removalReceipt);
-				if (removalReceipt.succeeded.size > 0) {
-					targetDebuffs.splice(debuffIndex, 1);
-				}
+				const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
+				receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 			}
 		}
 		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));

--- a/source/gear/medicskit-cleansing.js
+++ b/source/gear/medicskit-cleansing.js
@@ -13,14 +13,14 @@ module.exports = new GearTemplate(variantName,
 	"Water"
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
-		const { essence, scalings: { debuffsCured, critBonus, morale } } = module.exports;
+		const { essence, scalings: { debuffsCured, morale } } = module.exports;
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
 		const receipts = [];
 		for (const target of targets) {
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-			const debuffsToRemove = Math.min(targetDebuffs.length, user.crit ? debuffsCured * critBonus : debuffsCured);
+			const debuffsToRemove = Math.min(targetDebuffs.length, debuffsCured);
 			for (let i = 0; i < debuffsToRemove; i++) {
 				const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
 				receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));

--- a/source/gear/medicskit-cleansing.js
+++ b/source/gear/medicskit-cleansing.js
@@ -22,13 +22,8 @@ module.exports = new GearTemplate(variantName,
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 			const debuffsToRemove = Math.min(targetDebuffs.length, user.crit ? debuffsCured * critBonus : debuffsCured);
 			for (let i = 0; i < debuffsToRemove; i++) {
-				const debuffIndex = user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][0] % targetDebuffs.length;
-				const rolledDebuff = targetDebuffs[debuffIndex];
-				const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
-				receipts.push(removalReceipt);
-				if (removalReceipt.succeeded.size > 0) {
-					targetDebuffs.splice(debuffIndex, 1);
-				}
+				const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
+				receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 			}
 		}
 		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));

--- a/source/gear/medicskit-warning.js
+++ b/source/gear/medicskit-warning.js
@@ -44,5 +44,5 @@ module.exports = new GearTemplate(variantName,
 		debuffsCured: 1,
 		morale: 1
 	})
-	.setRnConfig({ debuffs: 2 })
+	.setRnConfig({ debuffs: 1 })
 	.setModifiers({ name: "Evasion", stacks: 1 });

--- a/source/gear/medicskit-warning.js
+++ b/source/gear/medicskit-warning.js
@@ -22,13 +22,8 @@ module.exports = new GearTemplate(variantName,
 			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 			const debuffsToRemove = Math.min(targetDebuffs.length, debuffsCured);
 			for (let i = 0; i < debuffsToRemove; i++) {
-				const debuffIndex = user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][0] % targetDebuffs.length;
-				const rolledDebuff = targetDebuffs[debuffIndex];
-				const [removalReceipt] = removeModifier([target], { name: rolledDebuff, stacks: "all" });
-				receipts.push(removalReceipt);
-				if (removalReceipt.succeeded.size > 0) {
-					targetDebuffs.splice(debuffIndex, 1);
-				}
+				const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
+				receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 			}
 		}
 		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));

--- a/source/gear/netlauncher-tormenting.js
+++ b/source/gear/netlauncher-tormenting.js
@@ -31,15 +31,15 @@ module.exports = new GearTemplate("Tormenting Net Launcher",
 				torpidityTargets = adventure.delvers;
 			}
 		}
-		const reciepts = addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) });
+		const receipts = addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) });
 		for (const target of survivors) {
 			for (const modifier in target.modifiers) {
 				if (getModifierCategory(modifier) === "Debuff") {
-					reciepts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+					receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 				}
 			}
 		}
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Thief's Net Launcher")
 	.setCooldown(1)

--- a/source/gear/revealflaw-distracting.js
+++ b/source/gear/revealflaw-distracting.js
@@ -21,9 +21,9 @@ module.exports = new GearTemplate(variantName,
 
 		const essencePool = essenceList(["Unaligned"]);
 		const selectedEsesnce = essencePool[user.roundRns[`${variantName}${SAFE_DELIMITER}vulnerabilities`][0] % 6];
-		const reciepts = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
-		reciepts.push(...addModifier(targets, distraction));
-		const resultLines = generateModifierResultLines(combineModifierReceipts(reciepts));
+		const receipts = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
+		receipts.push(...addModifier(targets, distraction));
+		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 		let pendingStagger = 0;
 		if (user.essence === essence) {
 			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;

--- a/source/gear/revealflaw-numbing.js
+++ b/source/gear/revealflaw-numbing.js
@@ -21,9 +21,9 @@ module.exports = new GearTemplate(variantName,
 
 		const essencePool = essenceList(["Unaligned"]);
 		const selectedEsesnce = essencePool[user.roundRns[`${variantName}${SAFE_DELIMITER}vulnerabilities`][0] % 6];
-		const reciepts = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
-		reciepts.push(...addModifier(targets, clumsiness));
-		const resultLines = generateModifierResultLines(combineModifierReceipts(reciepts));
+		const receipts = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
+		receipts.push(...addModifier(targets, clumsiness));
+		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 		let pendingStagger = 0;
 		if (user.essence === essence) {
 			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;

--- a/source/gear/sandstormformation-balanced.js
+++ b/source/gear/sandstormformation-balanced.js
@@ -37,12 +37,12 @@ module.exports = new GearTemplate("Balanced Sandstorm Formation",
 		if (hadCooldowns.length > 0) {
 			resultLines.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
 		}
-		const reciepts = [];
+		const receipts = [];
 		if (user.crit) {
-			reciepts.push(...addModifier(targets, impact));
+			receipts.push(...addModifier(targets, impact));
 		}
-		reciepts.push(...addModifier(targets, finesse));
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		receipts.push(...addModifier(targets, finesse));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: "all", team: "ally" })
 	.setSidegrades("Soothing Sandstorm Formation")
 	.setMoraleRequirement(2)

--- a/source/gear/sandstormformation-soothing.js
+++ b/source/gear/sandstormformation-soothing.js
@@ -37,12 +37,12 @@ module.exports = new GearTemplate("Soothing Sandstorm Formation",
 		if (hadCooldowns.length > 0) {
 			resultLines.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
 		}
-		const reciepts = [];
+		const receipts = [];
 		if (user.crit) {
-			reciepts.push(...addModifier(targets, impact));
+			receipts.push(...addModifier(targets, impact));
 		}
-		reciepts.push(...addModifier(targets, regeneration));
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		receipts.push(...addModifier(targets, regeneration));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: "all", team: "ally" })
 	.setSidegrades("Balanced Sandstorm Formation")
 	.setMoraleRequirement(2)

--- a/source/gear/smokescreen-base.js
+++ b/source/gear/smokescreen-base.js
@@ -26,5 +26,6 @@ module.exports = new GearTemplate("Smokescreen",
 		}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "ally" })
 	.setUpgrades("Chaining Smokescreen", "Double Smokescreen")
 	.setCooldown(1)
+	.setRnConfig({ allies: bounceCount })
 	.setModifiers(scalingEvasion(2))
 	.setScalings({ critBonus: 2 });

--- a/source/gear/smokescreen-chaining.js
+++ b/source/gear/smokescreen-chaining.js
@@ -25,5 +25,6 @@ module.exports = new GearTemplate("Chaining Smokescreen",
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "ally" })
 	.setSidegrades("Double Smokescreen")
 	.setCooldown(0)
+	.setRnConfig({ allies: bounceCount })
 	.setModifiers(scalingEvasion(2))
 	.setScalings({ critBonus: 2 });

--- a/source/gear/smokescreen-double.js
+++ b/source/gear/smokescreen-double.js
@@ -25,5 +25,6 @@ module.exports = new GearTemplate("Double Smokescreen",
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "ally" })
 	.setSidegrades("Chaining Smokescreen")
 	.setCooldown(1)
+	.setRnConfig({ allies: bounceCount })
 	.setModifiers(scalingEvasion(1))
 	.setScalings({ critBonus: 2 });

--- a/source/gear/stick-convalescence.js
+++ b/source/gear/stick-convalescence.js
@@ -20,10 +20,10 @@ module.exports = new GearTemplate(actionName,
 	}
 	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-	const reciepts = addModifier(survivors, impotence);
+	const receipts = addModifier(survivors, impotence);
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	reciepts.push(...removeModifier([user], { name: userDebuffs[user.roundRns[`${actionName}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+	receipts.push(...removeModifier([user], { name: userDebuffs[user.roundRns[`${actionName}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
+	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/stick-hunters.js
+++ b/source/gear/stick-hunters.js
@@ -17,13 +17,13 @@ module.exports = new GearTemplate("Hunter's Stick",
 		pendingDamage *= critBonus;
 	}
 	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const reciepts = [];
+	const receipts = [];
 	changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	if (survivors.length < targets.length) {
-		reciepts.push(...addModifier([user], empowerment));
+		receipts.push(...addModifier([user], empowerment));
 	}
-	reciepts.push(...addModifier(survivors, impotence));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+	receipts.push(...addModifier(survivors, impotence));
+	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,

--- a/source/gear/tornadoformation-charging.js
+++ b/source/gear/tornadoformation-charging.js
@@ -22,14 +22,14 @@ module.exports = new GearTemplate("Charging Tornado Formation",
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const reciepts = [];
+		const receipts = [];
 		const pendingSwiftness = { name: swiftness.name, stacks: swiftness.stacks.calculate(user) };
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 		if (user.crit) {
 			pendingSwiftness.stacks *= critBonus;
 		}
-		reciepts.push(...addModifier(userTeam, pendingSwiftness).concat(addModifier(userTeam, empowerment)));
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(reciepts)));
+		receipts.push(...addModifier(userTeam, pendingSwiftness).concat(addModifier(userTeam, empowerment)));
+		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Supportive Storm Formation")
 	.setMoraleRequirement(1)

--- a/source/gear/universalsolution-base.js
+++ b/source/gear/universalsolution-base.js
@@ -20,21 +20,21 @@ module.exports = new GearTemplate(variantName,
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-		const reciepts = [];
+		const receipts = [];
 		if (user.crit) {
 			for (const debuff of userDebuffs) {
-				reciepts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+				receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+				receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		} else {
 			for (let i = 0; i < debuffsTransferred; i++) {
-				const debuff = userDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
-				reciepts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+				const [debuff] = userDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
+				receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+				receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		}
-		reciepts.push(...addModifier([user], poison))
-		return generateModifierResultLines(combineModifierReceipts(reciepts));
+		receipts.push(...addModifier([user], poison))
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}, { type: "single", team: "foe" })
 	.setUpgrades("Centering Universal Solution", "Tormenting Universal Solution")
 	.setPactCost([poisonStacks, "Gain @{pactCost} @e{Poison} afterwards"])

--- a/source/gear/universalsolution-centering.js
+++ b/source/gear/universalsolution-centering.js
@@ -20,22 +20,22 @@ module.exports = new GearTemplate(variantName,
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-		const reciepts = [];
+		const receipts = [];
 		if (user.crit) {
 			for (const debuff of userDebuffs) {
-				reciepts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+				receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+				receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		} else {
 			for (let i = 0; i < debuffsTransferred; i++) {
-				const debuff = userDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
-				reciepts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+				const [debuff] = userDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
+				receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+				receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		}
 		changeStagger([user], staggerRelief);
-		reciepts.push(...addModifier([user], poison));
-		return generateModifierResultLines(combineModifierReceipts(reciepts)).concat(`${user.name} shrugs off some Stagger.`);
+		receipts.push(...addModifier([user], poison));
+		return generateModifierResultLines(combineModifierReceipts(receipts)).concat(`${user.name} shrugs off some Stagger.`);
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Tormenting Universal Solution")
 	.setPactCost([poisonStacks, "Gain @{pactCost} @e{Poison} afterwards"])

--- a/source/gear/universalsolution-tormenting.js
+++ b/source/gear/universalsolution-tormenting.js
@@ -20,28 +20,28 @@ module.exports = new GearTemplate(variantName,
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-		const reciepts = [];
+		const receipts = [];
 		if (user.crit) {
 			for (const debuff of userDebuffs) {
-				reciepts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+				receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+				receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		} else {
 			for (let i = 0; i < debuffsTransferred; i++) {
-				const debuff = userDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
-				reciepts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-				reciepts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+				const [debuff] = userDebuffs.splice(user.roundRns[`${variantName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
+				receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+				receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 			}
 		}
 		for (const target of targets) {
 			for (const modifier in target.modifiers) {
 				if (getModifierCategory(modifier) === "Debuff") {
-					reciepts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+					receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 				}
 			}
 		}
-		reciepts.push(...addModifier([user], poison))
-		return generateModifierResultLines(combineModifierReceipts(reciepts));
+		receipts.push(...addModifier([user], poison))
+		return generateModifierResultLines(combineModifierReceipts(receipts));
 	}, { type: "single", team: "foe" })
 	.setSidegrades("Centering Universal Solution")
 	.setPactCost([poisonStacks, "Gain @{pactCost} @e{Poison} afterwards"])

--- a/source/gear/wavecrash-disenchanting.js
+++ b/source/gear/wavecrash-disenchanting.js
@@ -17,15 +17,15 @@ module.exports = new GearTemplate("Disenchanting Wave Crash",
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		const reciepts = addModifier(targets, incompatibility);
+		const receipts = addModifier(targets, incompatibility);
 		const targetBuffs = Object.keys(targets[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 		if (targetBuffs.length > 0) {
 			for (let i = 0; i < pendingBuffRemovals; i++) {
-				const selectedBuff = targetBuffs.splice(user.roundRns(`${gearName}${SAFE_DELIMITER}buffs`), 1);
-				reciepts.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
+				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${gearName}${SAFE_DELIMITER}buffs`), 1);
+				receipts.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
 			}
 		}
-		const resultLines = generateModifierResultLines(combineModifierReceipts(reciepts));
+		const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 		if (user.crit) {
 			resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
 		}

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -271,7 +271,7 @@ function endRoom(roomType, thread) {
 	nextRoom(roomType, thread);
 }
 
-const rnsConcerningTargets = new Set(["vulnerabilities", "buffs", "debuffs"]);
+const rnsConcerningTargets = new Set(["vulnerabilities", "buffs", "debuffs", "Medicine"]);
 
 /**
  * Cache the random result of a move, onto the roundRns of a combatant
@@ -347,6 +347,9 @@ function cacheRoundRn(adventure, user, moveName, config) {
 				case "Deck of Cards":
 					user.roundRns[roundRnKeyname] = Array(rnCount).fill(null).map(() => adventure.generateRandomNumber(8, "battle"));
 					break;
+				case "Medicine":
+					user.roundRns[roundRnKeyname] = Array(rnCount).fill(null).map(() => adventure.generateRandomNumber(256, "battle"))
+					break;
 				default: {
 					const keyAsInt = parseInt(key);
 					if (!isNaN(keyAsInt)) {
@@ -417,6 +420,17 @@ function predictRoundRnTargeted(adventure, user, target, moveName, key) {
 			return `${user.name} will apply ${user.roundRns[roundRnKeyname][0] + 2} stacks of The Mark if there isn't a mark yet.`;
 		case "Deck of Cards":
 			return `${user.name}'s ${moveName} will inflict ${user.roundRns[roundRnKeyname][0] + 2} ${getApplicationEmojiMarkdown("Misfortune")}.`;
+		case "Medicine": {
+			const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
+			if (targetDebuffs.length > 1) {
+				const firstDebuff = getApplicationEmojiMarkdown(targetDebuffs.splice(user.roundRns[roundRnKeyname][0] % targetDebuffs.length, 1)[0]);
+				const secondDebuff = getApplicationEmojiMarkdown(targetDebuffs[user.roundRns[roundRnKeyname][1] % targetDebuffs.length]);
+				return `${user.name}'s ${moveName} will cure ${firstDebuff} (and ${secondDebuff} on 💥).`;
+			} else if (targetDebuffs.length === 1) {
+				return `${user.name}'s ${moveName} will cure ${getApplicationEmojiMarkdown(targetDebuffs[0])}.`;
+			}
+			break;
+		}
 		default:
 			console.error(`Invalid config key ${key} for predictRoundRnTargeted`);
 	}

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -416,7 +416,7 @@ function predictRoundRnTargeted(adventure, user, target, moveName, key) {
 		case "Mug or Mark":
 			return `${user.name} will apply ${user.roundRns[roundRnKeyname][0] + 2} stacks of The Mark if there isn't a mark yet.`;
 		case "Deck of Cards":
-			return `${user.name}'s Deck of Cards will inflict ${user.roundRns[roundRnKeyname][0] + 2} stacks of Misfortune.`;
+			return `${user.name}'s ${moveName} will inflict ${user.roundRns[roundRnKeyname][0] + 2} ${getApplicationEmojiMarkdown("Misfortune")}.`;
 		default:
 			console.error(`Invalid config key ${key} for predictRoundRnTargeted`);
 	}
@@ -470,7 +470,7 @@ function predictRoundRnOutcomes(adventure) {
 		if (counterpart) {
 			isCloneAlive = counterpart.hp > 0 && counterpart.archetype === "Mirror Clone";
 		}
-		for (const gear of delver.gear) {
+		for (const gear of delver.gear.concat({ name: getArchetypeActionName(delver.archetype, delver.specialization), cooldown: 0 })) {
 			if (gear.cooldown === 0) {
 				let rnConfig = getGearProperty(gear.name, "rnConfig")
 				let targetingTags = getGearProperty(gear.name, "targetingTags")

--- a/source/pets/_petDictionary.js
+++ b/source/pets/_petDictionary.js
@@ -81,7 +81,7 @@ function rollPets(count, allowDupes) {
 				results.push(archetype);
 			}
 		} else {
-			results.push(pool.splice(randomIndex, 1));
+			results.push(...pool.splice(randomIndex, 1));
 		}
 	}
 	return results;

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -108,11 +108,10 @@ function dealDamage(targets, assailant, damage, isUnblockable, essence, adventur
 						damageLine += ".";
 					}
 					const downedLines = downedCheck(target, adventure);
-					if (downedLines.addendum !== "") {
+					if (downedLines.addendum === "") {
+						survivors.push(target);
+					} else {
 						damageLine += downedLines.addendum;
-						if (target.hp > 0) {
-							survivors.push(target);
-						}
 					}
 					resultLines.push(damageLine, ...downedLines.extraLines);
 					if (pendingDamage > 0 && "Curse of Midas" in target.modifiers) {


### PR DESCRIPTION
Summary
-------
- fix crashes in Trickster predict
- add missing rnConfig to Bouncing gear
- fix Deck of Cards not being predicted
- fix survivors check in dealDamage()
- update Medic's Kit's rnConfig
- fix scalings in Cleansing Water's Stillness
- fix typo "reciepts" to "receipts"
- fix not unwrapping array returned from splice
- fix Medicine predict text to specify which cure is the crit

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] used Deck of Cards in battle
- [x] used Medic's Kit in battle
- [x] used Medicine in battle (crit)
- [x] checked predict texts for the above

Issue
-----
Closes #546