### PR TITLE
#482: single source of truth for combat state, move endRound race condition check earlier

### DIFF
--- a/source/buttons/appease.js
+++ b/source/buttons/appease.js
@@ -22,8 +22,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		let overwritten = false;
 		for (let i = 0; i < adventure.room.moves.length; i++) {
-			const { userReference } = adventure.room.moves[i];
-			if (userReference.team === delver.team && userReference.index === delverIndex) {
+			const { userReference, type } = adventure.room.moves[i];
+			if (type !== "pet" && userReference.team === delver.team && userReference.index === delverIndex) {
 				adventure.room.moves.splice(i, 1);
 				overwritten = true;
 				break;

--- a/source/buttons/greed.js
+++ b/source/buttons/greed.js
@@ -24,8 +24,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		let overwritten = false;
 		for (let i = 0; i < adventure.room.moves.length; i++) {
-			const { userReference } = adventure.room.moves[i];
-			if (userReference.team === delver.team && userReference.index === delverIndex) {
+			const { userReference, type } = adventure.room.moves[i];
+			if (type !== "pet" && userReference.team === delver.team && userReference.index === delverIndex) {
 				adventure.room.moves.splice(i, 1);
 				overwritten = true;
 				break;

--- a/source/buttons/readymove.js
+++ b/source/buttons/readymove.js
@@ -11,10 +11,10 @@ const { trimForSelectOptionDescription, listifyEN } = require('../util/textUtil'
 const mainId = "readymove";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Show the delver stats of the user and provide components to ready a move */
-	(interaction, args) => {
+	(interaction, [roundNumber]) => {
 		const adventure = getAdventure(interaction.channelId);
 		const delver = adventure?.delvers.find(delver => delver.id === interaction.user.id);
-		if (!delver) {
+		if (!delver || parseInt(roundNumber) !== adventure.room.round) {
 			interaction.reply({ content: "This adventure isn't active or you aren't participating in it.", flags: [MessageFlags.Ephemeral] });
 			return;
 		}
@@ -189,7 +189,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				const targetIndices = [];
 				const newMove = new Move(`${moveName}${SAFE_DELIMITER}${gearIndex}`, "gear", new CombatantReference(delver.team, userIndex))
 					.setSpeedByCombatant(delver);
-				const scalings = getGearProperty(moveName, "priority");
+				const scalings = getGearProperty(moveName, "scalings");
 				if (scalings && "priority" in scalings) {
 					if (typeof scalings.priority === "number") {
 						newMove.setPriority(scalings.priority);
@@ -241,7 +241,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}
 			collectedInteraction.channel.send(confirmationText).then(() => {
 				setAdventure(adventure);
-			}).catch(console.error);
+			});
 			if (checkNextRound(adventure)) {
 				endRound(adventure, collectedInteraction.channel);
 			}

--- a/source/classes/Adventure.js
+++ b/source/classes/Adventure.js
@@ -112,6 +112,18 @@ class Adventure {
 		}
 	}
 
+	getCombatState() {
+		if (this.lives <= 0) {
+			return "defeat";
+		}
+
+		if (this.room.enemies.every(enemy => enemy.hp === 0 || "Cowardice" in enemy.modifiers)) {
+			return "victory";
+		}
+
+		return "continue";
+	}
+
 	/** Calculates the adventure's score without end of run multipliers */
 	getBaseScore() {
 		const livesScore = this.lives ?? 0 * 10;

--- a/source/gear/bountyfist-base.js
+++ b/source/gear/bountyfist-base.js
@@ -13,7 +13,7 @@ module.exports = new GearTemplate(variantName,
 	"Earth"
 ).setCost(200)
 	.setEffect((targets, user, adventure) => {
-		const { essence, scalings: { damage, critBonus } } = module.exports;
+		const { essence, pactCost, scalings: { damage, critBonus } } = module.exports;
 		const goldUsed = Math.floor(adventure.gold * (pactCost[0] / 100));
 		adventure.gold -= goldUsed;
 		let pendingDamage = damage.calculate(user) + goldUsed;

--- a/source/gear/bountyfist-midass.js
+++ b/source/gear/bountyfist-midass.js
@@ -13,10 +13,10 @@ module.exports = new GearTemplate(variantName,
 	"Earth"
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
-		const { essence, scalings: { damage, critBonus }, modifiers: [curseOfMidas] } = module.exports;
+		const { essence, pactCost, scalings: { damage, critBonus }, modifiers: [curseOfMidas] } = module.exports;
 		const goldUsed = Math.floor(adventure.gold * (pactCost[0] / 100));
 		adventure.gold -= goldUsed;
-		let pendingDamage = damage + user.getPower() + goldUsed;
+		let pendingDamage = damage.calculate(user) + goldUsed;
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}

--- a/source/gear/carrot-balanced.js
+++ b/source/gear/carrot-balanced.js
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Balanced Carrot",
 		}
 		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
 		if (user.crit) {
-			pendingRegeneration += critBonus;
+			pendingRegeneration.stacks += critBonus;
 		}
 		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([target], pendingRegeneration).concat(addModifier([target], finesse))));
 		const ownerIndex = adventure.getCombatantIndex(target);

--- a/source/gear/carrot-base.js
+++ b/source/gear/carrot-base.js
@@ -19,7 +19,7 @@ module.exports = new GearTemplate("Carrot",
 		}
 		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
 		if (user.crit) {
-			pendingRegeneration += critBonus;
+			pendingRegeneration.stacks += critBonus;
 		}
 		const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration));
 		const ownerIndex = adventure.getCombatantIndex(target);

--- a/source/gear/carrot-guarding.js
+++ b/source/gear/carrot-guarding.js
@@ -20,7 +20,7 @@ module.exports = new GearTemplate("Guarding Carrot",
 		}
 		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
 		if (user.crit) {
-			pendingRegeneration += critBonus;
+			pendingRegeneration.stacks += critBonus;
 		}
 		addProtection([target], protection.calculate(user));
 		const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration)).concat(`${target.name} gains protection.`);

--- a/source/gear/carrot-guarding.js
+++ b/source/gear/carrot-guarding.js
@@ -8,7 +8,7 @@ const { protectionScalingGenerator } = require('./shared/scalings');
 module.exports = new GearTemplate("Guarding Carrot",
 	[
 		["use", "Grant <@{mod0Stacks}> @{mod0} and <@{protection}> protection to an ally and entice their pet to use its first move"],
-		["Critical💥", "@{mod0} + @{critMultiplier}"]
+		["Critical💥", "@{mod0} + @{critBonus}"]
 	],
 	"Support",
 	"Earth"

--- a/source/gear/flamescythes-toxic.js
+++ b/source/gear/flamescythes-toxic.js
@@ -6,7 +6,7 @@ const { damageScalingGenerator } = require('./shared/scalings');
 module.exports = new GearTemplate("Toxic Flame Scythes",
 	[
 		["use", "Inflict <@{damage}> @{essence} damage and @{mod0Stacks} @{mod0} on a foe, execute them if they end below half your damage cap"],
-		["Critical💥", "Damage x @{critMultiplier}"]
+		["Critical💥", "Damage x @{critBonus}"]
 	],
 	"Spell",
 	"Fire"

--- a/source/gear/flamescythes-toxic.js
+++ b/source/gear/flamescythes-toxic.js
@@ -13,7 +13,7 @@ module.exports = new GearTemplate("Toxic Flame Scythes",
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
 		const { essence, scalings: { damage, critBonus }, modifiers: [poison] } = module.exports;
-		let pendingDamage = damage + user.getPower();
+		let pendingDamage = damage.calculate(user);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}

--- a/source/gear/heatweaken-staggering.js
+++ b/source/gear/heatweaken-staggering.js
@@ -13,7 +13,7 @@ module.exports = new GearTemplate("Staggering Heat Weaken",
 	"Fire"
 ).setCost(350)
 	.setEffect((targets, user, adventure) => {
-		const { essence, modifiers: [frailty], critMultiplier, stagger } = module.exports;
+		const { essence, modifiers: [frailty], scalings: { critBonus }, stagger } = module.exports;
 		let pendingStagger = stagger;
 		if (user.essence === essence) {
 			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Staggering Heat Weaken",
 		changeStagger(targets, user, pendingStagger);
 		const pendingFrailty = { ...frailty };
 		if (user.crit) {
-			pendingFrailty.stacks *= critMultiplier;
+			pendingFrailty.stacks *= critBonus;
 		}
 		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingFrailty))).concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));
 	}, { type: `random${SAFE_DELIMITER}${bounceCount}`, team: "foe" })
@@ -29,4 +29,5 @@ module.exports = new GearTemplate("Staggering Heat Weaken",
 	.setCharges(15)
 	.setModifiers({ name: "Frailty", stacks: 2 })
 	.setStagger(2)
+	.setScalings({ critBonus: 2 })
 	.setRnConfig({ foes: bounceCount });

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1064,6 +1064,7 @@ function handleEndCombat(combatState, adventure, thread, lastRoundText) {
 		case "defeat":
 			adventure.room.round++;
 			thread.send(completeAdventure(adventure, thread, "defeat", lastRoundText));
+			return;
 		case "victory":
 			if (adventure.depth >= getLabyrinthProperty(adventure.labyrinth, "maxDepth")) {
 				thread.send(completeAdventure(adventure, thread, "success", lastRoundText));

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const { ThreadChannel, Message, EmbedBuilder, bold } = require("discord.js");
+const { ThreadChannel, Message, EmbedBuilder, bold, italic } = require("discord.js");
 
 const { Adventure, CombatantReference, Move, Enemy, Delver, Room, Combatant } = require("../classes");
 
@@ -759,7 +759,7 @@ function resolveMove(move, adventure) {
 					effect = action.effect;
 					headline += `used ${moveName}`;
 					if (action.combatFlavor) {
-						headline += action.combatFlavor;
+						headline += ` ${italic(action.combatFlavor)}`;
 					}
 				}
 				break;
@@ -1060,9 +1060,9 @@ function endRound(adventure, thread) {
  */
 function handleEndCombat(combatState, adventure, thread, lastRoundText) {
 	adventure.room.history.endedCombat = [];
+	adventure.room.round++;
 	switch (combatState) {
 		case "defeat":
-			adventure.room.round++;
 			thread.send(completeAdventure(adventure, thread, "defeat", lastRoundText));
 			return;
 		case "victory":

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -918,6 +918,10 @@ const RETAINING_MODIFIER_PAIRS = [["Exposure", "Distraction"], ["Evasion", "Vigi
  * @param {ThreadChannel} thread
  */
 function endRound(adventure, thread) {
+	if ("endedCombat" in adventure.room.history) {
+		return;
+	}
+
 	clearComponents(adventure.messageIds.battleRound, thread.messages);
 
 	const randomOrderBag = Array(adventure.room.moves.length).fill().map((_, idx) => idx) // ensure that unique values are available for each move
@@ -990,13 +994,9 @@ function endRound(adventure, thread) {
 		}
 		lastRoundText += resolveMove(move, adventure);
 
-		const { payload, type } = checkEndCombat(adventure, thread, lastRoundText);
-		if (payload) {
-			thread.send(payload).then(message => {
-				if (type === "endCombat") {
-					adventure.messageIds.battleRound = message.id;
-				}
-			})
+		const combatState = adventure.getCombatState();
+		if (combatState !== "continue") {
+			handleEndCombat(combatState, adventure, thread, lastRoundText);
 			return;
 		}
 	}
@@ -1028,13 +1028,9 @@ function endRound(adventure, thread) {
 			lastRoundText += `Other Happenings\n-# ${otherHappenings.join("\n-# ")}`
 		}
 
-		const { payload, type } = checkEndCombat(adventure, thread, lastRoundText);
-		if (payload) {
-			thread.send(payload).then(message => {
-				if (type === "endCombat") {
-					adventure.messageIds.battleRound = message.id;
-				}
-			})
+		const combatState = adventure.getCombatState();
+		if (combatState !== "continue") {
+			handleEndCombat(combatState, adventure, thread, lastRoundText);
 			return;
 		}
 
@@ -1057,61 +1053,58 @@ function endRound(adventure, thread) {
 }
 
 /**
+ * @param {"defeat" | "victory"} combatState
  * @param {Adventure} adventure
  * @param {ThreadChannel} thread
  * @param {string} lastRoundText
  */
-function checkEndCombat(adventure, thread, lastRoundText) {
-	if (adventure.lives <= 0) {
-		adventure.room.round++;
-		return { payload: completeAdventure(adventure, thread, "defeat", lastRoundText), type: "adventureDefeat" };
-	}
+function handleEndCombat(combatState, adventure, thread, lastRoundText) {
+	adventure.room.history.endedCombat = [];
+	switch (combatState) {
+		case "defeat":
+			adventure.room.round++;
+			thread.send(completeAdventure(adventure, thread, "defeat", lastRoundText));
+		case "victory":
+			if (adventure.depth >= getLabyrinthProperty(adventure.labyrinth, "maxDepth")) {
+				thread.send(completeAdventure(adventure, thread, "success", lastRoundText));
+				return;
+			}
 
-	if (adventure.room.enemies.every(enemy => enemy.hp === 0 || "Cowardice" in enemy.modifiers)) {
-		if ("endedCombat" in adventure.room.history) {
-			return { type: "endCombat" };
-		}
-		adventure.room.history.endedCombat = [];
-
-		if (adventure.depth >= getLabyrinthProperty(adventure.labyrinth, "maxDepth")) {
-			return { payload: completeAdventure(adventure, thread, "success", lastRoundText), type: "adventureSuccess" };
-		}
-
-		for (const resourceName in adventure.room.resources) {
-			const resource = adventure.room.resources[resourceName];
-			if (resource.type === "levelsGained") {
-				const [_, index] = resourceName.split(SAFE_DELIMITER);
-				if (!index) {
-					for (const delver of adventure.delvers) {
-						levelUp(delver, resource.count, adventure);
+			for (const resourceName in adventure.room.resources) {
+				const resource = adventure.room.resources[resourceName];
+				if (resource.type === "levelsGained") {
+					const [_, index] = resourceName.split(SAFE_DELIMITER);
+					if (!index) {
+						for (const delver of adventure.delvers) {
+							levelUp(delver, resource.count, adventure);
+						}
+					} else {
+						levelUp(adventure.delvers[index], resource.count, adventure);
 					}
-				} else {
-					levelUp(adventure.delvers[index], resource.count, adventure);
 				}
 			}
-		}
 
-		// Gear drops
-		const gearThreshold = 1;
-		const gearMax = 4;
-		if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
-			const tier = rollGearTier(adventure);
-			const droppedGear = rollGear(tier, adventure);
-			if (droppedGear) {
-				adventure.room.addResource(droppedGear, "Gear", "loot", 1);
+			// Gear drops
+			const gearThreshold = 1;
+			const gearMax = 4;
+			if (adventure.generateRandomNumber(gearMax, "general") < gearThreshold) {
+				const tier = rollGearTier(adventure);
+				const droppedGear = rollGear(tier, adventure);
+				if (droppedGear) {
+					adventure.room.addResource(droppedGear, "Gear", "loot", 1);
+				}
 			}
-		}
 
-		// Item drops
-		const itemThreshold = 1;
-		const itemMax = 4;
-		if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
-			adventure.room.addResource(rollItem(adventure), "Item", "loot", 1);
-		}
-
-		return { payload: renderRoom(adventure, thread, lastRoundText), type: "endCombat" };
+			// Item drops
+			const itemThreshold = 1;
+			const itemMax = 4;
+			if (adventure.generateRandomNumber(itemMax, "general") < itemThreshold) {
+				adventure.room.addResource(rollItem(adventure), "Item", "loot", 1);
+			}
+			thread.send(renderRoom(adventure, thread, lastRoundText)).then(message => {
+				adventure.messageIds.battleRound = message.id;
+			});
 	}
-	return { type: "continueCombat" };
 }
 
 /** The round ends when all combatants have readied all their moves

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -39,7 +39,7 @@ function generateCombatRoomBuilder(extraButtons) {
 			const buttons = [
 				module.exports.partyStatsButton,
 				module.exports.inspectSelfButton,
-				new ButtonBuilder().setCustomId("readymove")
+				new ButtonBuilder().setCustomId(`readymove${SAFE_DELIMITER}${adventure.room.round}`)
 					.setEmoji("⚔")
 					.setLabel("Ready a Move")
 					.setStyle(ButtonStyle.Success),

--- a/source/util/messageComponentUtil.js
+++ b/source/util/messageComponentUtil.js
@@ -35,8 +35,7 @@ const extraCombatButtonsMap = {
 function generateCombatRoomBuilder(extraButtons) {
 	return (roomEmbed, adventure) => {
 		roomEmbed.setFooter({ text: `Room #${adventure.depth} - Round ${adventure.room.round}` });
-		const isCombatVictory = adventure.room.enemies?.every(enemy => enemy.hp === 0 || "Cowardice" in enemy.modifiers);
-		if (!isCombatVictory) {
+		if (adventure.getCombatState() === "continue") {
 			const buttons = [
 				module.exports.partyStatsButton,
 				module.exports.inspectSelfButton,


### PR DESCRIPTION
Summary
-------
- single source of truth for combat state
- move endRound race condition check earlier

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] combat continues properly
- [x] combat ends in defeat properly
- [x] combat ends in victory properly
- [x] combat ends in adventure success properly
- [x] cannot reproduce race condition on end round

Issue
-----
Closes #482