### PR TITLE
#572: handle overflow in modifiers predict

### DIFF
--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -10,9 +10,10 @@ module.exports = new ArchetypeTemplate("Chemist",
 	(embed, adventure) => {
 		const eligibleCombatants = adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0);
 		eligibleCombatants.forEach(combatant => {
-			const modifiersText = modifiersToString(combatant, adventure);
+			const counterText = `Counters: ${counters.map(counter => getEmoji(counter)).join(" ")}\n`;
+			const modifiersText = modifiersToString(combatant, adventure, counterText.length);
 			const counters = getCombatantCounters(combatant);
-			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.essence)}`, value: `Counters: ${counters.map(counter => getEmoji(counter)).join(" ")}\n${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` });
+			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.essence)}`, value: `${counterText}${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` });
 		})
 		return embed.setDescription(`Chemist predictions for Round ${adventure.room.round}:`);
 	},

--- a/source/archetypes/chemist.js
+++ b/source/archetypes/chemist.js
@@ -10,9 +10,9 @@ module.exports = new ArchetypeTemplate("Chemist",
 	(embed, adventure) => {
 		const eligibleCombatants = adventure.room.enemies.concat(adventure.delvers).filter(combatant => combatant.hp > 0);
 		eligibleCombatants.forEach(combatant => {
+			const counters = getCombatantCounters(combatant);
 			const counterText = `Counters: ${counters.map(counter => getEmoji(counter)).join(" ")}\n`;
 			const modifiersText = modifiersToString(combatant, adventure, counterText.length);
-			const counters = getCombatantCounters(combatant);
 			embed.addFields({ name: `${combatant.name} ${getEmoji(combatant.essence)}`, value: `${counterText}${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` });
 		})
 		return embed.setDescription(`Chemist predictions for Round ${adventure.room.round}:`);

--- a/source/archetypes/tactician.js
+++ b/source/archetypes/tactician.js
@@ -9,7 +9,7 @@ function generateCritAndModifierField(team, adventure) {
 	return team.map(combatant => {
 		const critText = `Critical: ${combatant.crit ? "💥" : "🚫"}\n`;
 		const modifiersText = modifiersToString(combatant, adventure, critText.length);
-		return { name: combatant.name, value: `${critText}${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` };
+		return { name: combatant.name, value: `${critText}${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}`, inline: true };
 	})
 }
 

--- a/source/archetypes/tactician.js
+++ b/source/archetypes/tactician.js
@@ -7,8 +7,9 @@ const { modifiersToString } = require("../util/combatantUtil");
  */
 function generateCritAndModifierField(team, adventure) {
 	return team.map(combatant => {
-		const modifiersText = modifiersToString(combatant, adventure);
-		return { name: combatant.name, value: `Critical: ${combatant.crit ? "💥" : "🚫"}\n${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` };
+		const critText = `Critical: ${combatant.crit ? "💥" : "🚫"}\n`;
+		const modifiersText = modifiersToString(combatant, adventure, critText.length);
+		return { name: combatant.name, value: `${critText}${modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states"}` };
 	})
 }
 

--- a/source/archetypes/trickster.js
+++ b/source/archetypes/trickster.js
@@ -11,7 +11,7 @@ module.exports = new ArchetypeTemplate("Trickster",
 	(embed, adventure) => {
 		/** @param {Combatant} combatant */
 		function createModifierField(combatant) {
-			const modifiersText = modifiersToString(combatant, adventure);
+			const modifiersText = modifiersToString(combatant, adventure, 0);
 			embed.addFields({ name: combatant.name, value: modifiersText ? `${modifiersText}` : "No buffs, debuffs, or states", inline: true });
 		}
 


### PR DESCRIPTION
Summary
-------
- added handling to modifiersToString() that abbreviates information if a combatant's description would require too many characters for a single embed field

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] viewed description generation on Chemist, Tactician, and Trickster predicts

Issue
-----
Closes #572