### PR TITLE
fix "always floof" game design short circuit in Let Sleeping Dogs Lie

### DIFF
--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -11,11 +11,12 @@ for (const file of [
 	"challenges.js",
 	"clearstartingchallenges.js",
 	"collectartifact.js",
+	"comet-flooffur.js",
+	"comet-stealsword.js",
 	"deploy.js",
 	"deploypet.js",
 	"essenceresearch.js",
 	"eventartifact.js",
-	"floofcometfur.js",
 	"gearcapup.js",
 	"getgoldonfire.js",
 	"greed.js",
@@ -38,7 +39,6 @@ for (const file of [
 	"stealwishingwellcore.js",
 	"switchpet.js",
 	"switchspecialization.js",
-	"takeswordfromcomet.js",
 	"trainingdummy.js",
 	"upgrade.js"
 ]) {

--- a/source/buttons/comet-flooffur.js
+++ b/source/buttons/comet-flooffur.js
@@ -3,7 +3,7 @@ const { ButtonWrapper } = require('../classes');
 const { setAdventure, getAdventure } = require('../orcustrators/adventureOrcustrator');
 const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
-const { RN_TABLE_BASE } = require('../constants');
+const { RN_TABLE_BASE, ZERO_WIDTH_WHITESPACE } = require('../constants');
 
 const mainId = "floofcometfur";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -15,6 +15,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			interaction.reply({ content: "This adventure isn't active or you aren't participating in it.", flags: [MessageFlags.Ephemeral] });
 			return;
 		}
+		if (adventure.room.history["Awoke Comet"].length > 0) {
+			interaction.update({ content: ZERO_WIDTH_WHITESPACE });
+			return;
+		}
+
 		adventure.room.history["Floofed fur"].push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
 			let msg = "How therapeutic, " + gainHealth(delver, 120, adventure)

--- a/source/buttons/comet-flooffur.js
+++ b/source/buttons/comet-flooffur.js
@@ -7,8 +7,8 @@ const { RN_TABLE_BASE } = require('../constants');
 
 const mainId = "floofcometfur";
 module.exports = new ButtonWrapper(mainId, 3000,
-	/** Restore 120 hp to the user (fixed so it's good early but meh later), with chance to fight. Does not take sword, but sword should be available as loot*/
-	(interaction, args) => {
+	/** Restore 120 hp to the user (fixed so it's good early but meh later), with chance to fight. Does not take sword to be exclusive with Steal Sword option */
+	(interaction, [wakePercent]) => {
 		const adventure = getAdventure(interaction.channelId);
 		const delver = adventure?.delvers.find(delver => delver.id === interaction.user.id);
 		if (!delver) {
@@ -18,13 +18,13 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		adventure.room.history["Floofed fur"].push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
 			let msg = "How therapeutic, " + gainHealth(delver, 120, adventure)
-			// 40% chance fight
-			if (adventure.generateRandomNumber(RN_TABLE_BASE, "general") < (RN_TABLE_BASE * 0.4)) {
+			// base 40% chance fight
+			if (adventure.generateRandomNumber(RN_TABLE_BASE, "general") < (RN_TABLE_BASE * (parseInt(wakePercent) / 100))) {
 				adventure.room.history["Awoke Comet"].push(interaction.member.displayName);
 				msg += " but Comet wakes!"
 				interaction.message.edit(renderRoom(adventure, interaction.channel, `Comet has awoken! :anger::wolf:`));
 			} else {
-				msg += " Comet remains asleep"
+				msg += " Comet remains asleep..."
 				interaction.message.edit(renderRoom(adventure, interaction.channel))
 			}
 			interaction.channel.send({ content: msg });

--- a/source/buttons/comet-stealsword.js
+++ b/source/buttons/comet-stealsword.js
@@ -1,5 +1,4 @@
 const { ButtonWrapper } = require('../classes');
-const { RN_TABLE_BASE } = require('../constants');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags, DiscordjsErrorCodes } = require('discord.js');
 const { getAdventure, setAdventure } = require('../orcustrators/adventureOrcustrator');
 const { buildGearRecord, getGearProperty, buildGearDescription } = require('../gear/_gearDictionary');
@@ -9,7 +8,7 @@ const { getColor, getEmoji } = require('../util/essenceUtil');
 
 const mainId = "takeswordfromcomet";
 module.exports = new ButtonWrapper(mainId, 3000,
-	/** Taking sword results in fight 75% of the time */
+	/** Take a Sword of the Sun, but start a fight with Comet */
 	(interaction, args) => {
 		const adventure = getAdventure(interaction.channelId);
 		const delver = adventure?.delvers.find(delver => delver.id === interaction.user.id);
@@ -26,10 +25,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();
-		let charges = getGearProperty(name, "maxCharges");
 		const embed = new EmbedBuilder().setColor(getColor(adventure.room.essence))
 			.setAuthor(randomAuthorTip())
-			.setTitle("Take this gear?")
+			.setTitle("Steal this sword and wake Comet?")
 			.addFields({ name: `${name} ${getEmoji(getGearProperty(name, "essence"))}`, value: buildGearDescription(name) });
 		const components = [];
 		if (hasFreeGearSlots) {
@@ -79,9 +77,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				adventure.room.decrementResource(name, 1);
 				adventure.room.history["Awoke Comet"].push(interaction.member.displayName);
 				interaction.message.edit(renderRoom(adventure, interaction.channel, `Comet has awoken! :anger::wolf:`));
-				interaction.channel.send(`${interaction.member.displayName} takes the Sword of the Sun, and Comet wakes!`)
+				interaction.channel.send(`${interaction.member.displayName} takes the Sword of the Sun${discardedName ? ` (${discardedName} discarded)` : ""}, and Comet wakes!`)
 				setAdventure(adventure);
-
 				return collectedInteraction;
 			}
 		}).then(interactionToAcknowledge => {

--- a/source/rooms/event-letsleepingdogslie.js
+++ b/source/rooms/event-letsleepingdogslie.js
@@ -1,9 +1,9 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { RoomTemplate } = require("../classes");
 const { generateRoutingRow, pathVoteField } = require("../util/messageComponentUtil");
-const { rollArtifact } = require("../artifacts/_artifactDictionary");
 const { generateCombatRoomBuilder } = require("../util/messageComponentUtil");
 const { parseExpression } = require("../util/mathUtil");
+const { SAFE_DELIMITER } = require("../constants");
 
 const enemies = [["Comet the Sun Dog", "1"], ["Gust Wolf", "1*n"], ["Unkind Corvus", "1"]];
 
@@ -23,7 +23,7 @@ module.exports = new RoomTemplate("Let Sleeping Dogs Lie",
 		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
 		const goldCount = Math.ceil(parseExpression(`${enemies[0][1]}*35`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
 		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
-		adventure.room.addResource("Sword of the Sun", "Gear", "loot", 1);
+		adventure.room.addResource("Sword of the Sun", "Gear", "internal", 1);
 		return [];
 	},
 	function (roomEmbed, adventure) {
@@ -31,6 +31,7 @@ module.exports = new RoomTemplate("Let Sleeping Dogs Lie",
 			return generateCombatRoomBuilder([])(roomEmbed, adventure)
 		}
 		else {
+			const floofFailChance = 40;
 			return {
 				embeds: [roomEmbed.addFields(pathVoteField)],
 				components: [
@@ -38,13 +39,11 @@ module.exports = new RoomTemplate("Let Sleeping Dogs Lie",
 						new ButtonBuilder().setCustomId("takeswordfromcomet")
 							.setStyle(ButtonStyle.Danger)
 							.setLabel("Take sword [wake 100%]")
-							.setDisabled(adventure.room.history["Took sword"].length > 0)
-					),
-					// Does not take sword if fight starts, but sword should be available as loot
-					new ActionRowBuilder().addComponents(
-						new ButtonBuilder().setCustomId(`floofcometfur`)
+							.setDisabled(adventure.room.history["Took sword"].length > 0),
+						// Does not take sword if fight starts, but sword should be available as loot
+						new ButtonBuilder().setCustomId(`floofcometfur${SAFE_DELIMITER}${floofFailChance}`)
 							.setStyle(ButtonStyle.Danger)
-							.setLabel("Floof fur [wake 40%]")
+							.setLabel(`Floof fur [wake ${floofFailChance}%]`)
 					),
 					generateRoutingRow(adventure)
 				]

--- a/source/rooms/event-letsleepingdogslie.js
+++ b/source/rooms/event-letsleepingdogslie.js
@@ -23,7 +23,7 @@ module.exports = new RoomTemplate("Let Sleeping Dogs Lie",
 		adventure.room.addResource("levelsGained", "levelsGained", "internal", 1);
 		const goldCount = Math.ceil(parseExpression(`${enemies[0][1]}*35`, adventure.delvers.length) * (90 + adventure.generateRandomNumber(21, "general")) / 100);
 		adventure.room.addResource("Gold", "Currency", "loot", goldCount);
-		adventure.room.addResource("Sword of the Sun", "Gear", "internal", 1);
+		adventure.room.addResource("Sword of the Sun", "Gear", "loot", 1);
 		return [];
 	},
 	function (roomEmbed, adventure) {


### PR DESCRIPTION
Summary
-------
- ~~removed Sword of the Sun from loot after fighting Comet~~
   - ~~when the Sword of the Sun dropped after combat, if the party wanted the Sword, they should floof until Comet wakes as a chance for healing before the inevitible fight is better~~
- grouped filenames of Comet's buttons
- extracted wake percent of floof option into argument to make implementing a challenge that makes events more punishing easier
- removed unused imports and code
- moved floof and steal butons to same action row
- updated game text
- updated documentation
- added check to make sure Comet isn't awake before proceeding with floofening

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] stealing Sword of the Sun resolves without crashing
- [x] floofing Comet resolves without crashing