### PR TITLE
Refactor: pet move interference on move.effect signatures

### DIFF
--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -50,7 +50,8 @@ class GearTemplate {
 	}
 
 	/**
-	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => string[]} effectFunction
+	 * overrides is a dict *parameter* whose values can be defaulted, but can also be clobbered for polymorphism.  
+	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: any) => string[]} effectFunction
 	 * @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} tagObject
 	 */
 	setEffect(effectFunction, tagObject) {

--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -21,6 +21,8 @@ class GearTemplate {
 		this.essence = essenceEnum;
 	}
 	// Internal Configuration
+	/** @type {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: Partial<MoveEffectOverrides>) => string[]} */
+	effect;
 	/** @type {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} */
 	targetingTags;
 	/** @type {string[]} */
@@ -51,7 +53,7 @@ class GearTemplate {
 
 	/**
 	 * overrides is a dict *parameter* whose values can be defaulted, but can also be clobbered for polymorphism.  
-	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: any) => string[]} effectFunction
+	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: Partial<MoveEffectOverrides>) => string[]} effectFunction
 	 * @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} tagObject
 	 */
 	setEffect(effectFunction, tagObject) {
@@ -132,6 +134,18 @@ class GearTemplate {
 		return this;
 	}
 };
+
+class MoveEffectOverrides {
+	/** read-only class defines a type for overrides */
+	/** @type {delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}) */
+	petRNs; // either the adventure.petRNs or one submitted during move resolution
+	/** @type {Record<string, number | Scaling>}  */
+	// the respective gear-metadata is used for buildGearDescription token substitution
+	// the respective gear-metadata scalings.priority is read for ready.js priority assignment (but is unlikely to be used in calculations of effect resolution)
+	scalings = {};
+	/** @type {[{ name: string, stacks: number | Scaling }]}  */
+	modifiers = []; // the respective gear-metadata is used for buildGearDescription token substitution
+}
 
 module.exports = {
 	GearTemplate

--- a/source/classes/PetTemplate.js
+++ b/source/classes/PetTemplate.js
@@ -20,7 +20,7 @@ class PetMoveTemplate {
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
 	 * @param {(owner: Delver, petRNs: {delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}) => CombatantReference[]} selectorFunction
-	 * @param {(targets: Combatant[], owner: Delver, adventure: Adventure, petRNs: {delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}) => string[]} effectFunction
+	 * @param {(targets: Combatant[], owner: Delver, adventure: Adventure, {petRNs: {delverIndex: number, moveIndex: number, targetReferences: CombatantReference[], extras: number[]}}) => string[]} effectFunction
 	 */
 	constructor(nameInput, descriptionInput, selectorFunction, effectFunction) {
 		this.name = nameInput;

--- a/source/commands/set-favorite/archetype.js
+++ b/source/commands/set-favorite/archetype.js
@@ -25,7 +25,7 @@ async function executeSubcommand(interaction, ...[player]) {
 		flags: [MessageFlags.Ephemeral],
 		withResponse: true
 	}).then(response => response.resource.message.awaitMessageComponent({ time: 120000 })).then(collectedInteraction => {
-		const recentPlayer = getPlayer(interaction.user.id, reply.guildId);
+		const recentPlayer = getPlayer(interaction.user.id, interaction.guildId);
 		const selectedArchetype = collectedInteraction.values[0];
 		recentPlayer.favoriteArchetype = selectedArchetype;
 		setPlayer(recentPlayer);

--- a/source/commands/set-favorite/pet.js
+++ b/source/commands/set-favorite/pet.js
@@ -30,7 +30,7 @@ async function executeSubcommand(interaction, ...[player]) {
 		flags: [MessageFlags.Ephemeral],
 		withResponse: true
 	}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(collectedInteraction => {
-		const recentPlayer = getPlayer(interaction.user.id, reply.guildId);
+		const recentPlayer = getPlayer(interaction.user.id, interaction.guildId);
 		const newBestFriend = collectedInteraction.values[0];
 		recentPlayer.favoritePet = newBestFriend;
 		setPlayer(recentPlayer);

--- a/source/enemies/elegantstella.js
+++ b/source/enemies/elegantstella.js
@@ -57,13 +57,13 @@ module.exports = new EnemyTemplate("Elegant Stella",
 	description: `Deal minor ${getEmoji("Light")} damage and slowing @e{Misfortune} to all foes`,
 	priority: 0,
 	effect: (targets, user, adventure) => {
-		let pendingMisfortune = 1;
+		const pendingMisfortune = { name: "Misfortune", stacks: 1 };
 		if (user.crit) {
-			pendingMisfortune += 7;
+			pendingMisfortune.stacks += 7;
 		}
 		const { resultLines, survivors } = dealDamage(targets, user, user.getPower() + 25, false, "Light", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: "Misfortune", stacks: pendingMisfortune })));
+		return resultLines.concat(generateModifierResultLines(addModifier(survivors, pendingMisfortune)));
 	},
 	selector: selectAllFoes,
 	next: randomNonOpener

--- a/source/enemies/elegantstella.js
+++ b/source/enemies/elegantstella.js
@@ -57,13 +57,13 @@ module.exports = new EnemyTemplate("Elegant Stella",
 	description: `Deal minor ${getEmoji("Light")} damage and slowing @e{Misfortune} to all foes`,
 	priority: 0,
 	effect: (targets, user, adventure) => {
-		const pendingMisfortune = 1;
+		let pendingMisfortune = 1;
 		if (user.crit) {
 			pendingMisfortune += 7;
 		}
 		const { resultLines, survivors } = dealDamage(targets, user, user.getPower() + 25, false, "Light", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines.concat(generateModifierResultLines(addModifier(survivors, pendingMisfortune)));
+		return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: "Misfortune", stacks: pendingMisfortune })));
 	},
 	selector: selectAllFoes,
 	next: randomNonOpener

--- a/source/gear/carrot-balanced.js
+++ b/source/gear/carrot-balanced.js
@@ -3,6 +3,7 @@ const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
 const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
+const base = require('./carrot-base.js')
 
 module.exports = new GearTemplate("Balanced Carrot",
 	[
@@ -13,40 +14,10 @@ module.exports = new GearTemplate("Balanced Carrot",
 	"Earth"
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
-		const { essence, modifiers: [regeneration, finesse], scalings: { critBonus } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
-		}
-		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
-		if (user.crit) {
-			pendingRegeneration.stacks += critBonus;
-		}
-		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([target], pendingRegeneration).concat(addModifier([target], finesse))));
-		const ownerIndex = adventure.getCombatantIndex(target);
-		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
-		if (owner.pet?.type) {
-			const petMoveTemplate = getPetMove(owner.pet, 0);
-			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
-			petMoveTemplate.rnConfig.forEach(rnType => {
-				switch (rnType) {
-					case "enemyIndex":
-						const livingEnemyIndices = [];
-						for (let i = 0; i < adventure.room.enemies.length; i++) {
-							if (adventure.room.enemies[i].hp > 0) {
-								livingEnemyIndices.push(i);
-							}
-						}
-						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
-						break;
-					default:
-						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
-				}
-			})
-			resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));
-		}
-		return resultLines;
+		const { modifiers: [finesse] } = module.exports;
+		return base.effect([target], user, adventure, { extraReceipts: addModifier([target], finesse) });
 	}, { type: "single", team: "ally" })
 	.setSidegrades("Guarding Carrot")
 	.setCooldown(1)
-	.setModifiers(scalingRegeneration(2), { name: "Finesse", stacks: 1 })
+	.setModifiers({ name: "Finesse", stacks: 1 })
 	.setScalings({ critBonus: 1 });

--- a/source/gear/carrot-balanced.js
+++ b/source/gear/carrot-balanced.js
@@ -3,7 +3,6 @@ const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
 const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
-const base = require('./carrot-base.js')
 
 module.exports = new GearTemplate("Balanced Carrot",
 	[
@@ -14,10 +13,40 @@ module.exports = new GearTemplate("Balanced Carrot",
 	"Earth"
 ).setCost(350)
 	.setEffect(([target], user, adventure) => {
-		const { modifiers: [finesse] } = module.exports;
-		return base.effect([target], user, adventure, { extraReceipts: addModifier([target], finesse) });
+		const { essence, modifiers: [regeneration, finesse], scalings: { critBonus } } = module.exports;
+		if (user.essence === essence) {
+			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
+		}
+		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
+		if (user.crit) {
+			pendingRegeneration.stacks += critBonus;
+		}
+		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([target], pendingRegeneration).concat(addModifier([target], finesse))));
+		const ownerIndex = adventure.getCombatantIndex(target);
+		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
+		if (owner.pet?.type) {
+			const petMoveTemplate = getPetMove(owner.pet, 0);
+			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
+			petMoveTemplate.rnConfig.forEach(rnType => {
+				switch (rnType) {
+					case "enemyIndex":
+						const livingEnemyIndices = [];
+						for (let i = 0; i < adventure.room.enemies.length; i++) {
+							if (adventure.room.enemies[i].hp > 0) {
+								livingEnemyIndices.push(i);
+							}
+						}
+						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
+						break;
+					default:
+						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
+				}
+			})
+			resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		}
+		return resultLines;
 	}, { type: "single", team: "ally" })
 	.setSidegrades("Guarding Carrot")
 	.setCooldown(1)
-	.setModifiers({ name: "Finesse", stacks: 1 })
+	.setModifiers(scalingRegeneration(2), { name: "Finesse", stacks: 1 })
 	.setScalings({ critBonus: 1 });

--- a/source/gear/carrot-base.js
+++ b/source/gear/carrot-base.js
@@ -21,7 +21,6 @@ module.exports = new GearTemplate("Carrot",
 		if (user.crit) {
 			pendingRegeneration.stacks += critBonus;
 		}
-		console.log(regeneration, regeneration.stacks.calculate(user), pendingRegeneration, extraReceipts)
 		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([target], pendingRegeneration).concat(extraReceipts))).concat(extraResultLines);
 		const ownerIndex = adventure.getCombatantIndex(target);
 		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });

