### PR TITLE
#496: taking "Can't Hold All this Value" while at gear capacity forces a discard

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,7 +42,8 @@ Other Changes:
 - New Artifact: Add Blocker
 - Gear and Item drop chance from battle increased to 1/4 (from 1/16 and 1/8 respectively)
 - Fix merchant only stocking duplicates of the same item
-- Cursed Run (challenge) now causes found gear to be Cursed for the next 5 rooms, then reward the party with 250g
+- Cursed Run (challenge) now causes found gear to be Cursed for the next 5 rooms, then rewards the party with 250g
+- Fixed Can't Hold All this Value (challenge) not forcing a discard for delvers who are already above the new gear capacity
 ## Prophets of the Labyrinth v0.17.0:
 ### Pets
 Delvers can now bring pets with them on adventure. One of the party's pets will use a supportive move (or Loaf Around) each even round. You pick which pet to bring during the preparation phase or with `/set-favorite pet`. Your pet kennel is tracked per server so you can have different loadouts with different friend groups. Pets can be leveled-up per kennel, which gets them to stop Loafing Around or upgrades their moves.

--- a/source/buttons/challenges.js
+++ b/source/buttons/challenges.js
@@ -1,8 +1,8 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, DiscordjsErrorCodes } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, DiscordjsErrorCodes, ComponentType } = require('discord.js');
 const { ButtonWrapper, Challenge } = require('../classes');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { getChallenge } = require('../challenges/_challengeDictionary');
-const { trimForSelectOptionDescription } = require('../util/textUtil');
+const { trimForSelectOptionDescription, listifyEN } = require('../util/textUtil');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { renderRoom } = require('../util/embedUtil');
 
@@ -34,16 +34,16 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			components,
 			flags: [MessageFlags.Ephemeral],
 			withResponse: true
-		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000 })).then(collectedInteraction => {
+		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(collectedInteraction => {
 			const adventure = getAdventure(collectedInteraction.channelId);
 			const [_, startingDepth] = collectedInteraction.customId.split(SKIP_INTERACTION_HANDLING);
 			if (adventure?.room.history["New challenges"].length > 0 || startingDepth !== adventure.depth.toString()) {
 				return collectedInteraction;
 			}
 
-			const challengeName = collectedInteraction.values[0];
+			const [challengeName] = collectedInteraction.values;
 			const { intensity, duration, reward } = getChallenge(challengeName);
-			if (adventure.challenges[challengeName]) {
+			if (challengeName in adventure.challenges) {
 				adventure.challenges[challengeName].intensity += intensity;
 				adventure.challenges[challengeName].duration += duration;
 				adventure.challenges[challengeName].reward += reward;
@@ -52,7 +52,16 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}
 			adventure.room.history["New challenges"].push(challengeName);
 			interaction.message.edit(renderRoom(adventure, collectedInteraction.channel));
-			collectedInteraction.channel.send({ content: `The party takes on a new challenge: ${challengeName}` });
+			const dropMap = {};
+			if (challengeName === "Can't Hold All this Value") {
+				const reducedGearCapacity = adventure.getGearCapacity();
+				adventure.delvers.forEach(delver => {
+					if (delver.gear.length > reducedGearCapacity) {
+						dropMap[delver.name] = delver.gear.splice(reducedGearCapacity).map(gear => gear.name);
+					}
+				})
+			}
+			collectedInteraction.channel.send({ content: `The party takes on a new challenge: ${challengeName}${Object.entries(dropMap).map(([delverName, gearDropped]) => `\n- ${delverName} drops their ${listifyEN(gearDropped)}`).join("")}` });
 			setAdventure(adventure);
 			return collectedInteraction;
 		}).then(interactionToAcknowledge => {

--- a/source/challenges/cantholdallthisvalue.js
+++ b/source/challenges/cantholdallthisvalue.js
@@ -1,7 +1,7 @@
 const { ChallengeTemplate } = require("../classes");
 
 module.exports = new ChallengeTemplate("Can't Hold All this Value",
-	"Reduce the number of pieces of gear a delver can carry by @{intensity}.",
+	"Reduce the number of pieces of gear a delver can carry by @{intensity} (minimum: 1). If they have more than that, the last gear in their list will be dropped first.",
 	1,
 	true,
 	true


### PR DESCRIPTION
Summary
-------
- taking "Can't Hold All this Value" while at gear capacity forces a discard

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] gear is removed from delvers according to new gear cap
- [x] removed gear is reported in response message to challenge select

Issue
-----
Closes #496