### PR TITLE
#581: fix taking gear blanking last round battle results

### DIFF
--- a/source/selects/loot.js
+++ b/source/selects/loot.js
@@ -99,7 +99,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 							delver.hp = delver.getMaxHP();
 						}
 						adventure.room.decrementResource(name, 1);
-						interaction.message.edit(renderRoom(adventure, collectedInteraction.channel)).then(() => {
+						interaction.message.edit(renderRoom(adventure, collectedInteraction.channel, interaction.message.embeds[0].description)).then(() => {
 							collectedInteraction.channel.send({ content: `${interaction.member.displayName} takes a ${name}${discardedName ? ` (${discardedName} discarded)` : ""}. There are ${count - 1} remaining.` });
 							setAdventure(adventure);
 						})

--- a/source/selects/treasure.js
+++ b/source/selects/treasure.js
@@ -37,7 +37,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 				adventure.room.actions--;
 				adventure.room.history["Treasure picked"].push(name);
 				setAdventure(adventure);
-				interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				interaction.update(renderRoom(adventure, interaction.channel));
 				break;
 			case "Artifact":
 				adventure.gainArtifact(name, count);
@@ -45,7 +45,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 				adventure.room.actions--;
 				adventure.room.history["Treasure picked"].push(name);
 				setAdventure(adventure);
-				interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				interaction.update(renderRoom(adventure, interaction.channel));
 				break;
 			case "Item":
 				adventure.gainItem(name, count);
@@ -53,7 +53,7 @@ module.exports = new SelectWrapper(mainId, 2000,
 				adventure.room.actions--;
 				adventure.room.history["Treasure picked"].push(name);
 				setAdventure(adventure);
-				interaction.update(renderRoom(adventure, interaction.channel, interaction.message.embeds[0].description));
+				interaction.update(renderRoom(adventure, interaction.channel));
 				break;
 			case "Gear":
 				const hasFreeGearSlots = delver.gear.length < adventure.getGearCapacity();


### PR DESCRIPTION
Summary
-------
- fix taking gear blanking last round battle results
- skip unnedded overriding in loot acquisition

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] taking gear as loot preserves last round of combat results

Issue
-----
Closes #581