--- a/source/gear/carrot-base.js
+++ b/source/gear/carrot-base.js
@@ -1,7 +1,7 @@
 const { GearTemplate, CombatantReference } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
-const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
+const { changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
 
 module.exports = new GearTemplate("Carrot",
@@ -12,7 +12,7 @@ module.exports = new GearTemplate("Carrot",
 	"Support",
 	"Earth"
 ).setCost(200)
-	.setEffect(([target], user, adventure, { extraReceipts = [], extraResultLines = [] }) => {
+	.setEffect(([target], user, adventure) => {
 		const { essence, modifiers: [regeneration], scalings: { critBonus } } = module.exports;
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Carrot",
 		if (user.crit) {
 			pendingRegeneration.stacks += critBonus;
 		}
-		const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([target], pendingRegeneration).concat(extraReceipts))).concat(extraResultLines);
+		const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration));
 		const ownerIndex = adventure.getCombatantIndex(target);
 		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 		if (owner.pet?.type) {

--- a/source/gear/carrot-guarding.js
+++ b/source/gear/carrot-guarding.js
@@ -4,6 +4,7 @@ const { getPetMove } = require('../pets/_petDictionary');
 const { changeStagger, addModifier, addProtection, generateModifierResultLines } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
 const { protectionScalingGenerator } = require('./shared/scalings');
+const base = require('./carrot-base.js');
 
 module.exports = new GearTemplate("Guarding Carrot",
 	[
@@ -14,39 +15,9 @@ module.exports = new GearTemplate("Guarding Carrot",
 	"Earth"
 ).setCost(200)
 	.setEffect(([target], user, adventure) => {
-		const { essence, modifiers: [regeneration], scalings: { critBonus, protection } } = module.exports;
-		if (user.essence === essence) {
-			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
-		}
-		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
-		if (user.crit) {
-			pendingRegeneration.stacks += critBonus;
-		}
+		const { scalings: { protection } } = module.exports;
 		addProtection([target], protection.calculate(user));
-		const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration)).concat(`${target.name} gains protection.`);
-		const ownerIndex = adventure.getCombatantIndex(target);
-		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
-		if (owner.pet?.type) {
-			const petMoveTemplate = getPetMove(owner.pet, 0);
-			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
-			petMoveTemplate.rnConfig.forEach(rnType => {
-				switch (rnType) {
-					case "enemyIndex":
-						const livingEnemyIndices = [];
-						for (let i = 0; i < adventure.room.enemies.length; i++) {
-							if (adventure.room.enemies[i].hp > 0) {
-								livingEnemyIndices.push(i);
-							}
-						}
-						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
-						break;
-					default:
-						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
-				}
-			})
-			resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));
-		}
-		return resultLines;
+		return base.effect([target], user, adventure, { extraResultLines: `${target.name} gains protection.` });
 	}, { type: "single", team: "ally" })
 	.setSidegrades("Balanced Carrot")
 	.setCooldown(1)

--- a/source/gear/carrot-guarding.js
+++ b/source/gear/carrot-guarding.js
@@ -4,7 +4,6 @@ const { getPetMove } = require('../pets/_petDictionary');
 const { changeStagger, addModifier, addProtection, generateModifierResultLines } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
 const { protectionScalingGenerator } = require('./shared/scalings');
-const base = require('./carrot-base.js');
 
 module.exports = new GearTemplate("Guarding Carrot",
 	[
@@ -15,9 +14,39 @@ module.exports = new GearTemplate("Guarding Carrot",
 	"Earth"
 ).setCost(200)
 	.setEffect(([target], user, adventure) => {
-		const { scalings: { protection } } = module.exports;
+		const { essence, modifiers: [regeneration], scalings: { critBonus, protection } } = module.exports;
+		if (user.essence === essence) {
+			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
+		}
+		const pendingRegeneration = { name: regeneration.name, stacks: regeneration.stacks.calculate(user) };
+		if (user.crit) {
+			pendingRegeneration.stacks += critBonus;
+		}
 		addProtection([target], protection.calculate(user));
-		return base.effect([target], user, adventure, { extraResultLines: `${target.name} gains protection.` });
+		const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration)).concat(`${target.name} gains protection.`);
+		const ownerIndex = adventure.getCombatantIndex(target);
+		const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
+		if (owner.pet?.type) {
+			const petMoveTemplate = getPetMove(owner.pet, 0);
+			const petRNs = { delverIndex: ownerIndex, moveIndex: 0, targetReferences: [], extras: [] };
+			petMoveTemplate.rnConfig.forEach(rnType => {
+				switch (rnType) {
+					case "enemyIndex":
+						const livingEnemyIndices = [];
+						for (let i = 0; i < adventure.room.enemies.length; i++) {
+							if (adventure.room.enemies[i].hp > 0) {
+								livingEnemyIndices.push(i);
+							}
+						}
+						petRNs.targetReferences.push(new CombatantReference(owner.team === "delver" ? "enemy" : "delver", livingEnemyIndices[adventure.generateRandomNumber(livingEnemyIndices.length, "battle")]));
+						break;
+					default:
+						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
+				}
+			})
+			resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		}
+		return resultLines;
 	}, { type: "single", team: "ally" })
 	.setSidegrades("Balanced Carrot")
 	.setCooldown(1)

--- a/source/gear/forbiddenknowledge-enticing.js
+++ b/source/gear/forbiddenknowledge-enticing.js
@@ -1,5 +1,5 @@
 const { GearTemplate, CombatantReference } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
+const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
 const { changeStagger } = require('../util/combatantUtil');
 
@@ -56,7 +56,7 @@ module.exports = new GearTemplate("Enticing Forbidden Knowledge",
 						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 				}
 			})
