### PR TITLE
#617: update permissions for `PinMessages` splitting from `ManageMessages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A multiplayer rougelike dungeon crawl in Discord to play with other server members.
 
 ## Join Link
-[Click here](https://discord.com/api/oauth2/authorize?client_id=950469509628702740&permissions=397284665360&scope=bot%20applications.commands) to add Prophets of the Labyrinth to your server! The bot will be managable by anyone who has a role above the bot's roles, so make sure to check role order when the bot joins!
+[Click here](https://discord.com/oauth2/authorize?client_id=950469509628702740&permissions=2252162738612224&integration_type=0&scope=bot) to add Prophets of the Labyrinth to your server! The bot will be managable by anyone who has a role above the bot's roles, so make sure to check role order when the bot joins!
 
 ## Features and Gameplay
 Check out some of the unique features and gameplay for *Prophets of the Labyrinth*:

--- a/source/commands/support.js
+++ b/source/commands/support.js
@@ -13,7 +13,7 @@ module.exports = new CommandWrapper(mainId, "List ways to support PotL", null, f
 						.setThumbnail(`https://cdn.discordapp.com/attachments/545684759276421120/734202424960745545/love-mystery.png`)
 						.setDescription("Thanks for playing! Here are a few ways to support development:")
 						.addFields(
-							{ name: "Tell a Friend", value: "Use or send [this link](https://discord.com/api/oauth2/authorize?client_id=950469509628702740&permissions=397284665360&scope=bot%20applications.commands) to a friend to add PotL to a new Discord server!" },
+							{ name: "Tell a Friend", value: "Use or send [this link](https://discord.com/oauth2/authorize?client_id=950469509628702740&permissions=2252162738612224&integration_type=0&scope=bot) to a friend to add PotL to a new Discord server!" },
 							{ name: "Provide Feedback", value: "Use the `/feedback` command to submit bug reports, feature requests, or balance suggestions and get an invite to the Imaginary Horizons Productions test server." },
 							{ name: "Check out the GitHub", value: "Check out our [GitHub](https://github.com/Imaginary-Horizons-Productions) and tackle some issues or sponsor the project!" },
 						)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,7 +1,7 @@
 Welcome to the Prophets of the Labyrinth wiki!
 
 ## Links
-- [Bot Invite Link](https://discord.com/api/oauth2/authorize?client_id=950469509628702740&permissions=397284665360&scope=applications.commands%20bot)
+- [Bot Invite Link](https://discord.com/oauth2/authorize?client_id=950469509628702740&permissions=2252162738612224&integration_type=0&scope=bot)
 
 ## Writing Good Bug Reports and Feature Requests
 Coming soon!


### PR DESCRIPTION
Summary
-------
- updated bot invite links for permission set update with `PinMessages` splitting from `ManageMessages`
- checked for, but could not find, places where the bot was granting `ManageMessages`

Local Tests Performed
---------------------
- [x] no code changes

Issue
-----
Closes #617