### PR TITLE
#605: make new targetingTag for Opportunist's and Rallying variants

### DIFF
--- a/source/buttons/readymove.js
+++ b/source/buttons/readymove.js
@@ -62,7 +62,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			if (targetingTags) {
 				const { type, team } = targetingTags;
 				const essenceEmoji = getEmoji(getGearProperty(gearName, "essence"));
-				if (type === "single" || type.startsWith("blast")) {
+				if (type.startsWith("single") || type.startsWith("blast")) {
 					// Select Menu
 					let targetOptions = [];
 					if (team === "foe" || team === "any") {

--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -36,7 +36,7 @@ class GearTemplate {
 	// Internal Configuration
 	/** @type {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: Partial<MoveEffectOverrides>) => string[]} */
 	effect;
-	/** @type {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} */
+	/** @type {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x" | "single→x", team: "ally" | "foe" | "any" | "none"}} */
 	targetingTags;
 	/** @type {string[]} */
 	upgrades = [];
@@ -67,7 +67,7 @@ class GearTemplate {
 	/**
 	 * overrides is a dict *parameter* whose values can be defaulted, but can also be clobbered for polymorphism.
 	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: Partial<MoveEffectOverrides>) => string[]} effectFunction
-	 * @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x", team: "ally" | "foe" | "any" | "none"}} tagObject
+	 * @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x" | "single→x", team: "ally" | "foe" | "any" | "none"}} tagObject
 	 */
 	setEffect(effectFunction, tagObject) {
 		this.effect = effectFunction;

--- a/source/gear/elemental-scroll.js
+++ b/source/gear/elemental-scroll.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, concatTeamMembersWithModifier, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
+const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
 
 //#region Base
 const elementalScroll = new GearTemplate("Elemental Scroll",
@@ -11,23 +11,22 @@ const elementalScroll = new GearTemplate("Elemental Scroll",
 	"Support",
 	"Fire"
 ).setCost(200)
-	.setEffect(elementalScrollEffect, { type: "single", team: "ally" })
+	.setEffect(elementalScrollEffect, { type: `single${SAFE_DELIMITER}Vigilance`, team: "ally" })
 	.setCooldown(1)
 	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Vigilance", stacks: 0 })
 	.setScalings({ critBonus: 2 });
 
 /** @type {typeof elementalScroll.effect} */
 function elementalScrollEffect(targets, user, adventure) {
-	const { essence, modifiers: [attunement, vigilance], scalings: { critBonus } } = elementalScroll;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.delvers : adventure.room.enemies, vigilance.name);
+	const { essence, modifiers: [attunement], scalings: { critBonus } } = elementalScroll;
 	if (user.essence === essence) {
-		changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_ALLY);
+		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
 	const pendingAttunement = { ...attunement };
 	if (user.crit) {
 		pendingAttunement.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(allTargets, pendingAttunement)));
+	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingAttunement)));
 }
 //#endregion Base
 
@@ -40,23 +39,22 @@ const balancedElementalScroll = new GearTemplate("Balanced Elemental Scroll",
 	"Support",
 	"Fire"
 ).setCost(350)
-	.setEffect(balancedElementalScrollEffect, { type: "single", team: "ally" })
+	.setEffect(balancedElementalScrollEffect, { type: `single${SAFE_DELIMITER}Vigilance`, team: "ally" })
 	.setCooldown(1)
 	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Vigilance", stacks: 0 }, { name: "Finesse", stacks: 1 })
 	.setScalings({ critBonus: 2 });
 
 /** @type {typeof balancedElementalScroll.effect} */
 function balancedElementalScrollEffect(targets, user, adventure) {
-	const { essence, modifiers: [attunement, vigilance, finesse], scalings: { critBonus } } = balancedElementalScroll;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.delvers : adventure.room.enemies, vigilance.name);
+	const { essence, modifiers: [attunement, targetModifier, finesse], scalings: { critBonus } } = balancedElementalScroll;
 	if (user.essence === essence) {
-		changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_ALLY);
+		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
 	const pendingAttunement = { ...attunement };
 	if (user.crit) {
 		pendingAttunement.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(allTargets, pendingAttunement).concat(addModifier(allTargets, finesse))));
+	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingAttunement).concat(addModifier(targets, finesse))));
 }
 //#endregion Balanced
 