-			resultLines.push(`${target.name}'s ${owner.pet} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));
+			resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 		}
 		return resultLines;
 	}, { type: "single", team: "ally" })

--- a/source/gear/herbbasket-base.js
+++ b/source/gear/herbbasket-base.js
@@ -1,4 +1,5 @@
 const { GearTemplate } = require('../classes');
+const { SAFE_DELIMITER } = require('../constants');
 const { rollableHerbs } = require('../shared/herbs');
 const { listifyEN } = require('../util/textUtil');
 
@@ -16,7 +17,7 @@ module.exports = new GearTemplate("Herb Basket",
 		if (user.crit) {
 			pendingHerbCount *= critBonus;
 		}
-		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
+		const randomHerb = rollableHerbs[user.roundRns[`${module.exports.name}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
 		adventure.room.addResource(randomHerb, "Item", "loot", pendingHerbCount);
 		if (user.crit) {
 			return [`${user.name} gathers a double-batch of ${randomHerb}.`];

--- a/source/gear/herbbasket-enticing.js
+++ b/source/gear/herbbasket-enticing.js
@@ -1,5 +1,5 @@
 const { GearTemplate, CombatantReference } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
+const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
 const { rollableHerbs } = require('../shared/herbs');
 const { changeStagger } = require('../util/combatantUtil');
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Enticing Herb Basket",
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
-		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
+		const randomHerb = rollableHerbs[user.roundRns[`${module.exports.name}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
 		const resultLines = [];
 		if (user.crit) {
 			adventure.room.addResource(randomHerb, "Item", "loot", herbCount * critBonus);
@@ -47,7 +47,7 @@ module.exports = new GearTemplate("Enticing Herb Basket",
 						petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 				}
 			})
-			resultLines.push(`${target.name}'s ${owner.pet} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, petRNs));
+			resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 		}
 		return resultLines;
 	}, { type: "single", team: "ally" })

--- a/source/gear/herbbasket-guarding.js
+++ b/source/gear/herbbasket-guarding.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
+const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
 const { rollableHerbs } = require('../shared/herbs');
 const { changeStagger, addProtection } = require('../util/combatantUtil');
 const { listifyEN, joinAsStatement } = require('../util/textUtil');
@@ -18,7 +18,7 @@ module.exports = new GearTemplate("Guarding Herb Basket",
 		if (user.essence === essence) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 		}
-		const randomHerb = rollableHerbs[user.roundRns[`${gearName}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
+		const randomHerb = rollableHerbs[user.roundRns[`${module.exports.name}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
 		const resultLines = [];
 		if (user.crit) {
 			adventure.room.addResource(randomHerb, "Item", "loot", herbCount * critBonus);

--- a/source/gear/lightningstaff-disenchanting.js
+++ b/source/gear/lightningstaff-disenchanting.js
@@ -27,7 +27,7 @@ module.exports = new GearTemplate("Disenchanting Lightning Staff",
 			const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 			if (targetBuffs.length > 0) {
 				for (let i = 0; i < buffRemovals; i++) {
-					const [selectedBuff] = targetBuffs.splice(user.roundRns(`${gearName}${SAFE_DELIMITER}buffs`), 1);
+					const [selectedBuff] = targetBuffs.splice(user.roundRns(`${module.exports.name}${SAFE_DELIMITER}buffs`), 1);
 					receipts.push(...removeModifier([target], { name: selectedBuff, stacks: "all" }));
 				}
 			}

--- a/source/gear/wavecrash-disenchanting.js
+++ b/source/gear/wavecrash-disenchanting.js
@@ -1,5 +1,5 @@
 const { GearTemplate } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
+const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
 const { addModifier, generateModifierResultLines, dealDamage, changeStagger, removeModifier, combineModifierReceipts } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
@@ -21,7 +21,7 @@ module.exports = new GearTemplate("Disenchanting Wave Crash",
 		const targetBuffs = Object.keys(targets[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 		if (targetBuffs.length > 0) {
 			for (let i = 0; i < pendingBuffRemovals; i++) {
-				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${gearName}${SAFE_DELIMITER}buffs`), 1);
+				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${module.exports.name}${SAFE_DELIMITER}buffs`), 1);
 				receipts.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
 			}
 		}

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -818,7 +818,7 @@ function resolveMove(move, adventure) {
 					results.push(`${listifyEN(deadTargets.map(target => target.name), false)} ${deadTargets.length === 1 ? "was" : "were"} already dead!`);
 				}
 
-				results.push(...effect(livingTargets, user, adventure, adventure.petRNs));
+				results.push(...effect(livingTargets, user, adventure, { petRNs: adventure.petRNs }));
 			} else {
 				shouldDoGearUpkeep = false;
 				if (move.targets.length === 1) {

--- a/source/pets/friendlyslime.js
+++ b/source/pets/friendlyslime.js
@@ -9,14 +9,14 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 		[
 			new PetMoveTemplate("Toxin Spray", "Inflict @{mod0Stacks} @{mod0} on a random foe",
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const thisMove = module.exports.moves[0][0];
 					return generateModifierResultLines(addModifier(targets, thisMove.modifiers[0]));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Poison", stacks: 2 }),
 			new PetMoveTemplate("Sticky Toxin Spray", "Inflict @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} on a random foe",
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const thisMove = module.exports.moves[0][1];
 					const receipts = addModifier(targets, thisMove.modifiers[0]);
 					receipts.push(...addModifier(targets, thisMove.modifiers[1]))
@@ -26,7 +26,7 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 		],
 		[
 			new PetMoveTemplate("Amateur Alchemy", "Add a random Potion to loot 1/5 of the time", (owner, petRNs) => [],
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const [success, potionIndex] = petRNs.extras;
 					if (success === 0) {
 						const rolledPotion = rollablePotions[potionIndex];
@@ -37,7 +37,7 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 					}
 				}).setRnConfig([6, rollablePotions.length]),
 			new PetMoveTemplate("Not-So-Amateur Alchemy", "Add a random Potion to loot 1/4 of the time", (owner, petRNs) => [],
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const [success, potionIndex] = petRNs.extras;
 					if (success === 0) {
 						const rolledPotion = rollablePotions[potionIndex];

--- a/source/pets/redtailedraptor.js
+++ b/source/pets/redtailedraptor.js
@@ -9,7 +9,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 		[
 			new PetMoveTemplate("Rake", `Deal 15 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[0][0];
 					const { resultLines } = dealDamage(targets, owner, 15, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
@@ -17,7 +17,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				.setModifiers({ name: "Swiftness", stacks: 2 }),
 			new PetMoveTemplate("Secret Maneuver: Rake of the Heavens", `Deal 25 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[0][1];
 					const { resultLines } = dealDamage(targets, owner, 25, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
@@ -27,7 +27,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 		[
 			new PetMoveTemplate("Rake", `Deal 15 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[1][0];
 					const { resultLines } = dealDamage(targets, owner, 15, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
@@ -35,7 +35,7 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				.setModifiers({ name: "Swiftness", stacks: 2 }),
 			new PetMoveTemplate("World-Cleaving Rake: The Forbidden Technique", `Deal 25 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[1][1];
 					const { resultLines } = dealDamage(targets, owner, 25, false, "Wind", adventure);
 					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));

--- a/source/pets/shieldgoblin.js
+++ b/source/pets/shieldgoblin.js
@@ -8,12 +8,12 @@ module.exports = new PetTemplate(petName, Colors.Green,
 	[
 		[
 			new PetMoveTemplate("Prospect", "Find a random amount between 0-5g for the party", (owner, petRNs) => [],
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					adventure.gainGold(petRNs.extras[0]);
 					return [`${owner.name}'s Shield Goblin finds ${petRNs.extras[0]}g for the party.`];
 				}).setRnConfig([11]),
 			new PetMoveTemplate("Prospect+", "Find a random amount between 0-10g for the party", (owner, petRNs) => [],
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					adventure.gainGold(petRNs.extras[0]);
 					return [`${owner.name}'s Shield Goblin finds ${petRNs.extras[0]}g for the party.`];
 				}).setRnConfig([21])
@@ -21,12 +21,12 @@ module.exports = new PetTemplate(petName, Colors.Green,
 		[
 			new PetMoveTemplate("Shield Tackle", `Deal owner's protection in ${getEmoji("Earth")} damage to a random foe`,
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).resultLines;
 				}).setRnConfig(["enemyIndex"]),
 			new PetMoveTemplate("Shield Avalanche", `Deal owner's protection in ${getEmoji("Earth")} damage and 1 Stagger to a random foe`,
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					changeStagger(targets, null, 1);
 					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).resultLines;
 				}).setRnConfig(["enemyIndex"])

--- a/source/pets/shinystone.js
+++ b/source/pets/shinystone.js
@@ -9,14 +9,14 @@ module.exports = new PetTemplate(petName, Colors.LightGrey,
 		[
 			new PetMoveTemplate("Eye-Catcher", "Inflict a random foe with @{mod0Stacks} @{mod0}",
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const [distraction] = module.exports.moves[0][0].modifiers;
 					return generateModifierResultLines(addModifier(targets, distraction));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Distraction", stacks: 2 }),
 			new PetMoveTemplate("Extra Eye-Catcher", "Inflict a random foe with @{mod0Stacks} @{mod0} and 1 Stagger",
 				(owner, petRNs) => petRNs.targetReferences,
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const [distraction] = module.exports.moves[0][1].modifiers;
 					return generateModifierResultLines(addModifier(targets, distraction)).concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));
 				}).setRnConfig(["enemyIndex"])
@@ -24,12 +24,12 @@ module.exports = new PetTemplate(petName, Colors.LightGrey,
 		],
 		[
 			new PetMoveTemplate("Sparkle", "Grant owner @{mod0Stacks} @{mod0}", (owner, petRNs) => [],
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const [oblivious] = module.exports.moves[1][0].modifiers;
 					return generateModifierResultLines(addModifier([owner], oblivious));
 				}).setModifiers({ name: "Oblivious", stacks: 1 }),
 			new PetMoveTemplate("Sparkle Brilliantly", "Grant owner @{mod0Stacks} @{mod0} and relieve 1 Stagger", (owner, petRNs) => [],
-				(targets, owner, adventure, petRNs) => {
+				(targets, owner, adventure, { petRNs }) => {
 					const [oblivious] = module.exports.moves[1][1].modifiers;
 					const resultLines = generateModifierResultLines(addModifier([owner], oblivious));
 					if (owner.stagger > 0) {


### PR DESCRIPTION
Summary
-------
I want to have extra clobberable parameters for moves, so that we can do inheritance for base => upgrade (see carrot and its variants in this PR). I'm generalizing that extra cloberrable parameter as "overrides", an optional  (dict) object that effectively hosts named parameters

Currently petRNs are _already_ being passed as a mysterious 4th move parameter 🤣
Therefore I want to refactor this to generalize the current usage of the petRNs

Also I kept bumping into small errors so I propagated fixes to them 
- "gearname" was undefined in baskets and disenchanting gears
- stella apparently had a move that crashed.... maybe we killed her too soon, too often
- favorite archetype/pet weren't setting for me through command
- 
Local Tests Performed
---------------------
- [ x ] bot still turns on (no BuildErrors or circular dependencies)
- [ x ] tested each individual item to make sure they at least resolve
- [ x ] tested setting fave pet/archetype commands 

Issue
-----
(none) 