@@ -69,23 +67,22 @@ const surpassingElementalScroll = new GearTemplate("Surpassing Elemental Scroll"
 	"Support",
 	"Fire"
 ).setCost(350)
-	.setEffect(surpassingElementalScrollEffect, { type: "single", team: "ally" })
+	.setEffect(surpassingElementalScrollEffect, { type: `single${SAFE_DELIMITER}Vigilance`, team: "ally" })
 	.setCooldown(1)
 	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Vigilance", stacks: 0 }, { name: "Excellence", stacks: 2 })
 	.setScalings({ critBonus: 2 });
 
 /** @type {typeof surpassingElementalScroll.effect} */
 function surpassingElementalScrollEffect(targets, user, adventure) {
-	const { essence, modifiers: [attunement, vigilance, excellence], scalings: { critBonus } } = surpassingElementalScroll;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.delvers : adventure.room.enemies, vigilance.name);
+	const { essence, modifiers: [attunement, targetModifier, excellence], scalings: { critBonus } } = surpassingElementalScroll;
 	if (user.essence === essence) {
-		changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_ALLY);
+		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
 	const pendingAttunement = { ...attunement };
 	if (user.crit) {
 		pendingAttunement.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(allTargets, pendingAttunement).concat(addModifier(allTargets, excellence))));
+	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingAttunement).concat(addModifier(targets, excellence))));
 }
 //#endregion Surpassing
 

--- a/source/gear/encouragement.js
+++ b/source/gear/encouragement.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier, concatTeamMembersWithModifier } = require('../util/combatantUtil');
+const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
+const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
 const { scalingExcellence, scalingEmpowerment } = require('./shared/modifiers');
 
 //#region Base
@@ -42,26 +42,10 @@ const rallyingEncouragement = new GearTemplate("Rallying Encouragement",
 	"Spell",
 	"Light"
 ).setCost(350)
-	.setEffect(rallyingEncouragementEffect, { type: "single", team: "ally" })
+	.setEffect(encouragementEffect, { type: `single${SAFE_DELIMITER}Vigilance`, team: "ally" })
 	.setCharges(15)
 	.setModifiers(scalingExcellence(2), scalingEmpowerment(25), { name: "Vigilance", stacks: 0 })
 	.setScalings({ critBonus: 2 });
-
-/** @type {typeof rallyingEncouragement.effect} */
-function rallyingEncouragementEffect(targets, user, adventure) {
-	const { essence, modifiers: [excellence, empowerment, targetModifier], scalings: { critBonus } } = rallyingEncouragement;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.delvers : adventure.room.enemies, targetModifier.name);
-	if (user.essence === essence) {
-		changeStagger(allTargets, user, ESSENCE_MATCH_STAGGER_ALLY);
-	}
-	const pendingExcellence = { name: excellence.name, stacks: excellence.stacks.calculate(user) };
-	const pendingEmpowerment = { name: empowerment.name, stacks: empowerment.stacks.calculate(user) };
-	if (user.crit) {
-		pendingExcellence.stacks *= critBonus;
-		pendingEmpowerment.stacks *= critBonus;
-	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(allTargets, pendingExcellence).concat(addModifier(allTargets, pendingEmpowerment))));
-}
 //#endregion Rallying
 
 //#region Vigorous

--- a/source/gear/overburn-explosion.js
+++ b/source/gear/overburn-explosion.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { concatTeamMembersWithModifier, changeStagger, dealDamage } = require('../util/combatantUtil');
+const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
+const { changeStagger, dealDamage } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 const { accuratePassive, unstoppablePassive } = require('./shared/passiveDescriptions');
 
@@ -13,7 +13,7 @@ const overburnExplosion = new GearTemplate("Overburn Explosion",
 	"Pact",
 	"Fire"
 ).setCost(200)
-	.setEffect(overburnExplosionEffect, { type: "single", team: "foe" })
+	.setEffect(overburnExplosionEffect, { type: `single${SAFE_DELIMITER}Distraction`, team: "foe" })
 	.setPactCost([2, "Set all your gears' cooldowns to @{pactCost}"])
 	.setModifiers({ name: "Distraction", stacks: 0 })
 	.setScalings({
@@ -23,13 +23,12 @@ const overburnExplosion = new GearTemplate("Overburn Explosion",
 
 /** @type {typeof overburnExplosion.effect} */
 function overburnExplosionEffect(targets, user, adventure) {
-	const { essence, modifiers: [targetModifier], scalings: { damage, critBonus }, pactCost } = overburnExplosion;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
+	const { essence, scalings: { damage, critBonus }, pactCost } = overburnExplosion;
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(allTargets, user, pendingDamage, false, essence, adventure);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -53,7 +52,7 @@ const accurateOverburnExplosion = new GearTemplate("Accurate Overburn Explosion"
 	"Pact",
 	"Fire"
 ).setCost(350)
-	.setEffect(overburnExplosionEffect, { type: "single", team: "foe" })
+	.setEffect(overburnExplosionEffect, { type: `single${SAFE_DELIMITER}Distraction`, team: "foe" })
 	.setPactCost([2, "Set all your gears' cooldowns to @{pactCost}"])
 	.setModifiers({ name: "Distraction", stacks: 0 })
 	.setScalings({
@@ -73,7 +72,7 @@ const unstoppableOverburnExplosion = new GearTemplate("Unstoppable Overburn Expl
 	"Pact",
 	"Fire"
 ).setCost(350)
-	.setEffect(unstoppableOverburnExplosionEffect, { type: "single", team: "foe" })
+	.setEffect(unstoppableOverburnExplosionEffect, { type: `single${SAFE_DELIMITER}Distraction`, team: "foe" })
 	.setPactCost([2, "Set all your gears' cooldowns to @{pactCost}"])
 	.setModifiers({ name: "Distraction", stacks: 0 })
 	.setScalings({
@@ -83,13 +82,12 @@ const unstoppableOverburnExplosion = new GearTemplate("Unstoppable Overburn Expl
 
 /** @type {typeof unstoppableOverburnExplosion.effect} */
 function unstoppableOverburnExplosionEffect(targets, user, adventure) {
-	const { essence, modifiers: [targetModifier], scalings: { damage, critBonus }, pactCost } = unstoppableOverburnExplosion;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
+	const { essence, scalings: { damage, critBonus }, pactCost } = unstoppableOverburnExplosion;
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(allTargets, user, pendingDamage, true, essence, adventure);
+	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, true, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}

--- a/source/gear/war-cry.js
+++ b/source/gear/war-cry.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
-const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, concatTeamMembersWithModifier, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
+const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 const { scalingExposure } = require('./shared/modifiers');
 
@@ -13,7 +13,7 @@ const warCry = new GearTemplate("War Cry",
 	"Support",
 	"Darkness"
 ).setCost(200)
-	.setEffect(warCryEffect, { type: "single", team: "foe" })
+	.setEffect(warCryEffect, { type: `single${SAFE_DELIMITER}Distraction`, team: "foe" })
 	.setCooldown(1)
 	.setModifiers({ name: "Distraction", stacks: 0 })
 	.setStagger(2)
@@ -21,9 +21,7 @@ const warCry = new GearTemplate("War Cry",
 
 /** @type {typeof warCry.effect} */
 function warCryEffect(targets, user, adventure) {
-	const { essence, stagger, scalings: { critBonus }, modifiers: [targetModifier] } = warCry;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-
+	const { essence, stagger, scalings: { critBonus } } = warCry;
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
@@ -31,8 +29,8 @@ function warCryEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingStagger *= critBonus;
 	}
-	changeStagger(allTargets, user, pendingStagger);
-	return [joinAsStatement(false, allTargets.map(target => target.name), "was", "were", "Staggered.")];
+	changeStagger(targets, user, pendingStagger);
+	return [joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered.")];
 }
 //#endregion Base
 
@@ -45,7 +43,7 @@ const flankingWarCry = new GearTemplate("Flanking War Cry",
 	"Support",
 	"Darkness",
 ).setCost(350)
-	.setEffect(flankingWarCryEffect, { type: "single", team: "foe" })
+	.setEffect(flankingWarCryEffect, { type: `single${SAFE_DELIMITER}Distraction`, team: "foe" })
 	.setCooldown(1)
 	.setModifiers({ name: "Distraction", stacks: 0 }, scalingExposure(2))
 	.setStagger(2)
@@ -54,8 +52,6 @@ const flankingWarCry = new GearTemplate("Flanking War Cry",
 /** @type {typeof flankingWarCry.effect} */
 function flankingWarCryEffect(targets, user, adventure) {
 	const { essence, stagger, scalings: { critBonus }, modifiers: [targetModifier, exposure] } = flankingWarCry;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
@@ -63,8 +59,8 @@ function flankingWarCryEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingStagger *= critBonus;
 	}
-	changeStagger(allTargets, user, pendingStagger);
-	return [joinAsStatement(false, allTargets.map(target => target.name), "was", "were", "Staggered.")].concat(generateModifierResultLines(combineModifierReceipts(addModifier(allTargets, { name: exposure.name, stacks: exposure.stacks.calculate(user) }))));
+	changeStagger(targets, user, pendingStagger);
+	return [joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered.")].concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: exposure.name, stacks: exposure.stacks.calculate(user) }))));
 }
 //#endregion Flanking
 
@@ -77,7 +73,7 @@ const weakeningWarCry = new GearTemplate("Weakening War Cry",
 	"Support",
 	"Darkness"
 ).setCost(350)
-	.setEffect(weakeningWarCryEffect, { type: "single", team: "foe" })
+	.setEffect(weakeningWarCryEffect, { type: `single${SAFE_DELIMITER}Distraction`, team: "foe" })
 	.setCooldown(1)
 	.setModifiers({ name: "Distraction", stacks: 0 }, { name: "Weakness", stacks: 10 })
 	.setStagger(2)
@@ -86,8 +82,6 @@ const weakeningWarCry = new GearTemplate("Weakening War Cry",
 /** @type {typeof weakeningWarCry.effect} */
 function weakeningWarCryEffect(targets, user, adventure) {
 	const { essence, stagger, scalings: { critBonus }, modifiers: [targetModifier, weakness] } = weakeningWarCry;
-	const allTargets = concatTeamMembersWithModifier(targets, user.team === "delver" ? adventure.room.enemies : adventure.delvers, targetModifier.name);
-
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
@@ -95,8 +89,8 @@ function weakeningWarCryEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingStagger *= critBonus;
 	}
-	changeStagger(allTargets, user, pendingStagger);
-	return [joinAsStatement(false, allTargets.map(target => target.name), "was", "were", "Staggered.")].concat(generateModifierResultLines(combineModifierReceipts(addModifier(allTargets, weakness))));
+	changeStagger(targets, user, pendingStagger);
+	return [joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered.")].concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, weakness))));
 }
 //#endregion Weakening
 

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -528,31 +528,30 @@ function predictRoundRnOutcomes(adventure) {
  * Given a move and delver BUT NOT THE TARGET for a random-concerned-move that depends on targets, return a predicted outcome.
  * @param {Adventure} adventure
  * @param {Combatant} user
- * @param {"foes" | "allies" | "essences" | string} targetingTags
- * @param {"foes" | "allies" | "essences" | string} moveName
+ * @param {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x" | "single→x", team: "ally" | "foe" | "any" | "none"}} targetingTags
+ * @param {string} moveName
  * @param {Record<string, number>} config
  */
 function predictRoundRnPossibleTargets(adventure, user, targetingTags, moveName, key) {
 	const liveEnemies = adventure.room.enemies.filter(e => e.hp > 0);
 	let targetCombatants = [];
 	let results = [];
-	switch (targetingTags.team) {
-		case "ally":
-			if (targetingTags.type === "self") {
-				targetCombatants = [user];
-			}
-			else {
+	if (targetingTags.type === "self") {
+		targetCombatants.push(user);
+	} else {
+		switch (targetingTags.team) {
+			case "ally":
 				targetCombatants = user.team === "delver" ? adventure.delvers : liveEnemies;
-			}
-			break;
-		case "foe":
-			targetCombatants = user.team !== "delver" ? adventure.delvers : liveEnemies;
-			break;
-		case "any":
-			targetCombatants = adventure.delvers.concat(liveEnemies);
-			break;
-		case "none":
-			break;
+				break;
+			case "foe":
+				targetCombatants = user.team !== "delver" ? adventure.delvers : liveEnemies;
+				break;
+			case "any":
+				targetCombatants = adventure.delvers.concat(liveEnemies);
+				break;
+			case "none":
+				break;
+		}
 	}
 	for (const targetCombatant of targetCombatants) {
 		const rnOutcome = predictRoundRnTargeted(adventure, user, targetCombatant, moveName, key);
@@ -760,6 +759,8 @@ function resolveMove(move, adventure) {
 			headline = `${ICON_CRITICAL}${headline}`;
 		}
 
+		let bonusTargetsModifier;
+		let bonusTargetTeam;
 		let effect;
 		switch (move.type) {
 			case "action":
@@ -776,6 +777,10 @@ function resolveMove(move, adventure) {
 				effect = getGearProperty(moveName, "effect");
 				headline += `used ${moveName}`;
 				const targetingTags = getGearProperty(moveName, "targetingTags");
+				if (targetingTags.type.startsWith(`single${SAFE_DELIMITER}`)) {
+					bonusTargetsModifier = targetingTags.type.split(SAFE_DELIMITER)[1];
+					bonusTargetTeam = targetingTags.team;
+				}
 				if (user.team === "delver") {
 					const loadedDiceCount = adventure.getArtifactCount("Loaded Dice");
 					if (loadedDiceCount > 0 && targetingTags.type.startsWith("random")) {
@@ -808,7 +813,23 @@ function resolveMove(move, adventure) {
 		if (move.targets.length > 0) {
 			const livingTargets = [];
 			const deadTargets = [];
-			move.targets.forEach(targetReference => {
+			let allTargets = move.targets;
+			if (bonusTargetsModifier) {
+				const targetSet = new Set();
+				for (const target of move.targets) {
+					if (target.hp > 0) {
+						targetSet.add(target.name);
+					}
+				}
+				for (const member of bonusTargetTeam === "delver" ? adventure.delvers : adventure.room.enemies) {
+					if (member.hp > 0 && member.getModifierStacks(bonusTargetsModifier) > 0 && !targetSet.has(member.name)) {
+						targetSet.add(member.name);
+						allTargets.push(member);
+					}
+				}
+			}
+
+			allTargets.forEach(targetReference => {
 				const target = adventure.getCombatant(targetReference);
 				if (target) {
 					if (target.hp > 0) {
@@ -949,7 +970,7 @@ function endRound(adventure, thread) {
 			const [gearName, gearIndex] = counterpartMove.name.split(SAFE_DELIMITER);
 			if (gearExists(gearName)) {
 				const targetingTags = getGearProperty(gearName, "targetingTags");
-				if (targetingTags.type === "single" || targetingTags.type.startsWith("blast")) {
+				if (targetingTags.type.startsWith("single") || targetingTags.type.startsWith("blast")) {
 					move.targets = counterpartMove.targets.map(target => {
 						return { team: target.team === "enemy" ? "delver" : "enemy", index: target.index };
 					})

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -424,6 +424,14 @@ function getCombatantCounters(combatant) {
 	return counters;
 }
 
+/**
+ * @param {"delver" | "enemy"} referenceTeam
+ * @param {"ally" | "foe"} relativeTeam
+ */
+function evaluateAbsoluteTeam(referenceTeam, relativeTeam) {
+	return relativeTeam === "ally" ^ referenceTeam === "delver" ? "enemy" : "delver";
+}
+
 module.exports = {
 	downedCheck,
 	dealDamage,
@@ -437,5 +445,6 @@ module.exports = {
 	changeStagger,
 	addProtection,
 	modifiersToString,
-	getCombatantCounters
+	getCombatantCounters,
+	evaluateAbsoluteTeam
 };

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -424,29 +424,6 @@ function getCombatantCounters(combatant) {
 	return counters;
 }
 
-/**
- * @param {Combatant[]} targets
- * @param {Combatant[]} team
- * @param {string} modifier
- */
-function concatTeamMembersWithModifier(targets, team, modifier) {
-	const targetSet = new Set();
-	const targetArray = [];
-	for (const target of targets) {
-		if (target.hp > 0) {
-			targetSet.add(target.name);
-			targetArray.push(target);
-		}
-	}
-	for (const member of team) {
-		if (member.hp > 0 && member.getModifierStacks(modifier) > 0 && !targetSet.has(member.name)) {
-			targetSet.add(member.name);
-			targetArray.push(member);
-		}
-	}
-	return targetArray;
-}
-
 module.exports = {
 	downedCheck,
 	dealDamage,
@@ -460,6 +437,5 @@ module.exports = {
 	changeStagger,
 	addProtection,
 	modifiersToString,
-	getCombatantCounters,
-	concatTeamMembersWithModifier
+	getCombatantCounters
 };


### PR DESCRIPTION
Summary
-------
- make new targetingTag for Opportunist's and Rallying variants

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)
- [x] Single target move works without regression
- [x] Overburn Explosion selects bonus targets
- [x] Overburn Explosion selects bonus targets even if original target is dead

Issue
-----
Closes #605