### PR TITLE
#557 & #558: expand receipts to include more changes

### DIFF
--- a/source/buttons/comet-flooffur.js
+++ b/source/buttons/comet-flooffur.js
@@ -1,6 +1,6 @@
 const { MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
-const { setAdventure, getAdventure, receiptToResultLine } = require('../orcustrators/adventureOrcustrator');
+const { setAdventure, getAdventure, processResults } = require('../orcustrators/adventureOrcustrator');
 const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 const { RN_TABLE_BASE, ZERO_WIDTH_WHITESPACE } = require('../constants');
@@ -22,7 +22,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		adventure.room.history["Floofed fur"].push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
-			let msg = `How therapeutic, ${receiptToResultLine(gainHealth(delver, 120, adventure))}`;
+			let msg = `How therapeutic, ${processResults(gainHealth(delver, 120, adventure)).join(" ")}`;
 			// base 40% chance fight
 			if (adventure.generateRandomNumber(RN_TABLE_BASE, "general") < (RN_TABLE_BASE * (parseInt(wakePercent) / 100))) {
 				adventure.room.history["Awoke Comet"].push(interaction.member.displayName);

--- a/source/buttons/comet-flooffur.js
+++ b/source/buttons/comet-flooffur.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
-const { setAdventure, getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { gainHealth, receiptToResultLine } = require('../util/combatantUtil');
+const { setAdventure, getAdventure, receiptToResultLine } = require('../orcustrators/adventureOrcustrator');
+const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 const { RN_TABLE_BASE, ZERO_WIDTH_WHITESPACE } = require('../constants');
 

--- a/source/buttons/comet-flooffur.js
+++ b/source/buttons/comet-flooffur.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { setAdventure, getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { gainHealth } = require('../util/combatantUtil');
+const { gainHealth, receiptToResultLine } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 const { RN_TABLE_BASE, ZERO_WIDTH_WHITESPACE } = require('../constants');
 
@@ -22,7 +22,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		adventure.room.history["Floofed fur"].push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
-			let msg = "How therapeutic, " + gainHealth(delver, 120, adventure)
+			let msg = `How therapeutic, ${receiptToResultLine(gainHealth(delver, 120, adventure))}`;
 			// base 40% chance fight
 			if (adventure.generateRandomNumber(RN_TABLE_BASE, "general") < (RN_TABLE_BASE * (parseInt(wakePercent) / 100))) {
 				adventure.room.history["Awoke Comet"].push(interaction.member.displayName);

--- a/source/buttons/rest.js
+++ b/source/buttons/rest.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
-const { setAdventure, getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { gainHealth, receiptToResultLine } = require('../util/combatantUtil');
+const { setAdventure, getAdventure, receiptToResultLine } = require('../orcustrators/adventureOrcustrator');
+const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "rest";

--- a/source/buttons/rest.js
+++ b/source/buttons/rest.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { setAdventure, getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { gainHealth } = require('../util/combatantUtil');
+const { gainHealth, receiptToResultLine } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "rest";
@@ -24,7 +24,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		adventure.room.actions -= actionCost;
 		adventure.room.history.Rested.push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
-			interaction.followUp(gainHealth(delver, Math.ceil(delver.getMaxHP() * (parseInt(healPercent) / 100.0)), adventure));
+			interaction.followUp(receiptToResultLine(gainHealth(delver, Math.ceil(delver.getMaxHP() * (parseInt(healPercent) / 100.0)), adventure)));
 			setAdventure(adventure);
 		});
 	}

--- a/source/buttons/rest.js
+++ b/source/buttons/rest.js
@@ -1,6 +1,6 @@
 const { MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
-const { setAdventure, getAdventure, receiptToResultLine } = require('../orcustrators/adventureOrcustrator');
+const { setAdventure, getAdventure, processResults } = require('../orcustrators/adventureOrcustrator');
 const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 
@@ -24,7 +24,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		adventure.room.actions -= actionCost;
 		adventure.room.history.Rested.push(delver.name);
 		interaction.update(renderRoom(adventure, interaction.channel)).then(() => {
-			interaction.followUp(receiptToResultLine(gainHealth(delver, Math.ceil(delver.getMaxHP() * (parseInt(healPercent) / 100.0)), adventure)));
+			interaction.followUp(processResults(gainHealth(delver, Math.ceil(delver.getMaxHP() * (parseInt(healPercent) / 100.0)), adventure)).join(" "));
 			setAdventure(adventure);
 		});
 	}

--- a/source/classes/EnemyTemplate.js
+++ b/source/classes/EnemyTemplate.js
@@ -2,6 +2,7 @@ const { Adventure } = require("./Adventure");
 const { BuildError } = require("./BuildError");
 const { Combatant } = require("./Combatant");
 const { CombatantReference } = require("./Move");
+const { Receipt } = require("./Receipt");
 
 /** @typedef {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Unaligned"} Essence */
 
@@ -74,7 +75,7 @@ class EnemyTemplate {
 	 * @param {Essence | "@{adventure}" | "@{adventureOpposite}"} actionsInput.essence
 	 * @param {string} actionsInput.description
 	 * @param {number} actionsInput.priority
-	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => string[]} actionsInput.effect
+	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => (string | Receipt)[]} actionsInput.effect
 	 * @param {(self: Combatant, adventure: Adventure) => CombatantReference[]} actionsInput.selector
 	 * @param {string | (currentAction: string, adventure: Adventure) => string} actionsInput.next
 	 * @param {?string} actionsInput.combatFlavor

--- a/source/classes/GearTemplate.js
+++ b/source/classes/GearTemplate.js
@@ -1,6 +1,7 @@
 const { Adventure } = require("./Adventure");
 const { BuildError } = require("./BuildError");
 const { Combatant } = require("./Combatant");
+const { Receipt } = require("./Receipt");
 const { Scaling } = require("./Scaling");
 
 class GearFamily {
@@ -34,7 +35,7 @@ class GearTemplate {
 		this.essence = essenceEnum;
 	}
 	// Internal Configuration
-	/** @type {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: Partial<MoveEffectOverrides>) => string[]} */
+	/** @type {(targets: Combatant[], user: Combatant, adventure: Adventure, overrides: Partial<MoveEffectOverrides>) => (string | Receipt)[]} */
 	effect;
 	/** @type {{type: "single" | "all" | "random→x" | "self" | "none" | "blast→x" | "single→x", team: "ally" | "foe" | "any" | "none"}} */
 	targetingTags;

--- a/source/classes/ItemTemplate.js
+++ b/source/classes/ItemTemplate.js
@@ -1,6 +1,7 @@
 const { Adventure } = require("./Adventure");
 const { Combatant } = require("./Combatant");
 const { CombatantReference } = require("./Move");
+const { Receipt } = require("./Receipt");
 
 class ItemTemplate {
 	/**
@@ -9,7 +10,7 @@ class ItemTemplate {
 	 * @param {"Darkness" | "Earth" | "Fire" | "Light" | "Water" | "Wind" | "Unaligned"} essenceEnum
 	 * @param {number} costInput
 	 * @param {(self, adventure: Adventure) => CombatantReference[]} selectTargetsFunction
-	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => string[]} effectFunction
+	 * @param {(targets: Combatant[], user: Combatant, adventure: Adventure) => (string | Receipt)[]} effectFunction
 	 */
 	constructor(nameInput, descriptionInput, essenceEnum, costInput, selectTargetsFunction, effectFunction) {
 		this.name = nameInput;

--- a/source/classes/ModifierTemplate.js
+++ b/source/classes/ModifierTemplate.js
@@ -30,34 +30,6 @@ class ModifierTemplate {
 	}
 };
 
-class ModifierReceipt {
-	/**
-	 * @param {string} combatantNameInput
-	 * @param {"add" | "remove"} receiptType
-	 * @param {string[]} succeededEmojiArray
-	 */
-	constructor(combatantNameInput, receiptType, succeededEmojiArray) {
-		this.combatantNames = new Set([combatantNameInput]);
-		this.type = receiptType;
-		this.succeeded = new Set(succeededEmojiArray);
-	}
-
-	/** @param {ModifierReceipt} incomingReceipt */
-	combineCombatantNames(incomingReceipt) {
-		for (const name of incomingReceipt.combatantNames) {
-			this.combatantNames.add(name);
-		}
-	}
-
-	/** @param {ModifierReceipt} incomingReceipt */
-	combineModifierSets(incomingReceipt) {
-		for (const success of incomingReceipt.succeeded) {
-			this.succeeded.add(success);
-		}
-	}
-}
-
 module.exports = {
-	ModifierTemplate,
-	ModifierReceipt
+	ModifierTemplate
 };

--- a/source/classes/Receipt.js
+++ b/source/classes/Receipt.js
@@ -1,0 +1,136 @@
+const { areSetContentsCongruent } = require("../util/mathUtil");
+
+class Receipt {
+	/** A receipt is a runtime object representing either beneficial or harmful changes (damage or healing, modifiers, and/or stagger) to one or multiple (if changes match) combatants due to a single move
+	 * @param {string[]} combatantNamesArray
+	 * @param {"." | "!"} endPunctuation
+	 * @param {object} changes
+	 * @param {[string | null, number][]} changes.damagesArray
+	 * @param {number} changes.damageCapApplied
+	 * @param {number} changes.blockedDamage
+	 * @param {[number, string | null]} changes.healingsArray
+	 * @param {string[]} changes.addedModifierEmojiArray
+	 * @param {string[]} changes.removedModifierEmojiArray
+	 * @param {"add" | "remove" | null} changes.bonusStagger
+	 */
+	constructor(combatantNamesArray, endPunctuation, { damagesArray, damageCapApplied, blockedDamage, healingsArray, addedModifierEmojiArray, removedModifierEmojiArray, bonusStagger }) {
+		this.combatantNames = new Set(combatantNamesArray);
+		this.excitement = endPunctuation;
+		/** @type {Map<string | null, number>} key for damage essence or modifier emoji (`null` for Unaligned's special properities), value for magnitude */
+		this.damageMap = damagesArray ? new Map(damagesArray) : new Map();
+		this.damageCapApplied = damageCapApplied || null;
+		this.blockedDamage = blockedDamage || 0;
+		this.healingMap = healingsArray ? new Map(healingsArray) : new Map();
+		this.addedModifiers = addedModifierEmojiArray ? new Set(addedModifierEmojiArray) : new Set();
+		this.removedModifiers = removedModifierEmojiArray ? new Set(removedModifierEmojiArray) : new Set();
+		this.stagger = bonusStagger;
+	}
+
+	/** @param {Receipt} incomingReceipt */
+	combineCombatantNames(incomingReceipt) {
+		for (const name of incomingReceipt.combatantNames) {
+			this.combatantNames.add(name);
+		}
+	}
+
+	/** @param {Receipt} incomingReceipt */
+	combineChanges(incomingReceipt) {
+		// End Punctuation
+		if (this.excitement === "." && incomingReceipt.excitement === "!") {
+			this.excitement = "!";
+		}
+
+		// Damage
+		for (const [type, magnitude] of incomingReceipt.damageMap) {
+			if (type in this.damageMap) {
+				this.damageMap[type] += magnitude;
+			} else {
+				this.damageMap[type] = magnitude;
+			}
+		}
+
+		// Damage Cap Applied
+		if (incomingReceipt.damageCapApplied !== null) {
+			if (this.damageCapApplied !== null) {
+				this.damageCapApplied = Math.min(this.damageCapApplied, incomingReceipt.damageCapApplied);
+			} else {
+				this.damageCapApplied = incomingReceipt.damageCapApplied;
+			}
+		}
+
+		// Blocked Damage
+		this.blockedDamage += incomingReceipt.blockedDamage;
+
+		// Healing
+		for (const [source, magnitude] of incomingReceipt.healingMap) {
+			if (source in this.healingMap) {
+				this.healingMap[source] += magnitude;
+			} else {
+				this.healingMap[source] = magnitude;
+			}
+		}
+
+		// Modifiers
+		for (const modifier of incomingReceipt.addedModifiers) {
+			this.addedModifiers.add(modifier);
+		}
+		for (const modifier of incomingReceipt.removedModifiers) {
+			this.removedModifiers.add(modifier);
+		}
+
+		// Stagger
+		if (this.stagger === null && incomingReceipt.stagger !== null) {
+			this.stagger = incomingReceipt.stagger;
+		}
+	}
+
+	/**
+	 * @param {Receipt} receipt1
+	 * @param {Receipt} receipt2
+	 */
+	static congruenceCheck(receipt1, receipt2) {
+		// Excitement - fully derived from other changes, so no need to check
+
+		// Damage Cap Applied
+		if (receipt1.damageCapApplied !== receipt2.damageCapApplied) {
+			return false;
+		}
+
+		// Blocked Damage
+		if (receipt1.blockedDamage !== receipt2.blockedDamage) {
+			return false;
+		}
+
+		// Stagger
+		if (receipt1.stagger !== receipt2.stagger) {
+			return false;
+		}
+
+		// Damage
+		if (receipt1.damageMap.size !== receipt2.damageMap.size) {
+			return false;
+		}
+		for (const essence in receipt1.damageMap) {
+			if (!(essence in receipt2.damageMap)) {
+				return false;
+			}
+		}
+
+		// Healing
+		if (receipt1.healingMap.size !== receipt2.healingMap.size) {
+			return false;
+		}
+		for (const source in receipt1.healingMap) {
+			if (!(source in receipt2.healingMap)) {
+				return false;
+			}
+		}
+
+		// Modifiers
+		return areSetContentsCongruent(receipt1.addedModifiers, receipt2.addedModifiers) && areSetContentsCongruent(receipt1.removedModifiers, receipt2.removedModifiers);
+	}
+}
+
+module.exports = {
+	Receipt
+};

--- a/source/classes/Receipt.js
+++ b/source/classes/Receipt.js
@@ -23,7 +23,7 @@ class Receipt {
 		this.healingMap = healingsArray ? new Map(healingsArray) : new Map();
 		this.addedModifiers = addedModifierEmojiArray ? new Set(addedModifierEmojiArray) : new Set();
 		this.removedModifiers = removedModifierEmojiArray ? new Set(removedModifierEmojiArray) : new Set();
-		this.stagger = bonusStagger;
+		this.stagger = bonusStagger || null;
 	}
 
 	/** @param {Receipt} incomingReceipt */

--- a/source/classes/Receipt.js
+++ b/source/classes/Receipt.js
@@ -8,7 +8,7 @@ class Receipt {
 	 * @param {[string | null, number][]} changes.damagesArray
 	 * @param {number} changes.damageCapApplied
 	 * @param {number} changes.blockedDamage
-	 * @param {[number, string | null]} changes.healingsArray
+	 * @param {[string | null, number]} changes.healingsArray
 	 * @param {string[]} changes.addedModifierEmojiArray
 	 * @param {string[]} changes.removedModifierEmojiArray
 	 * @param {"add" | "remove" | null} changes.bonusStagger

--- a/source/classes/index.js
+++ b/source/classes/index.js
@@ -10,10 +10,11 @@ const { GearTemplate, GearFamily } = require("./GearTemplate");
 const { ButtonWrapper, CommandWrapper, SelectWrapper, ContextMenuWrapper, MessageContextMenuWrapper, UserContextMenuWrapper, SubcommandWrapper } = require("./InteractionWrapper");
 const { ItemTemplate } = require("./ItemTemplate");
 const { LabyrinthTemplate } = require("./LabyrinthTemplate");
-const { ModifierTemplate, ModifierReceipt } = require("./ModifierTemplate");
+const { ModifierTemplate } = require("./ModifierTemplate");
 const { CombatantReference, Move } = require("./Move");
 const { PetTemplate, PetMoveTemplate } = require("./PetTemplate");
 const { Player } = require("./Player");
+const { Receipt } = require("./Receipt");
 const { RoomTemplate } = require("./RoomTemplate");
 const { Scaling } = require("./Scaling");
 
@@ -41,11 +42,11 @@ module.exports = {
 	LabyrinthTemplate,
 	MessageContextMenuWrapper,
 	ModifierTemplate,
-	ModifierReceipt,
 	Move,
 	PetMoveTemplate,
 	PetTemplate,
 	Player,
+	Receipt,
 	Room,
 	RoomTemplate,
 	Scaling,

--- a/source/enemies/_enemy_blueprint.js
+++ b/source/enemies/_enemy_blueprint.js
@@ -14,7 +14,7 @@ module.exports = new EnemyTemplate("name",
 	description: "",
 	priority: 0,
 	effect: ([target], user, adventure) => {
-		return "";
+		return [];
 	},
 	selector: (self, adventure) => { // check shared/actionComponents for reusable selctors and next functions
 		return [];

--- a/source/enemies/asteroid.js
+++ b/source/enemies/asteroid.js
@@ -25,7 +25,7 @@ module.exports = new EnemyTemplate("Asteroid",
 				damage *= 2;
 			}
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-			return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(dealDamage([user], user, recoilDmg, true, "Unaligned", adventure).resultLines);
+			return dealDamage(targets, user, damage, false, user.essence, adventure).results.concat(dealDamage([user], user, recoilDmg, true, "Unaligned", adventure).results);
 		},
 		selector: selectRandomFoe,
 		next: "random"
@@ -41,7 +41,7 @@ module.exports = new EnemyTemplate("Asteroid",
 			}
 			user.hp = 0;
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-			return [...dealDamage(targets, user, damage, false, user.essence, adventure).resultLines, `${user.name} is downed.`];
+			return [...dealDamage(targets, user, damage, false, user.essence, adventure).results, `${user.name} is downed.`];
 		},
 		selector: selectAllOtherCombatants,
 		next: "random"

--- a/source/enemies/bloodtailhawk.js
+++ b/source/enemies/bloodtailhawk.js
@@ -23,7 +23,7 @@ module.exports = new EnemyTemplate("Bloodtail Hawk",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results;
 	},
 	selector: selectRandomFoe,
 	next: "Rake"

--- a/source/enemies/brute.js
+++ b/source/enemies/brute.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { SAFE_DELIMITER } = require("../constants");
 const { selectRandomFoe } = require("../shared/actionComponents");
-const { generateModifierResultLines, addModifier, changeStagger, dealDamage, removeModifier } = require("../util/combatantUtil");
+const { addModifier, changeStagger, dealDamage, removeModifier } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
 module.exports = new EnemyTemplate("Brute",
@@ -21,17 +21,16 @@ module.exports = new EnemyTemplate("Brute",
 		const markedTarget = adventure.delvers.find(delver => "The Target" in delver.modifiers);
 		if (!markedTarget) {
 			// Mark or Mug rolls on [0, 3] then adds 2 for the number of 'The Target' stacks it applies
-			return generateModifierResultLines(addModifier([target], { name: "The Target", stacks: user.roundRns[`Mug or Mark${SAFE_DELIMITER}Mug or Mark`][0] + 2 }));
+			return addModifier([target], { name: "The Target", stacks: user.roundRns[`Mug or Mark${SAFE_DELIMITER}Mug or Mark`][0] + 2 });
 		} else {
-			const resultLines = dealDamage([markedTarget], user, 70, false, "Unaligned", adventure).resultLines;
-			changeStagger([markedTarget], user, 3);
-			resultLines.push(`${markedTarget.name} is Staggered.`);
-			resultLines.push(...generateModifierResultLines(removeModifier([markedTarget], { name: "The Target", stacks: 1, force: true })));
+			const results = dealDamage([markedTarget], user, 70, false, "Unaligned", adventure).results;
+			results.push(...changeStagger([markedTarget], user, 3),
+				...removeModifier([markedTarget], { name: "The Target", stacks: 1, force: true }));
 			if (user.crit) {
 				adventure.gold -= 5;
-				resultLines.push(`5g suddenly goes missing from the party's coffers.`);
+				results.push(`5g suddenly goes missing from the party's coffers.`);
 			}
-			return resultLines;
+			return results;
 		}
 	},
 	selector: selectRandomFoe,

--- a/source/enemies/ck-gaiaknightess.js
+++ b/source/enemies/ck-gaiaknightess.js
@@ -1,10 +1,9 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, removeModifier, changeStagger, generateModifierResultLines, addProtection } = require("../util/combatantUtil.js");
+const { dealDamage, removeModifier, changeStagger, addProtection } = require("../util/combatantUtil.js");
 const { getModifierCategory } = require("../modifiers/_modifierDictionary.js");
 const { selectRandomFoe, selectNone, selectAllFoes } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/essenceUtil.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
-const { joinAsStatement } = require("../util/textUtil.js");
 
 const asteroid = require("./asteroid.js");
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require("../constants.js");
@@ -29,13 +28,13 @@ module.exports = new EnemyTemplate("Gaia Knightess",
 			resultLines.push(`${user.name} gains protection.`);
 		}
 		const damage = user.getPower() + 75;
-		const { resultLines: damageResults, survivors } = dealDamage(targets, user, damage, false, user.essence, adventure);
+		const { results: damageResults, survivors } = dealDamage(targets, user, damage, false, user.essence, adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		for (const target of survivors) {
 			const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 			if (targetBuffs.length > 0) {
 				const rolledBuff = targetBuffs[user.roundRns[`Damping Wallop${SAFE_DELIMITER}buffs`][0] % targetBuffs.length];
-				resultLines.push(...generateModifierResultLines(removeModifier([target], { name: rolledBuff, stacks: "all" })));
+				resultLines.push(...removeModifier([target], { name: rolledBuff, stacks: "all" }));
 			}
 		}
 		return damageResults.concat(resultLines);
@@ -55,10 +54,9 @@ module.exports = new EnemyTemplate("Gaia Knightess",
 			resultLines.push(`${user.name} gains protection.`);
 		}
 		const damage = user.getPower() + 25;
-		const { resultLines: damageResults, survivors } = dealDamage(targets, user, damage, false, user.essence, adventure);
+		const { results: damageResults, survivors } = dealDamage(targets, user, damage, false, user.essence, adventure);
 		if (survivors.length > 0) {
-			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE + 1);
-			resultLines.push(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
+			resultLines.push(...changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE + 1));
 		}
 		return damageResults.concat(resultLines);
 	},

--- a/source/enemies/ck-lunamilitissa.js
+++ b/source/enemies/ck-lunamilitissa.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require("../constants");
 const { selectRandomFoe, selectSelfAndRandomOtherAlly } = require("../shared/actionComponents");
-const { generateModifierResultLines, addModifier, changeStagger, dealDamage, addProtection } = require("../util/combatantUtil");
+const { addModifier, changeStagger, dealDamage, addProtection } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 const { joinAsStatement } = require("../util/textUtil");
 
@@ -41,7 +41,7 @@ module.exports = new EnemyTemplate("Luna Militissa",
 			resultLines.push(`${user.name} gains protection.`);
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return generateModifierResultLines(addModifier(targets, { name: "Frailty", stacks: 5 })).concat(resultLines);
+		return addModifier(targets, { name: "Frailty", stacks: 5 }).concat(resultLines);
 	},
 	selector: selectRandomFoe,
 	next: "Knighty Night Bash"
@@ -57,10 +57,9 @@ module.exports = new EnemyTemplate("Luna Militissa",
 			resultLines.push(`${user.name} gains protection.`);
 		}
 		const pendingDamage = 50 + user.getPower() + user.protection;
-		const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, "Darkness", adventure);
+		const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, "Darkness", adventure);
 		if (survivors.length > 0) {
-			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE + 2);
-			resultLines.push(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
+			resultLines.push(...changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE + 2));
 		}
 		return damageResults.concat(resultLines);
 	},

--- a/source/enemies/ck-meteorknight.js
+++ b/source/enemies/ck-meteorknight.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, changeStagger, addProtection, generateModifierResultLines, addModifier } = require("../util/combatantUtil.js");
+const { dealDamage, changeStagger, addProtection, addModifier } = require("../util/combatantUtil.js");
 const { selectRandomFoe, selectAllFoes } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/essenceUtil.js");
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require("../constants.js");
@@ -23,7 +23,7 @@ module.exports = new EnemyTemplate("Meteor Knight",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results;
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -35,13 +35,13 @@ module.exports = new EnemyTemplate("Meteor Knight",
 	effect: (targets, user, adventure) => {
 		const baseDamage = user.getPower() + 75;
 		const bonusDamage = 25
-		const resultLines = [];
+		const results = [];
 		for (const target of targets) {
 			const pendingDamage = (user.crit ? 2 : 1) * ((target.protection > 0 ? 0 : bonusDamage) + baseDamage);
-			resultLines.push(...dealDamage([target], user, pendingDamage, false, user.essence, adventure).resultLines);
+			results.push(...dealDamage([target], user, pendingDamage, false, user.essence, adventure).results);
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines;
+		return results;
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -52,13 +52,13 @@ module.exports = new EnemyTemplate("Meteor Knight",
 	priority: 0,
 	effect: (targets, user, adventure) => {
 		let pendingMisfortune = user.roundRns[`Meteor Mayhem${SAFE_DELIMITER}Meteor Mayhem`][0];
-		const { resultLines, survivors } = dealDamage(targets, user, user.getPower() + 5, false, "Fire", adventure);
+		const { results, survivors } = dealDamage(targets, user, user.getPower() + 5, false, "Fire", adventure);
 		if (user.crit) {
 			addProtection([user], 25);
-			resultLines.push(`${user.name} gains protection.`);
+			results.push(`${user.name} gains protection.`);
 		}
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: "Misfortune", stacks: pendingMisfortune })));
+		return results.concat(...addModifier(survivors, { name: "Misfortune", stacks: pendingMisfortune }));
 	},
 	selector: selectAllFoes,
 	next: "random",

--- a/source/enemies/ck-spacedustcadet.js
+++ b/source/enemies/ck-spacedustcadet.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require("../constants");
 const { selectRandomFoe, selectMultipleRandomFoes, selectAllAllies } = require("../shared/actionComponents");
-const { generateModifierResultLines, addModifier, changeStagger, addProtection, dealDamage, combineModifierReceipts } = require("../util/combatantUtil");
+const { addModifier, changeStagger, addProtection, dealDamage } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
 module.exports = new EnemyTemplate("Spacedust Cadet",
@@ -18,15 +18,15 @@ module.exports = new EnemyTemplate("Spacedust Cadet",
 	description: `Deal ${getEmoji("Wind")} damage to a foe, gain protection on Critical`,
 	priority: 0,
 	effect: (targets, user, adventure) => {
-		const resultLines = [];
+		const results = [];
 		if (user.crit) {
 			addProtection([user], 25);
-			resultLines.push(`${user.name} gains protection.`);
+			results.push(`${user.name} gains protection.`);
 		}
 		const pendingDamage = 50 + user.getPower();
-		const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, "Wind", adventure);
+		const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, "Wind", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return damageResults.concat(resultLines);
+		return damageResults.concat(results);
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -36,13 +36,13 @@ module.exports = new EnemyTemplate("Spacedust Cadet",
 	description: "Inflict @e{Exposure} on multiple random foes, gain protection on Critical",
 	priority: 0,
 	effect: (targets, user, adventure) => {
-		const resultLines = [];
+		const results = [];
 		if (user.crit) {
 			addProtection([user], 25);
-			resultLines.push(`${user.name} gains protection.`);
+			results.push(`${user.name} gains protection.`);
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Exposure", stacks: 2 }))).concat(resultLines);
+		return addModifier(targets, { name: "Exposure", stacks: 2 }).concat(results);
 	},
 	selector: selectMultipleRandomFoes(3),
 	next: "random"
@@ -58,7 +58,7 @@ module.exports = new EnemyTemplate("Spacedust Cadet",
 			resultLines.push(`${user.name} gains protection.`);
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
-		return generateModifierResultLines(addModifier(targets, { name: "Swiftness", stacks: 5 })).concat(resultLines);
+		return addModifier(targets, { name: "Swiftness", stacks: 5 }).concat(resultLines);
 	},
 	selector: selectAllAllies,
 	next: "random"

--- a/source/enemies/ck-starryknight.js
+++ b/source/enemies/ck-starryknight.js
@@ -2,7 +2,7 @@ const { bold } = require("discord.js");
 const { EnemyTemplate, Combatant, Adventure } = require("../classes");
 const { getModifierCategory } = require("../modifiers/_modifierDictionary");
 const { selectRandomFoe, selectAllFoes } = require("../shared/actionComponents");
-const { dealDamage, addModifier, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { dealDamage, addModifier, changeStagger, addProtection } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 const { ESSENCE_MATCH_STAGGER_FOE } = require("../constants");
 
@@ -42,9 +42,9 @@ module.exports = new EnemyTemplate("Starry Knight",
 			pendingDamage *= 2;
 		}
 		if (unfinishedChallenges.length > 0) {
-			return [`"Ha! You didn't finish ${bold(unfinishedChallenges[adventure.generateRandomNumber(unfinishedChallenges.length, "battle")])}."`, ...dealDamage([target], user, pendingDamage, false, "Light", adventure).resultLines];
+			return [`"Ha! You didn't finish ${bold(unfinishedChallenges[adventure.generateRandomNumber(unfinishedChallenges.length, "battle")])}."`, ...dealDamage([target], user, pendingDamage, false, "Light", adventure).results];
 		} else {
-			return dealDamage([target], user, pendingDamage, false, "Light", adventure).resultLines;
+			return dealDamage([target], user, pendingDamage, false, "Light", adventure).results;
 		}
 	},
 	selector: selectRandomFoe,
@@ -57,8 +57,8 @@ module.exports = new EnemyTemplate("Starry Knight",
 	effect: (targets, user, adventure) => {
 		let pendingDamage = user.getPower() + 50 * targets.length;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).resultLines
-			.concat(generateModifierResultLines(combineModifierReceipts(addNewRandomInsults(targets, user.crit ? 2 : 1, adventure))));
+		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).results
+			.concat(addNewRandomInsults(targets, user.crit ? 2 : 1, adventure));
 	},
 	selector: selectAllFoes,
 	next: "random",
@@ -73,8 +73,7 @@ module.exports = new EnemyTemplate("Starry Knight",
 		if (user.crit) {
 			addProtection([user], 100);
 		}
-		const receipts = addModifier(targets, { name: "Exposure", stacks: 1 }).concat(addNewRandomInsults(targets, 1, adventure));
-		return generateModifierResultLines(combineModifierReceipts(receipts));
+		return addModifier(targets, { name: "Exposure", stacks: 1 }).concat(addNewRandomInsults(targets, 1, adventure));
 	},
 	selector: selectAllFoes,
 	next: "random"
@@ -89,7 +88,7 @@ module.exports = new EnemyTemplate("Starry Knight",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Distraction", stacks: 4 })));
+		return dealDamage(targets, user, pendingDamage, false, "Light", adventure).results.concat(addModifier(targets, { name: "Distraction", stacks: 4 }));
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -113,7 +112,7 @@ function addNewRandomInsults(combatants, count, adventure) {
 			const rolledInsult = availableInsults[insultIndex];
 			const [receipt] = addModifier([combatant], { name: rolledInsult, stacks: 1 });
 			receipts.push(receipt);
-			if (receipt.succeeded.size > 0) {
+			if (receipt.addedModifiers.size > 0) {
 				availableInsults.splice(insultIndex, 1);
 			}
 		}

--- a/source/enemies/elegantstella.js
+++ b/source/enemies/elegantstella.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate, Adventure } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE } = require("../constants");
 const { selectAllFoes, selectRandomFoe } = require("../shared/actionComponents");
-const { changeStagger, generateModifierResultLines, addModifier, dealDamage } = require("../util/combatantUtil");
+const { changeStagger, addModifier, dealDamage } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
 const nonOpenerMoves = ["Tonitrus Spark", "Big Bang"];
@@ -32,7 +32,7 @@ module.exports = new EnemyTemplate("Elegant Stella",
 			pendingMisfortune.stacks += 7;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return generateModifierResultLines(addModifier(targets, pendingMisfortune));
+		return addModifier(targets, pendingMisfortune);
 	},
 	selector: selectAllFoes,
 	next: randomNonOpener
@@ -47,7 +47,7 @@ module.exports = new EnemyTemplate("Elegant Stella",
 			pendingMisfortune.stacks += 6;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return generateModifierResultLines(addModifier(targets, pendingMisfortune));
+		return addModifier(targets, pendingMisfortune);
 	},
 	selector: selectRandomFoe,
 	next: randomNonOpener
@@ -61,9 +61,9 @@ module.exports = new EnemyTemplate("Elegant Stella",
 		if (user.crit) {
 			pendingMisfortune.stacks += 7;
 		}
-		const { resultLines, survivors } = dealDamage(targets, user, user.getPower() + 25, false, "Light", adventure);
+		const { results, survivors } = dealDamage(targets, user, user.getPower() + 25, false, "Light", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines.concat(generateModifierResultLines(addModifier(survivors, pendingMisfortune)));
+		return results.concat(addModifier(survivors, pendingMisfortune));
 	},
 	selector: selectAllFoes,
 	next: randomNonOpener

--- a/source/enemies/firearrowfrog.js
+++ b/source/enemies/firearrowfrog.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_ALLY, ESSENCE_MATCH_STAGGER_FOE } = require("../constants.js");
 const { selectRandomFoe, selectSelf } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil.js");
 
 module.exports = new EnemyTemplate("Fire-Arrow Frog",
@@ -19,8 +19,8 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 	priority: 0,
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 20;
-		const resultLines = dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
-		return resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 6 : 3 })));
+		const results = dealDamage(targets, user, damage, false, user.essence, adventure).results;
+		return results.concat(addModifier(targets, { name: "Poison", stacks: user.crit ? 6 : 3 }));
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -35,7 +35,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 			stacks *= 3;
 		}
 		changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
-		return generateModifierResultLines(addModifier([user], { name: "Evasion", stacks }));
+		return addModifier([user], { name: "Evasion", stacks });
 	},
 	selector: selectSelf,
 	next: "Venom Cannon"
@@ -48,7 +48,7 @@ module.exports = new EnemyTemplate("Fire-Arrow Frog",
 		if (user.crit) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Torpidity", stacks: user.crit ? 3 : 2 })));
+		return addModifier(targets, { name: "Torpidity", stacks: user.crit ? 3 : 2 });
 	},
 	selector: selectRandomFoe,
 	next: "Venom Cannon"

--- a/source/enemies/geodetortoise.js
+++ b/source/enemies/geodetortoise.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes");
-const { addModifier, dealDamage, changeStagger, addProtection, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, addProtection } = require("../util/combatantUtil");
 const { selectRandomFoe, selectSelf } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/essenceUtil.js");
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require("../constants.js");
@@ -23,7 +23,7 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results;
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -39,7 +39,7 @@ module.exports = new EnemyTemplate("Geode Tortoise",
 		if (user.crit) {
 			pendingEmpowerment.stacks *= 2;
 		}
-		return [`${user.name} gains protection.`].concat(generateModifierResultLines(addModifier([user], pendingEmpowerment)));
+		return [`${user.name} gains protection.`].concat(addModifier([user], pendingEmpowerment));
 	},
 	selector: selectSelf,
 	next: "random"

--- a/source/enemies/gustwolf.js
+++ b/source/enemies/gustwolf.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate, Adventure } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require("../constants");
 const { selectMultipleRandomFoes, selectNone, selectRandomFoe } = require("../shared/actionComponents");
-const { generateModifierResultLines, addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
 /**
@@ -31,7 +31,7 @@ module.exports = new EnemyTemplate("Gust Wolf",
 			pendingEmpowerment.stacks *= 2;
 		}
 		changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
-		return generateModifierResultLines(addModifier([user], pendingEmpowerment));
+		return addModifier([user], pendingEmpowerment);
 	},
 	selector: selectNone,
 	next: "Bounding Frenzy"
@@ -45,9 +45,9 @@ module.exports = new EnemyTemplate("Gust Wolf",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, "Wind", adventure);
+		const { results, survivors } = dealDamage(targets, user, pendingDamage, false, "Wind", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines;
+		return results;
 	},
 	selector: selectMultipleRandomFoes(3),
 	next: randomWithoutBoundingFrenzy
@@ -61,9 +61,9 @@ module.exports = new EnemyTemplate("Gust Wolf",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, "Wind", adventure);
+		const { results, survivors } = dealDamage(targets, user, pendingDamage, false, "Wind", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines;
+		return results;
 	},
 	selector: selectRandomFoe,
 	next: randomWithoutBoundingFrenzy

--- a/source/enemies/mechabeedrone.js
+++ b/source/enemies/mechabeedrone.js
@@ -33,7 +33,6 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 	effect: (targets, user, adventure) => {
 		const receipts = addModifier([user], { name: "Evasion", stacks: 2 });
 		if (user.crit) {
-			pendingStagger -= 2;
 			receipts.push(...changeStagger([user], user, -2));
 		}
 		changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);

--- a/source/enemies/mechabeedrone.js
+++ b/source/enemies/mechabeedrone.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil.js");
+const { dealDamage, addModifier, changeStagger } = require("../util/combatantUtil.js");
 const { selectRandomFoe, selectSelf, selectNone, selectAllFoes } = require("../shared/actionComponents.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 const { getEmoji } = require("../util/essenceUtil.js");
@@ -21,7 +21,7 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results.concat(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 }));
 	},
 	selector: selectRandomFoe,
 	next: "Barrel Roll"
@@ -32,14 +32,12 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 	priority: 0,
 	effect: (targets, user, adventure) => {
 		const receipts = addModifier([user], { name: "Evasion", stacks: 2 });
-		const resultLines = [];
-		let pendingStagger = ESSENCE_MATCH_STAGGER_ALLY;
 		if (user.crit) {
-			pendingStagger += 2;
-			resultLines.push(`${user.name} shrugs off some Stagger.`);
+			pendingStagger -= 2;
+			receipts.push(...changeStagger([user], user, -2));
 		}
-		changeStagger([user], user, pendingStagger);
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+		changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
+		return receipts;
 	},
 	selector: selectSelf,
 	next: "Call for Help"
@@ -67,7 +65,7 @@ module.exports = new EnemyTemplate("Mechabee Drone",
 		user.hp = 0;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results;
 	},
 	selector: selectAllFoes,
 	next: "Sting"

--- a/source/enemies/mechabeesoldier.js
+++ b/source/enemies/mechabeesoldier.js
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 }));
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results.concat(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 }));
 	},
 	selector: selectRandomFoe,
 	next: "Neurotoxin Strike"

--- a/source/enemies/mechabeesoldier.js
+++ b/source/enemies/mechabeesoldier.js
@@ -1,5 +1,5 @@
 const { EnemyTemplate } = require("../classes/index.js");
-const { dealDamage, addModifier, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil.js");
+const { dealDamage, addModifier, changeStagger } = require("../util/combatantUtil.js");
 const { selectRandomFoe, selectSelf, selectAllFoes } = require("../shared/actionComponents.js");
 const { getEmoji } = require("../util/essenceUtil.js");
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require("../constants.js");
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 	effect: (targets, user, adventure) => {
 		let damage = user.getPower() + 10;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 })));
+		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(addModifier(targets, { name: "Poison", stacks: user.crit ? 4 : 2 }));
 	},
 	selector: selectRandomFoe,
 	next: "Neurotoxin Strike"
@@ -31,14 +31,11 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 	priority: 0,
 	effect: (targets, user, adventure) => {
 		const receipts = addModifier([user], { name: "Evasion", stacks: 2 });
-		const resultLines = [];
-		let pendingStagger = ESSENCE_MATCH_STAGGER_ALLY;
 		if (user.crit) {
-			pendingStagger += 2;
-			resultLines.push(`${user.name} shrugs off some Stagger.`);
+			receipts.push(...changeStagger([user], user, -2));
 		}
-		changeStagger([user], user, pendingStagger);
-		return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+		changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
+		return receipts;
 	},
 	selector: selectSelf,
 	next: "Sting"
@@ -53,8 +50,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		if (user.crit) {
 			pendingStagger += 2;
 		}
-		changeStagger(targets, user, pendingStagger);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat(`${targets[0].name} was Staggered.`);
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results.concat(changeStagger(targets, user, pendingStagger));
 	},
 	selector: selectRandomFoe,
 	next: "Self-Destruct"
@@ -70,8 +66,7 @@ module.exports = new EnemyTemplate("Mechabee Soldier",
 		}
 		user.hp = 0;
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results;
 	},
 	selector: selectAllFoes,
 	next: "Barrel Roll"

--- a/source/enemies/mechaqueenbee.js
+++ b/source/enemies/mechaqueenbee.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes/index.js");
 const { ESSENCE_MATCH_STAGGER_FOE } = require("../constants.js");
 const { selectRandomFoe, selectNone, selectAllFoes, selectRandomOtherAlly, selectAllAllies } = require("../shared/actionComponents.js");
-const { addModifier, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil.js");
+const { addModifier, changeStagger, addProtection } = require("../util/combatantUtil.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 
 const drone = require("./mechabeedrone.js")
@@ -62,7 +62,7 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 		const filteredTargets = targets.filter(target => target.hp > 0 && target.name !== user.name);
 		addProtection([user], user.crit ? 60 : 30);
 		const receipts = addModifier(filteredTargets, { name: "Swiftness", stacks: 3 }).concat(addModifier(filteredTargets, { name: "Empowerment", stacks: 3 }));
-		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+		return [`${user.name} gains protection.`].concat(receipts);
 	},
 	selector: selectAllAllies,
 	next: "V.E.N.O.Missile",
@@ -102,7 +102,7 @@ module.exports = new EnemyTemplate("Mecha Queen: Bee Mode",
 	priority: 0,
 	effect: (targets, user, adventure) => {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return generateModifierResultLines(addModifier(targets, { name: "Poison", stacks: user.crit ? 5 : 3 }));
+		return addModifier(targets, { name: "Poison", stacks: user.crit ? 5 : 3 });
 	},
 	selector: selectRandomFoe,
 	next: "Deploy Drone"

--- a/source/enemies/mechaqueenmech.js
+++ b/source/enemies/mechaqueenmech.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes/index.js");
 const { ESSENCE_MATCH_STAGGER_FOE } = require("../constants.js");
 const { selectRandomFoe, selectNone, selectAllFoes, selectRandomOtherAlly, selectAllAllies } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, addProtection, combineModifierReceipts, generateModifierResultLines } = require("../util/combatantUtil.js");
+const { addModifier, dealDamage, changeStagger, addProtection } = require("../util/combatantUtil.js");
 const { getEmoji } = require("../util/essenceUtil.js");
 const { spawnEnemy } = require("../util/roomUtil.js");
 
@@ -43,7 +43,7 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		const filteredTargets = targets.filter(target => target.hp > 0 && target.name !== user.name);
 		addProtection([user], user.crit ? 60 : 30);
 		const receipts = addModifier(filteredTargets, { name: "Swiftness", stacks: 3 }).concat(addModifier(filteredTargets, { name: "Empowerment", stacks: 3 }));
-		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+		return [`${user.name} gains protection.`].concat(receipts);
 	},
 	selector: selectAllAllies,
 	next: "Laser Array",
@@ -107,7 +107,7 @@ module.exports = new EnemyTemplate("Mecha Queen: Mech Mode",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		return dealDamage(targets, user, pendingDamage, false, "Darkness", adventure).resultLines;
+		return dealDamage(targets, user, pendingDamage, false, "Darkness", adventure).results;
 	},
 	selector: selectRandomFoe,
 	next: "Deploy Drone"

--- a/source/enemies/ooze.js
+++ b/source/enemies/ooze.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE } = require("../constants.js");
 const { selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
 
 module.exports = new EnemyTemplate("Ooze",
 	"@{adventureOpposite}",
@@ -20,7 +20,7 @@ module.exports = new EnemyTemplate("Ooze",
 		if (user.crit) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Torpidity", stacks: 3 })));
+		return addModifier(targets, { name: "Torpidity", stacks: 3 });
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -35,7 +35,7 @@ module.exports = new EnemyTemplate("Ooze",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, user.essence, adventure).results;
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/pulsarzebra.js
+++ b/source/enemies/pulsarzebra.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require("../constants");
 const { selectRandomFoe, selectRandomAlly } = require("../shared/actionComponents");
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require("../util/combatantUtil");
+const { changeStagger, dealDamage, addModifier } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
 module.exports = new EnemyTemplate("Pulsar Zebra",
@@ -22,9 +22,9 @@ module.exports = new EnemyTemplate("Pulsar Zebra",
 		if (user.crit) {
 			pendingDamage *= 2;
 		}
-		const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, "Darkness", adventure);
+		const { results, survivors } = dealDamage(targets, user, pendingDamage, false, "Darkness", adventure);
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
-		return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: "Weakness", stacks: 5 })));
+		return results.concat(addModifier(survivors, { name: "Weakness", stacks: 5 }));
 	},
 	selector: selectRandomFoe,
 	next: "Pulse Fade"
@@ -39,7 +39,7 @@ module.exports = new EnemyTemplate("Pulsar Zebra",
 			pendingEvasion.stacks *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
-		return generateModifierResultLines(addModifier(targets, pendingEvasion));
+		return addModifier(targets, pendingEvasion);
 	},
 	selector: selectRandomAlly,
 	next: "Pulse Flash"

--- a/source/enemies/slime.js
+++ b/source/enemies/slime.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_FOE } = require("../constants.js");
 const { selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger } = require("../util/combatantUtil");
 
 module.exports = new EnemyTemplate("Slime",
 	"@{adventure}",
@@ -22,7 +22,7 @@ module.exports = new EnemyTemplate("Slime",
 			damage *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
-		return dealDamage(targets, user, damage, false, adventure.essence, adventure).resultLines;
+		return dealDamage(targets, user, damage, false, adventure.essence, adventure).results;
 	},
 	selector: selectRandomFoe,
 	next: "random"
@@ -35,7 +35,7 @@ module.exports = new EnemyTemplate("Slime",
 		if (user.crit) {
 			changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Torpidity", stacks: user.crit ? 3 : 2 })));
+		return addModifier(targets, { name: "Torpidity", stacks: user.crit ? 3 : 2 });
 	},
 	selector: selectRandomFoe,
 	next: "random"

--- a/source/enemies/treasureelemental.js
+++ b/source/enemies/treasureelemental.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_ALLY } = require("../constants.js");
 const { selectAllFoes, selectRandomFoe } = require("../shared/actionComponents.js");
-const { addModifier, dealDamage, changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { addModifier, dealDamage, changeStagger, addProtection } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil.js");
 
 module.exports = new EnemyTemplate("Treasure Elemental",
@@ -22,7 +22,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			let damage = user.getPower() + 100;
 			addProtection([user], user.crit ? 100 : 50);
 			changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
-			return dealDamage(targets, user, damage, false, user.essence, adventure).resultLines.concat([`${user.name} gains protection.`]);
+			return dealDamage(targets, user, damage, false, user.essence, adventure).results.concat([`${user.name} gains protection.`]);
 		},
 		selector: selectRandomFoe,
 		next: "random"
@@ -39,7 +39,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			changeStagger([user], user, ESSENCE_MATCH_STAGGER_ALLY);
 			const texts = [];
 			for (let i = 0; i < 3; i++) {
-				texts.push(...dealDamage(targets, user, damage, false, user.essence, adventure).resultLines);
+				texts.push(...dealDamage(targets, user, damage, false, user.essence, adventure).results);
 			}
 			return texts;
 		},
@@ -55,7 +55,7 @@ module.exports = new EnemyTemplate("Treasure Elemental",
 			if (user.crit) {
 				stacks *= 2;
 			}
-			return generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: "Torpidity", stacks })));
+			return addModifier(targets, { name: "Torpidity", stacks });
 		},
 		selector: selectAllFoes,
 		next: "random"

--- a/source/enemies/unkindcorvus.js
+++ b/source/enemies/unkindcorvus.js
@@ -1,7 +1,7 @@
 const { EnemyTemplate } = require("../classes");
 const { ESSENCE_MATCH_STAGGER_ALLY } = require("../constants");
 const { selectRandomAlly, selectNone } = require("../shared/actionComponents");
-const { changeStagger, generateModifierResultLines, addModifier } = require("../util/combatantUtil");
+const { changeStagger, addModifier } = require("../util/combatantUtil");
 const { spawnEnemy } = require("../util/roomUtil");
 
 module.exports = new EnemyTemplate("Unkind Corvus",
@@ -23,7 +23,7 @@ module.exports = new EnemyTemplate("Unkind Corvus",
 			pendingEvasion.stacks *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
-		return generateModifierResultLines(addModifier(targets, pendingEvasion));
+		return addModifier(targets, pendingEvasion);
 	},
 	selector: selectRandomAlly,
 	next: "random"
@@ -38,7 +38,7 @@ module.exports = new EnemyTemplate("Unkind Corvus",
 			pendingVigilance.stacks *= 2;
 		}
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
-		return generateModifierResultLines(addModifier(targets, pendingVigilance));
+		return addModifier(targets, pendingVigilance);
 	},
 	selector: selectRandomAlly,
 	next: "Never-touched"

--- a/source/gear/_appease.js
+++ b/source/gear/_appease.js
@@ -1,5 +1,5 @@
 const { GearTemplate, GearFamily } = require('../classes/index.js');
-const { removeModifier, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil.js');
+const { removeModifier } = require('../util/combatantUtil.js');
 
 //#region Base
 const base = new GearTemplate("Appease",
@@ -13,7 +13,7 @@ function execute(targets, user, adventure) {
 	for (const insult of ["Boring", "Lacking Rhythm", "Smelly", "Stupid", "Ugly"]) {
 		receipts.push(...removeModifier([user], { name: insult, stacks: "all" }));
 	}
-	return generateModifierResultLines(combineModifierReceipts(receipts));
+	return receipts;
 }
 //#endregion Base
 

--- a/source/gear/_gear_blueprint.js
+++ b/source/gear/_gear_blueprint.js
@@ -21,7 +21,7 @@ function execute(targets, user, adventure) {
 	if (user.crit) {
 
 	}
-	return []; // see style guide for conventions on result texts
+	return []; // see style guide for conventions on results
 }
 //#endregion Base
 

--- a/source/gear/_greed.js
+++ b/source/gear/_greed.js
@@ -1,5 +1,5 @@
 const { GearTemplate, GearFamily } = require('../classes/index.js');
-const { addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil.js');
+const { addModifier } = require('../util/combatantUtil.js');
 
 //#region Base
 const base = new GearTemplate("Greed",
@@ -13,7 +13,7 @@ const base = new GearTemplate("Greed",
 function execute(targets, user, adventure) {
 	const [midas, empowerment] = base.modifiers;
 	const affectedTargets = targets.filter(target => target.archetype === "Treasure Elemental");
-	return generateModifierResultLines(combineModifierReceipts(addModifier(affectedTargets, empowerment).concat(addModifier(affectedTargets, midas))));
+	return addModifier(affectedTargets, empowerment).concat(addModifier(affectedTargets, midas));
 }
 //#endregion Base
 

--- a/source/gear/arcane-sledge.js
+++ b/source/gear/arcane-sledge.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, removeModifier, dealDamage, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, removeModifier, dealDamage, addModifier } = require('../util/combatantUtil');
 const { scalingImpotence } = require('./shared/modifiers');
 const { kineticDamageScalingGenerator, damageScalingGenerator } = require('./shared/scalings');
 
@@ -26,7 +26,7 @@ const arcaneSledge = new GearTemplate("Arcane Sledge",
 /** @type {typeof arcaneSledge.effect} */
 function arcaneSledgeEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, buffsRemoved, critBonus } } = arcaneSledge;
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
@@ -36,16 +36,14 @@ function arcaneSledgeEffect(targets, user, adventure) {
 			pendingBuffRemovals *= critBonus;
 		}
 		const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		const receipts = [];
 		if (targetBuffs.length > 0) {
 			for (let i = 0; i < pendingBuffRemovals; i++) {
 				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${arcaneSledge.name}${SAFE_DELIMITER}buffs`), 1);
-				receipts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+				results.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
 			}
 		}
-		resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -71,7 +69,7 @@ const fatiguingArcaneSledge = new GearTemplate("Fatiguing Arcane Sledge",
 /** @type {typeof fatiguingArcaneSledge.effect} */
 function fatiguingArcaneSledgeEffect(targets, user, adventure) {
 	const { essence, modifiers: [impotence], scalings: { damage, buffsRemoved, critBonus } } = fatiguingArcaneSledge;
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
@@ -81,16 +79,15 @@ function fatiguingArcaneSledgeEffect(targets, user, adventure) {
 			pendingBuffRemovals *= critBonus;
 		}
 		const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		const receipts = addModifier(survivors, { name: impotence.name, stacks: impotence.stacks.calculate(user) });
+		results.push(...addModifier(survivors, { name: impotence.name, stacks: impotence.stacks.calculate(user) }));
 		if (targetBuffs.length > 0) {
 			for (let i = 0; i < pendingBuffRemovals; i++) {
 				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${fatiguingArcaneSledge.name}${SAFE_DELIMITER}buffs`), 1);
-				receipts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+				results.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
 			}
 		}
-		resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Fatiguing
 
@@ -115,7 +112,7 @@ const kineticArcaneSledge = new GearTemplate("Kinetic Arcane Sledge",
 /** @type {typeof kineticArcaneSledge.effect} */
 function kineticArcaneSledgeEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, buffsRemoved, critBonus } } = kineticArcaneSledge;
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
@@ -125,16 +122,14 @@ function kineticArcaneSledgeEffect(targets, user, adventure) {
 			pendingBuffRemovals *= critBonus;
 		}
 		const targetBuffs = Object.keys(survivors[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		const receipts = [];
 		if (targetBuffs.length > 0) {
 			for (let i = 0; i < pendingBuffRemovals; i++) {
 				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${kineticArcaneSledge.name}${SAFE_DELIMITER}buffs`), 1);
-				receipts.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
+				results.push(...removeModifier(survivors, { name: selectedBuff, stacks: "all" }));
 			}
 		}
-		resultLines.push(...generateModifierResultLines(combineModifierReceipts(receipts)));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Kinetic
 

--- a/source/gear/battle-standard.js
+++ b/source/gear/battle-standard.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, dealDamage, generateModifierResultLines, removeModifier, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, removeModifier, addModifier } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -23,17 +23,17 @@ const battleStandard = new GearTemplate("Battle Standard",
 function battleStandardEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, morale } } = battleStandard;
 	let pendingDamage = damage.calculate(user);
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!")
+		results.push("The party's morale is increased!")
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines);
+	return damageResults.concat(results);
 }
 //#endregion Base
 
@@ -59,21 +59,21 @@ const disenchantingBattleStandard = new GearTemplate("Disenchanting Battle Stand
 function disenchantingBattleStandardEffect([target], user, adventure) {
 	const { essence, scalings: { damage, critBonus, morale } } = disenchantingBattleStandard;
 	let pendingDamage = damage.calculate(user);
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!")
+		results.push("The party's morale is increased!")
 	}
-	const { resultLines: damageResults } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { results: damageResults } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (target.hp > 0) {
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		resultLines.push(...generateModifierResultLines(removeModifier([target], { name: targetBuffs[user.roundRns[`${disenchantingBattleStandard.name}${SAFE_DELIMITER}buffs`][0] % targetBuffs.length], stacks: "all" })));
+		results.push(...removeModifier([target], { name: targetBuffs[user.roundRns[`${disenchantingBattleStandard.name}${SAFE_DELIMITER}buffs`][0] % targetBuffs.length], stacks: "all" }));
 	}
-	return damageResults.concat(resultLines);
+	return damageResults.concat(results);
 }
 //#endregion Disenchanting
 
@@ -97,17 +97,17 @@ const flankingBattleStandard = new GearTemplate("Flanking Battle Standard",
 function flankingBattleStandardEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, morale }, modifiers: [exposure] } = flankingBattleStandard;
 	let pendingDamage = damage.calculate(user);
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!")
+		results.push("The party's morale is increased!")
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, exposure)));
+	return damageResults.concat(results, addModifier(survivors, exposure));
 }
 //#endregion Flanking
 
@@ -131,23 +131,23 @@ const hasteningBattleStandard = new GearTemplate("Hastening Battle Standard",
 function hasteningBattleStandardEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, morale, cooldownReduction } } = hasteningBattleStandard;
 	let pendingDamage = damage.calculate(user);
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!");
+		results.push("The party's morale is increased!");
 		user.gear?.forEach(gear => {
 			if (gear.cooldown > 1) {
 				gear.cooldown -= cooldownReduction;
 			}
 		})
-		resultLines.push(`${user.name}'s cooldowns are hastened.`);
+		results.push(`${user.name}'s cooldowns are hastened.`);
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines);
+	return damageResults.concat(results);
 }
 //#endregion Hastening
 
@@ -171,17 +171,17 @@ const weakeningBattleStandard = new GearTemplate("Weakening Battle Standard",
 function weakeningBattleStandardEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, morale }, modifiers: [weakness] } = weakeningBattleStandard;
 	let pendingDamage = damage.calculate(user);
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!")
+		results.push("The party's morale is increased!")
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, weakness)));
+	return damageResults.concat(results, addModifier(survivors, weakness));
 }
 //#endregion Weakening
 

--- a/source/gear/blood-aegis.js
+++ b/source/gear/blood-aegis.js
@@ -1,6 +1,6 @@
 const { GearTemplate, Move, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { payHP, changeStagger, addProtection, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { payHP, changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
 const { protectionScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -34,14 +34,14 @@ function bloodAegisEffect([target], user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	const resultLines = [`Gaining protection, ${paymentSentence}`];
+	const results = [`Gaining protection, ${paymentSentence}`];
 	const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
 	const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 	if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 		targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-		resultLines.push(`${target.name} falls for the provocation.`);
+		results.push(`${target.name} falls for the provocation.`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -84,7 +84,7 @@ function toxicBloodAegisEffect([target], user, adventure) {
 		targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
 		resultLines.push(`${target.name} falls for the provocation.`);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([target], poison)));
+	return resultLines.concat(addModifier([target], poison));
 }
 //#endregion Toxic
 

--- a/source/gear/bonfire-formation.js
+++ b/source/gear/bonfire-formation.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { listifyEN } = require('../util/textUtil');
 
 //#region Base
@@ -35,7 +35,7 @@ function bonfireFormationEffect(targets, user, adventure) {
 		excellence.stacks += critBonus;
 		attunement.stacks += critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts([...addModifier(targets, pendingExcellence), ...addModifier(targets, pendingAttunement)]));
+	return addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingAttunement));
 }
 //#endregion Base
 
@@ -71,7 +71,7 @@ function chargingBonfireFormationEffect(targets, user, adventure) {
 		excellence.stacks += critBonus;
 		attunement.stacks += critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts([...addModifier(targets, pendingExcellence), ...addModifier(targets, pendingAttunement), ...addModifier(targets, empowerment)]));
+	return addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingAttunement), addModifier(targets, empowerment));
 }
 //#endregion Charging
 
@@ -123,7 +123,7 @@ function hasteningBonfireFormationEffect(targets, user, adventure) {
 		}
 		resultLines.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
 	}
-	return generateModifierResultLines(combineModifierReceipts([...addModifier(targets, pendingExcellence), ...addModifier(targets, pendingAttunement)])).concat(resultLines);
+	return addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingAttunement), resultLines);
 }
 //#endregion Hastening
 

--- a/source/gear/bounty-fist.js
+++ b/source/gear/bounty-fist.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier, gainHealth } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier, gainHealth } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -28,11 +28,11 @@ function bountyFistEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(`${user.name}'s ${bountyFist.name} consumed ${goldUsed}g.`);
+	return results.concat(`${user.name}'s ${bountyFist.name} consumed ${goldUsed}g.`);
 }
 //#endregion Base
 
@@ -62,11 +62,11 @@ function midassBountyFistEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(targets, curseOfMidas)), `${user.name}'s ${midassBountyFist.name} consumed ${goldUsed}g.`);
+	return results.concat(addModifier(targets, curseOfMidas), `${user.name}'s ${midassBountyFist.name} consumed ${goldUsed}g.`);
 }
 //#endregion Midas's
 
@@ -96,16 +96,15 @@ function thirstingBountyFistEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
 		const pendingHealing = healing.calculate(user);
-		gainHealth(user, pendingHealing, adventure);
-		resultLines.push(`${user.name} regains ${pendingHealing} HP.`);
+		results.push(gainHealth(user, pendingHealing, adventure));
 	}
-	return resultLines.concat(`${user.name}'s ${thirstingBountyFist.name} consumed ${goldUsed}g.`);
+	return results.concat(`${user.name}'s ${thirstingBountyFist.name} consumed ${goldUsed}g.`);
 }
 //#endregion Thirsting
 

--- a/source/gear/buckler.js
+++ b/source/gear/buckler.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier, addProtection } = require('../util/combatantUtil');
+const { changeStagger, addModifier, addProtection } = require('../util/combatantUtil');
 const { protectionScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -31,7 +31,7 @@ function bucklerEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection(targets, pendingProtection);
-	return [`${targets[0].name} gains protection.`].concat(generateModifierResultLines(addModifier([user], swiftness)));
+	return [`${targets[0].name} gains protection.`].concat(addModifier([user], swiftness));
 }
 //#endregion Base
 
@@ -63,7 +63,7 @@ function guardingBucklerEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection(targets, pendingProtection);
-	return [`${targets[0].name} gains protection.`].concat(generateModifierResultLines(addModifier([user], swiftness)));
+	return [`${targets[0].name} gains protection.`].concat(addModifier([user], swiftness));
 }
 //#endregion Guarding
 
@@ -86,24 +86,22 @@ const supportiveBuckler = new GearTemplate("Supportive Buckler",
 	.setModifiers({ name: "Swiftness", stacks: 3 });
 
 /** @type {typeof supportiveBuckler.effect} */
-function supportiveBucklerEffect(targets, user, adventure) {
+function supportiveBucklerEffect([target], user, adventure) {
 	const { essence, stagger, scalings: { protection, critBonus }, modifiers: [swiftness] } = supportiveBuckler;
-	let hadStagger = targets[0].stagger > 0;
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_ALLY;
 	}
-	changeStagger(targets, user, pendingStagger);
 	let pendingProtection = protection + Math.floor(user.getBonusHP() / 5);
 	if (user.crit) {
 		pendingProtection *= critBonus;
 	}
-	addProtection(targets, pendingProtection);
-	if (hadStagger) {
-		return [`${targets[0].name} gains protection and shrugs off some Stagger.`].concat(generateModifierResultLines(addModifier([user], swiftness)));
-	} else {
-		return [`${targets[0].name} gains protection.`].concat(generateModifierResultLines(addModifier([user], swiftness)));
+	addProtection([target], pendingProtection);
+	const results = [`${target.name} gains protection.`].concat(addModifier([user], swiftness));
+	if (target.stagger > 0) {
+		results.push(...changeStagger([target], user, pendingStagger));
 	}
+	return results;
 }
 //#endregion Supportive
 

--- a/source/gear/carrot.js
+++ b/source/gear/carrot.js
@@ -1,7 +1,7 @@
 const { GearTemplate, CombatantReference, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
-const { changeStagger, addModifier, addProtection, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
+const { changeStagger, addModifier, addProtection } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
 const { protectionScalingGenerator } = require('./shared/scalings');
 
@@ -29,7 +29,7 @@ function carrotEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingRegeneration.stacks += critBonus;
 	}
-	const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration));
+	const results = addModifier([target], pendingRegeneration);
 	const ownerIndex = adventure.getCombatantIndex(target);
 	const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 	if (owner.pet?.type) {
@@ -50,9 +50,9 @@ function carrotEffect([target], user, adventure) {
 					petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 			}
 		})
-		resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		results.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion
 
@@ -80,7 +80,7 @@ function balancedCarrotEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingRegeneration.stacks += critBonus;
 	}
-	const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([target], pendingRegeneration).concat(addModifier([target], finesse))));
+	const results = addModifier([target], pendingRegeneration).concat(addModifier([target], finesse));
 	const ownerIndex = adventure.getCombatantIndex(target);
 	const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 	if (owner.pet?.type) {
@@ -101,9 +101,9 @@ function balancedCarrotEffect([target], user, adventure) {
 					petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 			}
 		})
-		resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		results.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Balanced
 
@@ -135,7 +135,7 @@ function guardingCarrotEffect([target], user, adventure) {
 		pendingRegeneration.stacks += critBonus;
 	}
 	addProtection([target], protection.calculate(user));
-	const resultLines = generateModifierResultLines(addModifier([target], pendingRegeneration)).concat(`${target.name} gains protection.`);
+	const results = addModifier([target], pendingRegeneration).concat(`${target.name} gains protection.`);
 	const ownerIndex = adventure.getCombatantIndex(target);
 	const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
 	if (owner.pet?.type) {
@@ -156,9 +156,9 @@ function guardingCarrotEffect([target], user, adventure) {
 					petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 			}
 		})
-		resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		results.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Guarding
 

--- a/source/gear/cauldron-stir.js
+++ b/source/gear/cauldron-stir.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { rollablePotions } = require('../shared/potions');
-const { dealDamage, changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier, getCombatantCounters } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier, getCombatantCounters } = require('../util/combatantUtil');
 const { essenceList } = require('../util/essenceUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
@@ -24,19 +24,19 @@ const cauldronStir = new GearTemplate("Cauldron Stir",
 /** @type {typeof cauldronStir.effect} */
 function cauldronStirEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, potionCount } } = cauldronStir;
-	const resultLines = [];
+	const results = [];
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		const rolledPotion = rollablePotions[user.roundRns[`${cauldronStir.name}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
-		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
+		results.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines);
+	return damageResults.concat(results);
 }
 //#endregion Base
 
@@ -60,19 +60,19 @@ const incompatibleCauldronStir = new GearTemplate("Incompatible Cauldron Stir",
 /** @type {typeof incompatibleCauldronStir.effect} */
 function incompatibleCauldronStirEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, potionCount }, modifiers: [incompatible] } = incompatibleCauldronStir;
-	const resultLines = generateModifierResultLines(addModifier(targets, incompatible));
+	const results = addModifier(targets, incompatible);
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		const rolledPotion = rollablePotions[user.roundRns[`${incompatibleCauldronStir.name}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
-		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
+		results.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines);
+	return damageResults.concat(results);
 }
 //#endregion Incompatible
 
@@ -96,23 +96,23 @@ const innovativeCauldronStir = new GearTemplate("Innovative Cauldron Stir",
 /** @type {typeof innovativeCauldronStir.effect} */
 function innovativeCauldronStirEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, potionCount }, modifiers: [empowerment] } = innovativeCauldronStir;
-	const resultLines = [];
+	const results = [];
 	if (getCombatantCounters(targets[0]).includes(this.essence)) {
 		const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
-		resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(userTeam, empowerment))));
+		results.push(...addModifier(userTeam, empowerment));
 	}
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		const rolledPotion = rollablePotions[user.roundRns[`${innovativeCauldronStir.name}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
-		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
+		results.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines);
+	return damageResults.concat(results);
 }
 //#endregion Innovative
 
@@ -139,20 +139,20 @@ const sabotagingCauldronStir = new GearTemplate("Sabotaging Cauldron Stir",
 /** @type {typeof sabotagingCauldronStir.effect} */
 function sabotagingCauldronStirEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, potionCount }, modifiers: [vulnerability] } = sabotagingCauldronStir;
-	const resultLines = [];
+	const results = [];
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		const rolledPotion = rollablePotions[user.roundRns[`${sabotagingCauldronStir.name}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
-		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
+		results.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	const rolledVulnerability = essenceList(["Unaligned"])[user.roundRns[`${sabotagingName}${SAFE_DELIMITER}vulnerabilities`][0]];
-	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, { name: `${rolledVulnerability} Vulnerability`, stacks: vulnerability.stacks })));
+	return damageResults.concat(results, addModifier(survivors, { name: `${rolledVulnerability} Vulnerability`, stacks: vulnerability.stacks }));
 }
 //#endregion Sabotaging
 
@@ -176,19 +176,19 @@ const toxicCauldronStir = new GearTemplate("Toxic Cauldron Stir",
 /** @type {typeof toxicCauldronStir.effect} */
 function toxicCauldronStirEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus, potionCount }, modifiers: [poison] } = toxicCauldronStir;
-	const resultLines = [];
+	const results = [];
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 		const rolledPotion = rollablePotions[user.roundRns[`${toxicCauldronStir.name}${SAFE_DELIMITER}potions`][0] % rollablePotions.length];
 		adventure.room.addResource(rolledPotion, "Item", "loot", potionCount);
-		resultLines.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
+		results.push(`${user.name} sets a batch of ${rolledPotion} to simmer.`);
 	}
 	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return damageResults.concat(resultLines, generateModifierResultLines(addModifier(survivors, poison)));
+	return damageResults.concat(results, addModifier(survivors, poison));
 }
 //#endregion Toxic
 

--- a/source/gear/cloak.js
+++ b/source/gear/cloak.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingEvasion } = require('./shared/modifiers');
 const { accuratePassive, powerfulPassive } = require('./shared/passiveDescriptions');
 
@@ -28,7 +28,7 @@ function cloakEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingEvasion.stacks *= critBonus;
 	}
-	return generateModifierResultLines(addModifier([user], pendingEvasion));
+	return addModifier([user], pendingEvasion);
 }
 //#endregion Base
 

--- a/source/gear/conjured-ice-pillar.js
+++ b/source/gear/conjured-ice-pillar.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily, Move } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingEvasion } = require('./shared/modifiers');
 
 //#region Base
@@ -27,7 +27,7 @@ function conjuredIcePillarEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingEvasion.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingEvasion).concat(addModifier([user], vigilance))));
+	return addModifier([user], pendingEvasion).concat(addModifier([user], vigilance));
 }
 //#endregion Base
 
@@ -55,7 +55,7 @@ function devotedConjuredIcePillarEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingEvasion.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingEvasion).concat(addModifier(targets, vigilance))));
+	return addModifier(targets, pendingEvasion).concat(addModifier(targets, vigilance));
 }
 //#endregion Devoted
 
@@ -83,14 +83,14 @@ function tauntingConjuredIcePillarEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingEvasion.stacks *= critBonus;
 	}
-	const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier([user], pendingEvasion).concat(addModifier([user], vigilance))));
+	const results = addModifier([user], pendingEvasion).concat(addModifier([user], vigilance));
 	const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
 	const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 	if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 		targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-		resultLines.push(`${target.name} falls for the provocation.`);
+		results.push(`${target.name} falls for the provocation.`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Taunting
 

--- a/source/gear/daggers.js
+++ b/source/gear/daggers.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { dealDamage, changeStagger, generateModifierResultLines, addModifier, combineModifierReceipts } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -25,11 +25,11 @@ function daggersEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([user], excellence)));
+	return results.concat(addModifier([user], excellence));
 }
 //#endregion Base
 
@@ -55,11 +55,11 @@ function attunedDaggersEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamge *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamge, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamge, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user], excellence).concat(addModifier([user], attunement)))));
+	return results.concat(addModifier([user], excellence), addModifier([user], attunement));
 }
 //#endregion Attuned
 
@@ -85,11 +85,11 @@ function balancedDaggersEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user], excellence).concat(addModifier([user], finesse)))));
+	return results.concat(addModifier([user], excellence), addModifier([user], finesse));
 }
 //#endregion Balanced
 
@@ -116,12 +116,12 @@ function centeringDaggersEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	changeStagger([user], user, selfStagger);
-	return resultLines.concat(generateModifierResultLines(addModifier([user], excellence)), `${user.name} shrugs off some Stagger.`);
+	results.push(...changeStagger([user], user, selfStagger));
+	return results.concat(addModifier([user], excellence));
 }
 //#endregion Centering
 
@@ -147,11 +147,11 @@ function distractingDaggersEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier([user], excellence).concat(addModifier(targets, distraction)))));
+	return results.concat(addModifier([user], excellence), addModifier(targets, distraction));
 }
 //#endregion Distracting
 

--- a/source/gear/deck-of-cards.js
+++ b/source/gear/deck-of-cards.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily, Scaling } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { dealDamage, generateModifierResultLines, addModifier, getCombatantCounters, changeStagger } = require('../util/combatantUtil');
+const { dealDamage, addModifier, getCombatantCounters, changeStagger } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 /** @type {(variantName: string) => ({ name: "Misfortune", stacks: Scaling })} */
@@ -44,11 +44,11 @@ function deckOfCardsEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) })));
+	return results.concat(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
 }
 //#endregion Base
 
@@ -76,11 +76,11 @@ function evasiveDeckOfCardsEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }).concat(addModifier([user], evasion))));
+	return results.concat(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }), addModifier([user], evasion));
 }
 //#endregion Evasive
 
@@ -108,11 +108,11 @@ function numbingDeckOfCardsEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }).concat(addModifier(survivors, clumsiness))));
+	return results.concat(addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }), addModifier(survivors, clumsiness));
 }
 //#endregion Numbing
 
@@ -140,7 +140,7 @@ function omenousDeckOfCardsEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
@@ -149,9 +149,9 @@ function omenousDeckOfCardsEffect(targets, user, adventure) {
 		if (getCombatantCounters(survivors[0]).includes(essence)) {
 			misfortuneStacks *= 2;
 		}
-		resultLines.push(...generateModifierResultLines(addModifier(survivors, { name: misfortune.name, stacks: misfortuneStacks })))
+		results.push(...addModifier(survivors, { name: misfortune.name, stacks: misfortuneStacks }))
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Omenous
 
@@ -180,8 +180,7 @@ function tormentingDeckOfCardsEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const receipts = [];
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
@@ -189,13 +188,13 @@ function tormentingDeckOfCardsEffect(targets, user, adventure) {
 		for (const target of survivors) {
 			for (const modifier in target.modifiers) {
 				if (getModifierCategory(modifier) === "Debuff") {
-					receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+					results.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 				}
 			}
 		}
 	}
-	receipts.push(...addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
-	return resultLines.concat(generateModifierResultLines(receipts));
+	results.push(...addModifier(survivors, { name: misfortune.name, stacks: misfortune.stacks.calculate(user) }));
+	return results;
 }
 //#endregion Tormenting
 

--- a/source/gear/elemental-scroll.js
+++ b/source/gear/elemental-scroll.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 
 //#region Base
 const elementalScroll = new GearTemplate("Elemental Scroll",
@@ -26,14 +26,14 @@ function elementalScrollEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingAttunement.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingAttunement)));
+	return addModifier(targets, pendingAttunement);
 }
 //#endregion Base
 
 //#region Balanced
 const balancedElementalScroll = new GearTemplate("Balanced Elemental Scroll",
 	[
-		["use", "Grant @{mod0Stacks} @{mod0} and @{mod2Stacks} @{mod2} to an ally and allies with @{mod1}"],
+		["use", "Grant @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to an ally and allies with @{mod2}"],
 		["critical", "@{mod0} x @{critBonus}"]
 	],
 	"Support",
@@ -41,12 +41,12 @@ const balancedElementalScroll = new GearTemplate("Balanced Elemental Scroll",
 ).setCost(350)
 	.setEffect(balancedElementalScrollEffect, { type: `single${SAFE_DELIMITER}Vigilance`, team: "ally" })
 	.setCooldown(1)
-	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Vigilance", stacks: 0 }, { name: "Finesse", stacks: 1 })
+	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Finesse", stacks: 1 }, { name: "Vigilance", stacks: 0 })
 	.setScalings({ critBonus: 2 });
 
 /** @type {typeof balancedElementalScroll.effect} */
 function balancedElementalScrollEffect(targets, user, adventure) {
-	const { essence, modifiers: [attunement, targetModifier, finesse], scalings: { critBonus } } = balancedElementalScroll;
+	const { essence, modifiers: [attunement, finesse], scalings: { critBonus } } = balancedElementalScroll;
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
@@ -54,14 +54,14 @@ function balancedElementalScrollEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingAttunement.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingAttunement).concat(addModifier(targets, finesse))));
+	return addModifier(targets, pendingAttunement).concat(addModifier(targets, finesse));
 }
 //#endregion Balanced
 
 //#region Surpassing
 const surpassingElementalScroll = new GearTemplate("Surpassing Elemental Scroll",
 	[
-		["use", "Grant @{mod0Stacks} @{mod0} and @{mod2Stacks} @{mod2} to an ally and allies with @{mod1}"],
+		["use", "Grant @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} to an ally and allies with @{mod2}"],
 		["critical", "@{mod0} x @{critBonus}"]
 	],
 	"Support",
@@ -69,12 +69,12 @@ const surpassingElementalScroll = new GearTemplate("Surpassing Elemental Scroll"
 ).setCost(350)
 	.setEffect(surpassingElementalScrollEffect, { type: `single${SAFE_DELIMITER}Vigilance`, team: "ally" })
 	.setCooldown(1)
-	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Vigilance", stacks: 0 }, { name: "Excellence", stacks: 2 })
+	.setModifiers({ name: "Attunement", stacks: 3 }, { name: "Excellence", stacks: 2 }, { name: "Vigilance", stacks: 0 })
 	.setScalings({ critBonus: 2 });
 
 /** @type {typeof surpassingElementalScroll.effect} */
 function surpassingElementalScrollEffect(targets, user, adventure) {
-	const { essence, modifiers: [attunement, targetModifier, excellence], scalings: { critBonus } } = surpassingElementalScroll;
+	const { essence, modifiers: [attunement, excellence], scalings: { critBonus } } = surpassingElementalScroll;
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
@@ -82,7 +82,7 @@ function surpassingElementalScrollEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingAttunement.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingAttunement).concat(addModifier(targets, excellence))));
+	return addModifier(targets, pendingAttunement).concat(addModifier(targets, excellence));
 }
 //#endregion Surpassing
 

--- a/source/gear/enchantment-siphon.js
+++ b/source/gear/enchantment-siphon.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, addProtection, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
+const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
 const { protectionScalingGenerator } = require('./shared/scalings');
 const { scalingExposure } = require('./shared/modifiers');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
@@ -72,11 +72,11 @@ function flankingEnchantmentSiphonEffect([target], user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	const resultLines = generateModifierResultLines(addModifier([target], { name: exposure.name, stacks: exposure.stacks.calculate(user) }));
+	const results = addModifier([target], { name: exposure.name, stacks: exposure.stacks.calculate(user) });
 	if (stolenProtection > 0) {
-		return [`${user.name} steals ${target.name}'s protection.`].concat(resultLines);
+		return [`${user.name} steals ${target.name}'s protection.`].concat(results);
 	} else {
-		return [`${user.name} gains protection.`].concat(resultLines);
+		return [`${user.name} gains protection.`].concat(results);
 	}
 }
 //#endregion Flanking
@@ -118,9 +118,9 @@ function tormentingEnchantmentSiphonEffect([target], user, adventure) {
 		}
 	}
 	if (stolenProtection > 0) {
-		return [`${user.name} steals ${target.name}'s protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+		return [`${user.name} steals ${target.name}'s protection.`, ...receipts];
 	} else {
-		return [`${user.name} gains protection.`].concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+		return [`${user.name} gains protection.`, ...receipts];
 	}
 }
 //#endregion Tormenting

--- a/source/gear/encouragement.js
+++ b/source/gear/encouragement.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingExcellence, scalingEmpowerment } = require('./shared/modifiers');
 
 //#region Base
@@ -29,7 +29,7 @@ function encouragementEffect(targets, user, adventure) {
 		pendingExcellence.stacks *= critBonus;
 		pendingEmpowerment.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingEmpowerment))));
+	return addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingEmpowerment));
 }
 //#endregion Base
 
@@ -74,7 +74,7 @@ function vigorousEncouragementEffect(targets, user, adventure) {
 		pendingExcellence.stacks *= critBonus;
 		pendingEmpowerment.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingEmpowerment), addModifier(targets, impact))));
+	return addModifier(targets, pendingExcellence).concat(addModifier(targets, pendingEmpowerment), addModifier(targets, impact));
 }
 //#endregion Vigorous
 

--- a/source/gear/fever-break.js
+++ b/source/gear/fever-break.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { dealDamage, removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { dealDamage, removeModifier, changeStagger, addModifier } = require('../util/combatantUtil');
 const { unstoppablePassive } = require('./shared/passiveDescriptions');
 
 //#region Base
@@ -50,7 +50,7 @@ function feverBreakEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return resultLines.concat(receipts);
 }
 //#endregion Base
 
@@ -101,7 +101,7 @@ function fatiguingFeverBreakEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return resultLines.concat(receipts);
 }
 //#endregion Fatiguing
 
@@ -152,7 +152,7 @@ function unstoppableFeverBreakEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return resultLines.concat(receipts);
 }
 //#endregion Unstoppable
 

--- a/source/gear/fever-break.js
+++ b/source/gear/fever-break.js
@@ -39,7 +39,7 @@ function feverBreakEffect(targets, user, adventure) {
 		const poisonStacks = target.getModifierStacks("Poison");
 		const frailtyStacks = target.getModifierStacks("Frailty");
 		const pendingDamage = poisonDamage * (poisonStacks ** 2 + poisonStacks) / 2 + frailDamage * frailtyStacks;
-		resultLines.push(...dealDamage([target], user, pendingDamage, false, essence, adventure).resultLines);
+		resultLines.push(...dealDamage([target], user, pendingDamage, false, essence, adventure).results);
 		if (target.hp > 0) {
 			survivors.push(target);
 			if (!user.crit) {
@@ -89,7 +89,7 @@ function fatiguingFeverBreakEffect(targets, user, adventure) {
 		const poisonStacks = target.getModifierStacks("Poison");
 		const frailtyStacks = target.getModifierStacks("Frailty");
 		const pendingDamage = poisonDamage * (poisonStacks ** 2 + poisonStacks) / 2 + frailDamage * frailtyStacks;
-		resultLines.push(...dealDamage([target], user, pendingDamage, false, essence, adventure).resultLines);
+		resultLines.push(...dealDamage([target], user, pendingDamage, false, essence, adventure).results);
 		if (target.hp > 0) {
 			survivors.push(target);
 			if (!user.crit) {
@@ -141,7 +141,7 @@ function unstoppableFeverBreakEffect(targets, user, adventure) {
 		const poisonStacks = target.getModifierStacks("Poison");
 		const frailtyStacks = target.getModifierStacks("Frailty");
 		const pendingDamage = poisonDamage * (poisonStacks ** 2 + poisonStacks) / 2 + frailDamage * frailtyStacks;
-		resultLines.push(...dealDamage([target], user, pendingDamage, true, essence, adventure).resultLines);
+		resultLines.push(...dealDamage([target], user, pendingDamage, true, essence, adventure).results);
 		if (target.hp > 0) {
 			survivors.push(target);
 			if (!user.crit) {

--- a/source/gear/flail.js
+++ b/source/gear/flail.js
@@ -34,7 +34,7 @@ function flailEffect(targets, user, adventure) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
 	if (survivors.length > 0) {
-		results.push(changeStagger(survivors, user, pendingStagger));
+		results.push(...changeStagger(survivors, user, pendingStagger));
 	}
 	return results;
 }
@@ -73,7 +73,7 @@ function bouncingFlailEffect(targets, user, adventure) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
 	if (survivors.length > 0) {
-		results.push(changeStagger(survivors, user, pendingStagger));
+		results.push(...changeStagger(survivors, user, pendingStagger));
 	}
 	return results;
 }
@@ -110,7 +110,7 @@ function incompatibleFlailEffect(targets, user, adventure) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
 	if (survivors.length > 0) {
-		results.push(changeStagger(survivors, user, pendingStagger));
+		results.push(...changeStagger(survivors, user, pendingStagger));
 	}
 	return results.concat(addModifier(survivors, torpidity));
 }

--- a/source/gear/flail.js
+++ b/source/gear/flail.js
@@ -1,7 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
-const { joinAsStatement } = require('../util/textUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -29,16 +28,15 @@ function flailEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
 	if (survivors.length > 0) {
-		changeStagger(survivors, user, pendingStagger);
-		resultLines.push(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
+		results.push(changeStagger(survivors, user, pendingStagger));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -69,16 +67,15 @@ function bouncingFlailEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
 	if (survivors.length > 0) {
-		changeStagger(survivors, user, pendingStagger);
-		resultLines.push(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
+		results.push(changeStagger(survivors, user, pendingStagger));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Bouncing
 
@@ -107,16 +104,15 @@ function incompatibleFlailEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
 	if (survivors.length > 0) {
-		changeStagger(survivors, user, pendingStagger);
-		resultLines.push(joinAsStatement(false, survivors.map(target => target.name), "is", "are", "Staggered."));
+		results.push(changeStagger(survivors, user, pendingStagger));
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, torpidity)));
+	return results.concat(addModifier(survivors, torpidity));
 }
 //#endregion Incompatible
 

--- a/source/gear/flame-scythes.js
+++ b/source/gear/flame-scythes.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, downedCheck, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, downedCheck, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -26,16 +26,16 @@ function flameScythesEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { results } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (target.hp < (user.getDamageCap() / 2)) {
 		target.hp = 0;
-		const { extraLines } = downedCheck(target, adventure);
-		return [`${target.name} meets the reaper!`].concat(extraLines);
+		const downedLinesSansGeneric = downedCheck(target, adventure).slice(1);
+		return [`${target.name} meets the reaper!`, ...downedLinesSansGeneric];
 	} else {
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return resultLines;
+		return results;
 	}
 }
 //#endregion Base
@@ -64,18 +64,17 @@ function thiefsFlameScythesEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { results } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (target.hp < (user.getDamageCap() / 2)) {
 		target.hp = 0;
-		const { extraLines } = downedCheck(target, adventure);
 		adventure.room.addResource("Gold", "Currency", "loot", bounty);
-		extraLines.push(`${user.name} pillages ${bounty}g.`);
-		return [`${target.name} meets the reaper!`].concat(extraLines);
+		const downedLinesSansGeneric = downedCheck(target, adventure).slice(1);
+		return [`${target.name} meets the reaper!`, ...downedLinesSansGeneric, `${user.name} pillages ${bounty}g.`];
 	} else {
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return resultLines;
+		return results;
 	}
 }
 //#endregion Thief's
@@ -104,16 +103,16 @@ function toxicFlameScythesEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { results } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (target.hp < (user.getDamageCap() / 2)) {
 		target.hp = 0;
-		const { extraLines } = downedCheck(target, adventure);
-		return [`${target.name} meets the reaper!`].concat(extraLines);
+		const downedLinesSansGeneric = downedCheck(target, adventure).slice(1);
+		return [`${target.name} meets the reaper!`, ...downedLinesSansGeneric];
 	} else {
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return resultLines.concat(generateModifierResultLines(addModifier([target], poison)));
+		return results.concat(addModifier([target], poison));
 	}
 }
 //#endregion Toxic

--- a/source/gear/flourish.js
+++ b/source/gear/flourish.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
-const { dealDamage, changeStagger, generateModifierResultLines, addModifier, combineModifierReceipts } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, addModifier } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -25,11 +25,11 @@ function flourishEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
+	return results.concat(addModifier(survivors, distraction));
 }
 //#endregion Base
 
@@ -58,11 +58,11 @@ function bouncingFlourishEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
+	return results.concat(addModifier(survivors, distraction));
 }
 //#endregion Bouncing
 
@@ -88,11 +88,11 @@ function shatteringFlourishEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, distraction).concat(addModifier(survivors, frailty)))));
+	return results.concat(addModifier(survivors, distraction).concat(addModifier(survivors, frailty)));
 }
 //#endregion Shattering
 
@@ -119,13 +119,12 @@ function staggeringFlourishEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	let pendingStagger = stagger;
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
-	changeStagger(survivors, user, pendingStagger);
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, distraction)));
+	return results.concat(addModifier(survivors, distraction), changeStagger(survivors, user, pendingStagger));
 }
 //#endregion Staggering
 

--- a/source/gear/forbidden-knowledge.js
+++ b/source/gear/forbidden-knowledge.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily, CombatantReference } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
 const { getPetMove } = require('../pets/_petDictionary');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingRegeneration } = require('./shared/modifiers');
 
 //#region Base
@@ -30,7 +30,7 @@ function forbiddenKnowledgeEffect([target], user, adventure) {
 		adventure.room.morale -= pactCost[0];
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(target)}`, "levelsGained", "loot", levelUps);
 	}
-	const resultLines = [`${target.name} gains a level's worth of cursed knowledge. The party's morale falls.`];
+	const results = [`${target.name} gains a level's worth of cursed knowledge. The party's morale falls.`];
 	if (user.essence === essence) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
@@ -43,10 +43,10 @@ function forbiddenKnowledgeEffect([target], user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name}'s cooldowns were hastened.`);
+			results.push(`${target.name}'s cooldowns were hastened.`);
 		}
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -76,7 +76,7 @@ function enticingForbiddenKnowledgeEffect([target], user, adventure) {
 		adventure.room.morale -= pactCost[0];
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(target)}`, "levelsGained", "loot", levelUps);
 	}
-	const resultLines = [`${target.name} gains a level's worth of cursed knowledge. The party's morale falls.`];
+	const results = [`${target.name} gains a level's worth of cursed knowledge. The party's morale falls.`];
 	if (user.essence === essence) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
@@ -89,7 +89,7 @@ function enticingForbiddenKnowledgeEffect([target], user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name}'s cooldowns were hastened.`);
+			results.push(`${target.name}'s cooldowns were hastened.`);
 		}
 	}
 	const ownerIndex = adventure.getCombatantIndex(target);
@@ -112,9 +112,9 @@ function enticingForbiddenKnowledgeEffect([target], user, adventure) {
 					petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 			}
 		})
-		resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		results.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Enticing
 
@@ -145,11 +145,11 @@ function soothingForbiddenKnowledgeEffect([target], user, adventure) {
 		adventure.room.morale -= pactCost[0];
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(target)}`, "levelsGained", "loot", levelUps);
 	}
-	const resultLines = [`${target.name} gains a level's worth of cursed knowledge. The party's morale falls.`];
+	const results = [`${target.name} gains a level's worth of cursed knowledge. The party's morale falls.`];
 	if (user.essence === essence) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	resultLines.push(...generateModifierResultLines(addModifier([target], { name: regeneration.name, stacks: regeneration.stacks.calculate(user) })));
+	results.push(...addModifier([target], { name: regeneration.name, stacks: regeneration.stacks.calculate(user) }));
 	if (user.crit) {
 		let didCooldown = false;
 		target.gear?.forEach(gear => {
@@ -159,10 +159,10 @@ function soothingForbiddenKnowledgeEffect([target], user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name}'s cooldowns were hastened.`);
+			results.push(`${target.name}'s cooldowns were hastened.`);
 		}
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Soothing
 

--- a/source/gear/greatsword.js
+++ b/source/gear/greatsword.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -26,11 +26,11 @@ function greatswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -75,11 +75,11 @@ function distractingGreatswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, distraction))));
+	return results.concat(addModifier(survivors, distraction));
 }
 //#endregion Distracting
 

--- a/source/gear/heat-weaken.js
+++ b/source/gear/heat-weaken.js
@@ -1,7 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
-const { joinAsStatement } = require('../util/textUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 
 const bounces = 3;
 
@@ -30,7 +29,7 @@ function heatWeakenEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingFrailty.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingFrailty)));
+	return addModifier(targets, pendingFrailty);
 }
 //#endregion Base
 
@@ -59,7 +58,7 @@ function numbingHeatWeakenEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingFrailty.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingFrailty).concat(addModifier(targets, clumsiness))));
+	return addModifier(targets, pendingFrailty).concat(addModifier(targets, clumsiness));
 }
 //#endregion Numbing
 
@@ -86,12 +85,11 @@ function staggeringHeatWeakenEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 	}
-	changeStagger(targets, user, pendingStagger);
 	const pendingFrailty = { ...frailty };
 	if (user.crit) {
 		pendingFrailty.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingFrailty))).concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));
+	return addModifier(targets, pendingFrailty).concat(changeStagger(targets, user, pendingStagger));
 }
 //#endregion Staggering
 

--- a/source/gear/herb-basket.js
+++ b/source/gear/herb-basket.js
@@ -66,13 +66,13 @@ function enticingHerbBasketEffect([target], user, adventure) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
 	const randomHerb = rollableHerbs[user.roundRns[`${enticingHerbBasket.name}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		adventure.room.addResource(randomHerb, "Item", "loot", herbCount * critBonus);
-		resultLines.push(`${user.name} gathers a double-batch of ${randomHerb}.`);
+		results.push(`${user.name} gathers a double-batch of ${randomHerb}.`);
 	} else {
 		adventure.room.addResource(randomHerb, "Item", "loot", herbCount);
-		resultLines.push(`${user.name} gathers a batch of ${randomHerb}.`);
+		results.push(`${user.name} gathers a batch of ${randomHerb}.`);
 	}
 	const ownerIndex = adventure.getCombatantIndex(target);
 	const owner = target.team === "delver" ? target : adventure.getCombatant({ team: "delver", index: ownerIndex });
@@ -94,9 +94,9 @@ function enticingHerbBasketEffect([target], user, adventure) {
 					petRNs.extras.push(adventure.generateRandomNumber(rnType, "battle"));
 			}
 		})
-		resultLines.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
+		results.push(`${target.name}'s ${owner.pet.type} uses ${petMoveTemplate.name}`, ...petMoveTemplate.effect(petMoveTemplate.selector(owner, petRNs).map(reference => adventure.getCombatant(reference)), owner, adventure, { petRNs }));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Enticing
 
@@ -126,17 +126,17 @@ function guardingHerbBasketEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
 	const randomHerb = rollableHerbs[user.roundRns[`${guardingHerbBasket.name}${SAFE_DELIMITER}herbs`][0] % rollableHerbs.length];
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		adventure.room.addResource(randomHerb, "Item", "loot", herbCount * critBonus);
-		resultLines.push(`${user.name} gathers a double-batch of ${randomHerb}.`);
+		results.push(`${user.name} gathers a double-batch of ${randomHerb}.`);
 	} else {
 		adventure.room.addResource(randomHerb, "Item", "loot", herbCount);
-		resultLines.push(`${user.name} gathers a batch of ${randomHerb}.`);
+		results.push(`${user.name} gathers a batch of ${randomHerb}.`);
 	}
-	resultLines.push(joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."));
+	results.push(joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."));
 	addProtection(targets, protection.calculate(user));
-	return resultLines;
+	return results;
 }
 //#endregion Guarding
 

--- a/source/gear/illumination.js
+++ b/source/gear/illumination.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 
 //#region Base
 const illumination = new GearTemplate("Illumination",
@@ -24,7 +24,7 @@ function illuminationEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	const resultLines = [];
+	const results = [];
 	for (const target of targets) {
 		let didCooldown = false;
 		target.gear?.forEach(gear => {
@@ -34,14 +34,14 @@ function illuminationEffect(targets, user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name} had their cooldowns hastened.`);
+			results.push(`${target.name} had their cooldowns hastened.`);
 		}
 	}
 	if (user.crit) {
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!");
+		results.push("The party's morale is increased!");
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -68,7 +68,7 @@ function balancedIlluminationEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	const resultLines = [];
+	const results = [];
 	for (const target of targets) {
 		let didCooldown = false;
 		target.gear?.forEach(gear => {
@@ -78,14 +78,14 @@ function balancedIlluminationEffect(targets, user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name} had their cooldowns hastened.`);
+			results.push(`${target.name} had their cooldowns hastened.`);
 		}
 	}
 	if (user.crit) {
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!");
+		results.push("The party's morale is increased!");
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(targets, finesse)));
+	return results.concat(addModifier(targets, finesse));
 }
 //#endregion Balanced
 
@@ -112,7 +112,7 @@ function inspiringIlluminationEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	const resultLines = [];
+	const results = [];
 	for (const target of targets) {
 		let didCooldown = false;
 		target.gear?.forEach(gear => {
@@ -122,15 +122,15 @@ function inspiringIlluminationEffect(targets, user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name} had their cooldowns hastened.`);
+			results.push(`${target.name} had their cooldowns hastened.`);
 		}
 	}
 	if (user.crit) {
 		adventure.room.morale += critMorale;
 	}
 	adventure.room.morale += baseMorale;
-	resultLines.push("The party's morale is increased!");
-	return resultLines;
+	results.push("The party's morale is increased!");
+	return results;
 }
 //#endregion Inspiring
 

--- a/source/gear/lance.js
+++ b/source/gear/lance.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily, Move } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, addProtection, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addProtection, addModifier } = require('../util/combatantUtil');
 const { protectionScalingGenerator, archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -26,11 +26,11 @@ function lanceEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(`${user.name} gains protection.`);
+	return results.concat(`${user.name} gains protection.`);
 }
 //#endregion Base
 
@@ -58,11 +58,11 @@ function acceleratingLanceEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(`${user.name} gains protection.`, generateModifierResultLines(addModifier([user], swiftness)));
+	return results.concat(`${user.name} gains protection.`, addModifier([user], swiftness));
 }
 //#endregion Accelerating
 
@@ -89,11 +89,11 @@ function bashingLanceEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(`${user.name} gains protection.`);
+	return results.concat(`${user.name} gains protection.`);
 }
 //#endregion Bashing
 
@@ -121,11 +121,11 @@ function juggernautsLanceEffect(targets, user, adventure) {
 	}
 	addProtection([user], pendingProtection);
 	addProtection([user], pendingProtection);
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(`${user.name} gains protection.`);
+	return results.concat(`${user.name} gains protection.`);
 }
 //#endregion Juggernaut's
 
@@ -152,8 +152,8 @@ function tauntingLanceEffect([target], user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection([user], pendingProtection);
-	const { resultLines, survivors } = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
-	resultLines.push(`${user.name} gains protection.`);
+	const { results, survivors } = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
+	results.push(`${user.name} gains protection.`);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
@@ -162,10 +162,10 @@ function tauntingLanceEffect([target], user, adventure) {
 		const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 		if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 			targetMove.targets = [{ team: user.team, index: adventure.getCombatantIndex(user) }];
-			resultLines.push(`${target.name} falls for the provocation.`);
+			results.push(`${target.name} falls for the provocation.`);
 		}
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Taunting
 

--- a/source/gear/life-drain.js
+++ b/source/gear/life-drain.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { gainHealth, dealDamage, changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { gainHealth, dealDamage, changeStagger, addModifier, downedCheck } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -25,11 +25,11 @@ function lifeDrainEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(gainHealth(user, pendingHealing, adventure));
+	return results.concat(gainHealth(user, pendingHealing, adventure));
 }
 //#endregion Base
 
@@ -56,11 +56,11 @@ function fatiguingLifeDrainEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier(survivors, impotence)), gainHealth(user, pendingHealing, adventure));
+	return results.concat(addModifier(survivors, impotence), gainHealth(user, pendingHealing, adventure));
 }
 //#endregion Fatiguing
 
@@ -92,11 +92,11 @@ function furiousLifeDrainEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(gainHealth(user, pendingHealing, adventure));
+	return results.concat(gainHealth(user, pendingHealing, adventure));
 }
 //#endregion Furious
 
@@ -122,16 +122,16 @@ function reapersLifeDrainEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const { resultLines } = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
+	const { results } = dealDamage([target], user, damage.calculate(user), false, essence, adventure);
 	if (target.hp > (user.getDamageCap() / 2)) {
 		target.hp = 0;
-		const { extraLines } = downedCheck(target, adventure);
-		return [`${target.name} meets the reaper!`].concat(extraLines, gainHealth(user, pendingHealing, adventure));
+		const downedLinesSansGeneric = downedCheck(target, adventure).slice(1);
+		return [`${target.name} meets the reaper!`, ...downedLinesSansGeneric, gainHealth(user, pendingHealing, adventure)];
 	} else {
 		if (user.essence === essence) {
 			changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		return resultLines.concat(gainHealth(user, pendingHealing, adventure));
+		return results.concat(gainHealth(user, pendingHealing, adventure));
 	}
 }
 //#endregion Reaper's
@@ -159,14 +159,14 @@ function thirstingLifeDrainEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingHealing *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
 		pendingHealing += thirstingHealing.calculate(user);
 	}
-	return resultLines.concat(gainHealth(user, pendingHealing, adventure));
+	return results.concat(gainHealth(user, pendingHealing, adventure));
 }
 //#endregion Thirsting
 

--- a/source/gear/lightning-staff.js
+++ b/source/gear/lightning-staff.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, dealDamage, generateModifierResultLines, combineModifierReceipts, removeModifier, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, removeModifier, addModifier } = require('../util/combatantUtil');
 
 const bounces = 3;
 
@@ -30,11 +30,11 @@ function lightningStaffEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -64,21 +64,20 @@ function disenchantingLightningStaffEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const receipts = [];
 	for (const target of survivors) {
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 		if (targetBuffs.length > 0) {
 			for (let i = 0; i < buffRemovals; i++) {
 				const [selectedBuff] = targetBuffs.splice(user.roundRns(`${disenchantingLightningStaff.name}${SAFE_DELIMITER}buffs`), 1);
-				receipts.push(...removeModifier([target], { name: selectedBuff, stacks: "all" }));
+				results.push(...removeModifier([target], { name: selectedBuff, stacks: "all" }));
 			}
 		}
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return results;
 }
 //#endregion Disenchanting
 
@@ -108,11 +107,11 @@ function hexingLightningStaffEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(addModifier(survivors, misfortune));
+	return results.concat(addModifier(survivors, misfortune));
 }
 //#endregion Hexing
 

--- a/source/gear/longsword.js
+++ b/source/gear/longsword.js
@@ -28,15 +28,15 @@ function longswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(user)}`, "levelsGained", "loot", levelUps);
-		resultLines.push(`${user.name} gains a level.`);
+		results.push(`${user.name} gains a level.`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -64,17 +64,17 @@ function doubleLongswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines: firstresultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const { resultLines: secondresultLines, survivors: finalSurvivors } = dealDamage(survivors, user, pendingDamage, false, essence, adventure);
-	const allresultLines = firstresultLines.concat(secondresultLines);
+	const { results: firstResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: secondResults, survivors: finalSurvivors } = dealDamage(survivors, user, pendingDamage, false, essence, adventure);
+	const allResults = firstResults.concat(secondResults);
 	if (user.essence === essence) {
 		changeStagger(finalSurvivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (finalSurvivors.length < targets.length) {
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(user)}`, "levelsGained", "loot", levelUps);
-		allresultLines.push(`${user.name} gains a level.`);
+		allResults.push(`${user.name} gains a level.`);
 	}
-	return allresultLines;
+	return allResults;
 }
 //#endregion Double
 
@@ -102,15 +102,15 @@ function lethalLongswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
 		adventure.room.addResource(`levelsGained${SAFE_DELIMITER}${adventure.getCombatantIndex(user)}`, "levelsGained", "loot", levelUps);
-		resultLines.push(`${user.name} gains a level.`);
+		results.push(`${user.name} gains a level.`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Lethal
 

--- a/source/gear/medicine.js
+++ b/source/gear/medicine.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY, SAFE_DELIMITER } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, removeModifier } = require('../util/combatantUtil');
+const { changeStagger, removeModifier } = require('../util/combatantUtil');
 
 //#region Base
 const medicine = new GearTemplate("Medicine",
@@ -31,12 +31,12 @@ function medicineEffect([target], user, adventure) {
 		pendingCures *= critBonus;
 	}
 	const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	const receipts = [];
+	const results = [];
 	for (let i = 0; i < pendingCures; i++) {
 		const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${medicine.name}${SAFE_DELIMITER}Medicine`][i] % targetDebuffs.length, 1);
-		receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
+		results.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 	}
-	return generateModifierResultLines(combineModifierReceipts(receipts));
+	return results;
 }
 //#endregion Base
 
@@ -65,7 +65,7 @@ function hasteningMedicineEffect([target], user, adventure) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
 	let pendingCures = debuffsCured;
-	const resultLines = [];
+	const results = [];
 	if (user.crit) {
 		pendingCures *= critBonus;
 		let didCooldown = false;
@@ -76,16 +76,15 @@ function hasteningMedicineEffect([target], user, adventure) {
 			}
 		})
 		if (didCooldown) {
-			resultLines.push(`${target.name}'s cooldowns were hastened.`);
+			results.push(`${target.name}'s cooldowns were hastened.`);
 		}
 	}
 	const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	const receipts = [];
 	for (let i = 0; i < pendingCures; i++) {
 		const [selectedDebuff] = targetDebuffs.splice(user.roundRns[`${hasteningMedicine.name}${SAFE_DELIMITER}Medicine`][i] % targetDebuffs.length, 1);
-		receipts.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
+		results.push(...removeModifier([target], { name: selectedDebuff, stacks: "all" }));
 	}
-	return generateModifierResultLines(combineModifierReceipts(receipts)).concat(resultLines);
+	return results;
 }
 //#endregion Hastening
 

--- a/source/gear/medics-kit.js
+++ b/source/gear/medics-kit.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes/index.js');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary.js');
-const { removeModifier, changeStagger, combineModifierReceipts, generateModifierResultLines, addModifier } = require('../util/combatantUtil.js');
+const { removeModifier, changeStagger, addModifier } = require('../util/combatantUtil.js');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_ALLY } = require('../constants.js');
 
 //#region Base
@@ -27,21 +27,20 @@ function medicsKitEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	const receipts = [];
+	const results = [];
 	for (const target of targets) {
 		const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		const debuffsToRemove = Math.min(targetDebuffs.length, debuffsCured);
 		for (let i = 0; i < debuffsToRemove; i++) {
 			const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${medicsKit.name}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
-			receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
+			results.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 		}
 	}
-	const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 	if (user.crit) {
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!");
+		results.push("The party's morale is increased!");
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -68,21 +67,20 @@ function cleansingMedicsKitEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	const receipts = [];
+	const results = [];
 	for (const target of targets) {
 		const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		const debuffsToRemove = Math.min(targetDebuffs.length, debuffsCured);
 		for (let i = 0; i < debuffsToRemove; i++) {
 			const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${cleansingMedicsKit.name}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
-			receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
+			results.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 		}
 	}
-	const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 	if (user.crit) {
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!");
+		results.push("The party's morale is increased!");
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Cleansing
 
@@ -110,21 +108,20 @@ function warningMedicsKitEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_ALLY);
 	}
-	const receipts = addModifier(targets, evasion);
+	const results = addModifier(targets, evasion);
 	for (const target of targets) {
 		const targetDebuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		const debuffsToRemove = Math.min(targetDebuffs.length, debuffsCured);
 		for (let i = 0; i < debuffsToRemove; i++) {
 			const [rolledDebuff] = targetDebuffs.splice(user.roundRns[`${warningMedicsKit.name}${SAFE_DELIMITER}debuffs`][i] % targetDebuffs.length, 1);
-			receipts.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
+			results.push(...removeModifier([target], { name: rolledDebuff, stacks: "all" }));
 		}
 	}
-	const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 	if (user.crit) {
 		adventure.room.morale += morale;
-		resultLines.push("The party's morale is increased!");
+		results.push("The party's morale is increased!");
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Warning
 

--- a/source/gear/midas-staff.js
+++ b/source/gear/midas-staff.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { discountedPassive } = require('./shared/passiveDescriptions');
 
 //#region Base
@@ -27,7 +27,7 @@ function midasStaffEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingCurse.stacks += critBonus;
 	}
-	return generateModifierResultLines(addModifier(targets, pendingCurse));
+	return addModifier(targets, pendingCurse);
 }
 //#endregion Base
 
@@ -55,7 +55,7 @@ function acceleratingMidasStaffEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingCurse.stacks += critBonus;
 	}
-	return generateModifierResultLines(addModifier(targets, pendingCurse).concat(addModifier(targets, swiftness)));
+	return addModifier(targets, pendingCurse).concat(addModifier(targets, swiftness));
 }
 //#endregion Accelerating
 

--- a/source/gear/musket.js
+++ b/source/gear/musket.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 const { discountedPassive } = require('./shared/passiveDescriptions');
 
@@ -20,7 +20,7 @@ const musket = new GearTemplate("Musket",
 /** @type {typeof musket.effect} */
 function musketEffect(targets, user, adventure) {
 	const { essence, scalings: { damage }, cooldown } = musket;
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -28,9 +28,9 @@ function musketEffect(targets, user, adventure) {
 		const move = adventure.room.findCombatantMove({ team: user.team, index: adventure.getCombatantIndex(user) });
 		const [_, gearIndex] = move.name.split(SAFE_DELIMITER);
 		user.gear[gearIndex].cooldown = -1 * cooldown;
-		resultLines.push(`${user.name} reloads their ${musket.name} immediately!`);
+		results.push(`${user.name} reloads their ${musket.name} immediately!`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -66,20 +66,20 @@ const huntersMusket = new GearTemplate("Hunter's Musket",
 /** @type {typeof huntersMusket.effect} */
 function huntersMusketEffect(targets, user, adventure) {
 	const { essence, scalings: { damage }, cooldown, modifiers: [empowerment] } = huntersMusket;
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
-		resultLines.push(...generateModifierResultLines(addModifier([user], empowerment)));
+		results.push(...addModifier([user], empowerment));
 	}
 	if (user.crit && user.gear) {
 		const move = adventure.room.findCombatantMove({ team: user.team, index: adventure.getCombatantIndex(user) });
 		const [_, gearIndex] = move.name.split(SAFE_DELIMITER);
 		user.gear[gearIndex].cooldown = -1 * cooldown;
-		resultLines.push(`${user.name} reloads their ${huntersMusket.name} immediately!`);
+		results.push(`${user.name} reloads their ${huntersMusket.name} immediately!`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Hunter's
 module.exports = new GearFamily(musket, [discountedMusket, huntersMusket], false);

--- a/source/gear/natures-caprice.js
+++ b/source/gear/natures-caprice.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { accuratePassive, heartyPassive } = require('./shared/passiveDescriptions');
 
 //#region Base
@@ -23,9 +23,9 @@ function naturesCapriceEffect(targets, user, adventure) {
 		changeStagger(targets, user, user.team === targets[0].team ? ESSENCE_MATCH_STAGGER_ALLY : ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		return generateModifierResultLines(addModifier(targets, misfortune));
+		return addModifier(targets, misfortune);
 	} else {
-		return generateModifierResultLines(addModifier(targets, fortune));
+		return addModifier(targets, fortune);
 	}
 }
 //#region Base

--- a/source/gear/net-launcher.js
+++ b/source/gear/net-launcher.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, dealDamage, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { scalingTorpidity } = require('./shared/modifiers');
 const { damageScalingGenerator } = require('./shared/scalings');
 
@@ -26,7 +26,7 @@ function netLauncherEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -38,7 +38,7 @@ function netLauncherEffect(targets, user, adventure) {
 			torpidityTargets = adventure.delvers;
 		}
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) }))));
+	return results.concat(addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) }));
 }
 //#endregion Base
 
@@ -63,7 +63,7 @@ function thiefsNetLauncherEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -78,9 +78,9 @@ function thiefsNetLauncherEffect(targets, user, adventure) {
 	if (survivors.length < targets.length) {
 		const totalBounty = (targets.length - survivors.length) * bounty;
 		adventure.room.addResource("Gold", "Currency", "loot", totalBounty);
-		resultLines.push(`${user.name} pillages ${totalBounty}g.`);
+		results.push(`${user.name} pillages ${totalBounty}g.`);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) }))));
+	return results.concat(addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) }));
 }
 //#endregion Thief's
 
@@ -105,7 +105,7 @@ function tormentingNetLauncherEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -117,15 +117,15 @@ function tormentingNetLauncherEffect(targets, user, adventure) {
 			torpidityTargets = adventure.delvers;
 		}
 	}
-	const receipts = addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) });
+	results.push(addModifier(torpidityTargets, { name: torpidity.name, stacks: torpidity.stacks.calculate(user) }));
 	for (const target of survivors) {
 		for (const modifier in target.modifiers) {
 			if (getModifierCategory(modifier) === "Debuff") {
-				receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+				results.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 			}
 		}
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return results;
 }
 //#endregion Tormenting
 

--- a/source/gear/overburn-explosion.js
+++ b/source/gear/overburn-explosion.js
@@ -28,7 +28,7 @@ function overburnExplosionEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -36,9 +36,9 @@ function overburnExplosionEffect(targets, user, adventure) {
 		for (const gear of user.gear) {
 			gear.cooldown += pactCost[0];
 		}
-		resultLines.push(`${user.name} is burnt out.`);
+		results.push(`${user.name} is burnt out.`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -87,7 +87,7 @@ function unstoppableOverburnExplosionEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, true, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, true, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -95,9 +95,9 @@ function unstoppableOverburnExplosionEffect(targets, user, adventure) {
 		for (const gear of user.gear) {
 			gear.cooldown += pactCost[0];
 		}
-		resultLines.push(`${user.name} is burnt out.`);
+		results.push(`${user.name} is burnt out.`);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Unstoppable
 

--- a/source/gear/parrying-dagger.js
+++ b/source/gear/parrying-dagger.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, addProtection, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
 const { protectionScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -31,7 +31,7 @@ function parryingDaggerEffect(targets, user, adventure) {
 		pendingFinesse.stacks *= critBonus;
 	}
 	addProtection([user], protection.calculate(user));
-	return [`${user.name} gains protection.`].concat(generateModifierResultLines(addModifier([user], pendingFinesse)));
+	return [`${user.name} gains protection.`].concat(addModifier([user], pendingFinesse));
 }
 //#endregion Base
 
@@ -63,7 +63,7 @@ function devotedParryingDaggerEffect(targets, user, adventure) {
 		pendingFinesse.stacks *= critBonus;
 	}
 	addProtection(targets, protection.calculate(user));
-	return [`${targets[0].name} gains protection.`].concat(generateModifierResultLines(addModifier(targets, pendingFinesse)));
+	return [`${targets[0].name} gains protection.`].concat(addModifier(targets, pendingFinesse));
 }
 //#endregion Devoted
 
@@ -104,9 +104,9 @@ function hasteningParryingDaggerEffect(targets, user, adventure) {
 	}
 	addProtection([user], protection.calculate(user));
 	if (didCooldown) {
-		return [`${user.name} gains protection and hastens their cooldowns.`].concat(generateModifierResultLines(addModifier([user], pendingFinesse)));
+		return [`${user.name} gains protection and hastens their cooldowns.`].concat(addModifier([user], pendingFinesse));
 	} else {
-		return [`${user.name} gains protection.`].concat(generateModifierResultLines(addModifier([user], pendingFinesse)));
+		return [`${user.name} gains protection.`].concat(addModifier([user], pendingFinesse));
 	}
 }
 //#endregion Hastening

--- a/source/gear/reveal-flaw.js
+++ b/source/gear/reveal-flaw.js
@@ -1,8 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { essenceList } = require('../util/essenceUtil');
-const { joinAsStatement } = require('../util/textUtil');
 
 //#region Base
 const revealFlaw = new GearTemplate("Reveal Flaw",
@@ -28,19 +27,14 @@ function revealFlawEffect(targets, user, adventure) {
 
 	const essencePool = essenceList(["Unaligned"]);
 	const selectedEsesnce = essencePool[user.roundRns[`${revealFlaw.name}${SAFE_DELIMITER}vulnerabilities`][0] % 6];
-	const resultLines = generateModifierResultLines(combineModifierReceipts(addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks })));
-	let pendingStagger = 0;
+	const results = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
 	if (user.essence === essence) {
-		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
+		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		pendingStagger += critBonus;
-		resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));
+		results.push(changeStagger(targets, user, critBonus));
 	}
-	if (pendingStagger > 0) {
-		changeStagger(targets, user, pendingStagger);
-	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -68,21 +62,15 @@ function distractingRevealFlawEffect(targets, user, adventure) {
 
 	const essencePool = essenceList(["Unaligned"]);
 	const selectedEsesnce = essencePool[user.roundRns[`${distractingRevealFlaw.name}${SAFE_DELIMITER}vulnerabilities`][0] % 6];
-	const receipts = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
-	receipts.push(...addModifier(targets, distraction));
-	const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
-	let pendingStagger = 0;
+	const results = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
+	results.push(...addModifier(targets, distraction));
 	if (user.essence === essence) {
-		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
+		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		pendingStagger += critBonus;
-		resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));
+		results.push(changeStagger(targets, user, critBonus));
 	}
-	if (pendingStagger > 0) {
-		changeStagger(targets, user, pendingStagger);
-	}
-	return resultLines;
+	return results;
 }
 //#endregion Distracting
 
@@ -110,21 +98,15 @@ function numbingRevealFlawEffect(targets, user, adventure) {
 
 	const essencePool = essenceList(["Unaligned"]);
 	const selectedEsesnce = essencePool[user.roundRns[`${numbingRevealFlaw.name}${SAFE_DELIMITER}vulnerabilities`][0] % 6];
-	const receipts = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
-	receipts.push(...addModifier(targets, clumsiness));
-	const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
-	let pendingStagger = 0;
+	const results = addModifier(targets, { name: `${selectedEsesnce} Vulnerability`, stacks: vulnerability.stacks });
+	results.push(...addModifier(targets, clumsiness));
 	if (user.essence === essence) {
-		pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
+		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		pendingStagger += critBonus;
-		resultLines.push(joinAsStatement(false, targets.map(target => target.name), "was", "were", "Staggered."));
+		results.push(changeStagger(targets, user, critBonus));
 	}
-	if (pendingStagger > 0) {
-		changeStagger(targets, user, pendingStagger);
-	}
-	return resultLines;
+	return results;
 }
 //#endregion Numbing
 

--- a/source/gear/reveal-flaw.js
+++ b/source/gear/reveal-flaw.js
@@ -32,7 +32,7 @@ function revealFlawEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		results.push(changeStagger(targets, user, critBonus));
+		results.push(...changeStagger(targets, user, critBonus));
 	}
 	return results;
 }
@@ -68,7 +68,7 @@ function distractingRevealFlawEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		results.push(changeStagger(targets, user, critBonus));
+		results.push(...changeStagger(targets, user, critBonus));
 	}
 	return results;
 }
@@ -104,7 +104,7 @@ function numbingRevealFlawEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (user.crit) {
-		results.push(changeStagger(targets, user, critBonus));
+		results.push(...changeStagger(targets, user, critBonus));
 	}
 	return results;
 }

--- a/source/gear/sandstorm-formation.js
+++ b/source/gear/sandstorm-formation.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, addModifier, generateModifierResultLines, combineModifierReceipts } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { listifyEN } = require('../util/textUtil');
 
 //#region Base
@@ -40,15 +40,15 @@ function sandstormFormationEffect(targets, user, adventure) {
 			hadCooldowns.push(target.name);
 		}
 	}
-	const resultLines = [];
+	const results = [];
 	if (hadCooldowns.length > 0) {
-		resultLines.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
+		results.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
 	}
 	if (user.crit) {
-		resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(targets, impact))));
+		results.push(...addModifier(targets, impact));
 	}
-	if (resultLines.length > 0) {
-		return resultLines;
+	if (results.length > 0) {
+		return results;
 	} else {
 		return ["...but nothing happened."];
 	}
@@ -92,16 +92,15 @@ function balancedSandstormFormationEffect(targets, user, adventure) {
 			hadCooldowns.push(target.name);
 		}
 	}
-	const resultLines = [];
+	const results = [];
 	if (hadCooldowns.length > 0) {
-		resultLines.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
+		results.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
 	}
-	const receipts = [];
 	if (user.crit) {
-		receipts.push(...addModifier(targets, impact));
+		results.push(...addModifier(targets, impact));
 	}
-	receipts.push(...addModifier(targets, finesse));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	results.push(...addModifier(targets, finesse));
+	return results;
 }
 //#endregion Balanced
 
@@ -142,16 +141,15 @@ function soothingSandstormFormationEffect(targets, user, adventure) {
 			hadCooldowns.push(target.name);
 		}
 	}
-	const resultLines = [];
+	const results = [];
 	if (hadCooldowns.length > 0) {
-		resultLines.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
+		results.push(`${listifyEN(hadCooldowns)} had their cooldowns hastened.`);
 	}
-	const receipts = [];
 	if (user.crit) {
-		receipts.push(...addModifier(targets, impact));
+		results.push(...addModifier(targets, impact));
 	}
-	receipts.push(...addModifier(targets, regeneration));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	results.push(...addModifier(targets, regeneration));
+	return results;
 }
 //#endregion Soothing
 

--- a/source/gear/shadow-of-confusion.js
+++ b/source/gear/shadow-of-confusion.js
@@ -1,6 +1,6 @@
 const { GearTemplate, Move, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingEvasion } = require('./shared/modifiers');
 
 //#region Base
@@ -22,17 +22,17 @@ function shadowOfConfusionEffect([target], user, adventure) {
 	if (user.essence === essence) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const resultLines = [];
+	const results = [];
 	const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
 	const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 	if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 		targetMove.targets = [{ team: target.team, index: adventure.getCombatantIndex(target) }];
-		resultLines.push(`${target.name} is redirected into targeting themself.`);
+		results.push(`${target.name} is redirected into targeting themself.`);
 	}
 	if (user.crit) {
-		resultLines.push(...generateModifierResultLines(addModifier([user], { name: evade.name, stacks: evade.stacks.calculate(user) })));
+		results.push(...addModifier([user], { name: evade.name, stacks: evade.stacks.calculate(user) }));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -55,17 +55,17 @@ function incompatibleShadowOfConfusionEffect([target], user, adventure) {
 	if (user.essence === essence) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const resultLines = [];
+	const results = [];
 	const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
 	const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 	if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 		targetMove.targets = [{ team: target.team, index: adventure.getCombatantIndex(target) }];
-		resultLines.push(`${target.name} is redirected into targeting themself.`);
+		results.push(`${target.name} is redirected into targeting themself.`);
 	}
 	if (user.crit) {
-		resultLines.push(...generateModifierResultLines(addModifier([user], { name: evade.name, stacks: evade.stacks.calculate(user) })));
+		results.push(...addModifier([user], { name: evade.name, stacks: evade.stacks.calculate(user) }));
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([target], incompatible)));
+	return results.concat(addModifier([target], incompatible));
 }
 //#endregion Incompatible
 
@@ -88,17 +88,17 @@ function shatteringShadowOfConfusionEffect([target], user, adventure) {
 	if (user.essence === essence) {
 		changeStagger([target], user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const resultLines = [];
+	const results = [];
 	const targetMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(target), team: target.team });
 	const userMove = adventure.room.findCombatantMove({ index: adventure.getCombatantIndex(user), team: user.team });
 	if (targetMove.targets.length === 1 && Move.compareMoveSpeed(userMove, targetMove) < 0) {
 		targetMove.targets = [{ team: target.team, index: adventure.getCombatantIndex(target) }];
-		resultLines.push(`${target.name} is redirected into targeting themself.`);
+		results.push(`${target.name} is redirected into targeting themself.`);
 	}
 	if (user.crit) {
-		resultLines.push(...generateModifierResultLines(addModifier([user], { name: evade.name, stacks: evade.stacks.calculate(user) })));
+		results.push(...addModifier([user], { name: evade.name, stacks: evade.stacks.calculate(user) }));
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([target], frailty)));
+	return results.concat(addModifier([target], frailty));
 }
 //#endregion Shattering
 

--- a/source/gear/shortsword.js
+++ b/source/gear/shortsword.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -25,11 +25,11 @@ function shortswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse)));
+	return results.concat(addModifier([user], finesse));
 }
 //#endregion Base
 
@@ -55,11 +55,11 @@ function flankingShortswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(survivors, exposure))));
+	return results.concat(addModifier([user], finesse), addModifier(survivors, exposure));
 }
 //#endregion Flanking
 
@@ -85,11 +85,11 @@ function hexingShortswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(survivors, misfortune))));
+	return results.concat(addModifier([user], finesse), addModifier(survivors, misfortune));
 }
 //#endregion Hexing
 
@@ -115,11 +115,11 @@ function midassShortswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier(survivors, curseOfMidas))));
+	return results.concat(addModifier([user], finesse), addModifier(survivors, curseOfMidas));
 }
 //#endregion Midas's
 
@@ -145,11 +145,11 @@ function vigilantShortswordEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([user], finesse).concat(addModifier([user], vigilance))));
+	return results.concat(addModifier([user], finesse), addModifier([user], vigilance));
 }
 //#endregion Vigilant
 

--- a/source/gear/smokescreen.js
+++ b/source/gear/smokescreen.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingEvasion } = require('./shared/modifiers');
 
 const bounces = 3;
@@ -30,7 +30,7 @@ function smokescreenEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingEvasion.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingEvasion)));
+	return addModifier(targets, pendingEvasion);
 }
 //#endregion Base
 
@@ -76,7 +76,7 @@ function doubleSmokescreenEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingEvasion.stacks *= critBonus;
 	}
-	return generateModifierResultLines(combineModifierReceipts(addModifier(targets, pendingEvasion)));
+	return addModifier(targets, pendingEvasion);
 }
 //#endregion Double
 

--- a/source/gear/spiked-shield.js
+++ b/source/gear/spiked-shield.js
@@ -28,11 +28,11 @@ function spikedShieldEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -61,11 +61,11 @@ function furiousSpikedShieldEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Furious
 
@@ -93,11 +93,11 @@ function reinforcedSpikedShieldEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Reinforced
 

--- a/source/gear/steam-wall.js
+++ b/source/gear/steam-wall.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_ALLY } = require('../constants');
-const { changeStagger, addProtection, generateModifierResultLines, combineModifierReceipts, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addProtection, addModifier } = require('../util/combatantUtil');
 const { joinAsStatement } = require('../util/textUtil');
 const { protectionScalingGenerator } = require('./shared/scalings');
 
@@ -71,9 +71,7 @@ function supportiveSteamWallEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection(targets, pendingProtection);
-	changeStagger(targets, user, staggerRelief);
-	const targetNames = targets.map(target => target.name);
-	return [joinAsStatement(false, targetNames, "gains", "gain", "protection."), joinAsStatement(false, targetNames, "is", "are", "relieved of Stagger.")];
+	return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...changeStagger(targets, user, staggerRelief)];
 }
 //#endregion Supportive
 
@@ -109,7 +107,7 @@ function vigilantSteamWallEffect(targets, user, adventure) {
 		pendingProtection *= critBonus;
 	}
 	addProtection(targets, pendingProtection);
-	return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection.")].concat(generateModifierResultLines(combineModifierReceipts(addModifier(targets, vigilance))));
+	return [joinAsStatement(false, targets.map(target => target.name), "gains", "gain", "protection."), ...addModifier(targets, vigilance)];
 }
 //#endregion Vigilant
 

--- a/source/gear/stick.js
+++ b/source/gear/stick.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { SAFE_DELIMITER, ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { dealDamage, generateModifierResultLines, addModifier, combineModifierReceipts, changeStagger, removeModifier } = require('../util/combatantUtil');
+const { dealDamage, addModifier, changeStagger, removeModifier } = require('../util/combatantUtil');
 const { archetypeActionDamageScaling } = require('./shared/scalings');
 
 //#region Base
@@ -18,11 +18,11 @@ const stick = new GearTemplate("Stick",
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, impotence))));
+	return results.concat(addModifier(survivors, impotence));
 }, { type: "single", team: "foe" })
 	.setScalings({
 		damage: archetypeActionDamageScaling,
@@ -57,14 +57,14 @@ function convalescenceStickEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const receipts = addModifier(survivors, impotence);
+	results.push(...addModifier(survivors, impotence));
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	receipts.push(...removeModifier([user], { name: userDebuffs[user.roundRns[`${convalescenceStick.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	results.push(...removeModifier([user], { name: userDebuffs[user.roundRns[`${convalescenceStick.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
+	return results;
 }
 //#endregion Convalescence
 
@@ -90,11 +90,11 @@ function flankingStickEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, impotence), addModifier(survivors, exposure))));
+	return results.concat(addModifier(survivors, impotence), addModifier(survivors, exposure));
 }
 //#endregion Flanking
 
@@ -120,16 +120,14 @@ function huntersStickEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
-	const receipts = [];
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
-		receipts.push(...addModifier([user], empowerment));
+		results.push(...addModifier([user], empowerment));
 	}
-	receipts.push(...addModifier(survivors, impotence));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return results.concat(addModifier(survivors, impotence));
 }
 //#endregion Hunter's
 
@@ -156,15 +154,15 @@ function thiefsStickEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	if (survivors.length < targets.length) {
 		adventure.room.addResource("Gold", "Currency", "loot", bounty);
-		resultLines.push(`${user.name} pillages ${bounty}g.`);
+		results.push(`${user.name} pillages ${bounty}g.`);
 	}
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(addModifier(survivors, impotence))));
+	return results.concat(addModifier(survivors, impotence));
 }
 //#endregion Thief's
 

--- a/source/gear/sword-of-the-sun.js
+++ b/source/gear/sword-of-the-sun.js
@@ -1,7 +1,7 @@
-const { GearTemplate, GearFamily, ModifierReceipt } = require('../classes');
+const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { dealDamage, changeStagger, combineModifierReceipts, removeModifier, generateModifierResultLines } = require('../util/combatantUtil');
+const { dealDamage, changeStagger, removeModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 const targetingTags = { type: "single", team: "foe" };
@@ -25,29 +25,25 @@ const swordOfTheSun = new GearTemplate("Sword of the Sun",
 /** @type {typeof swordOfTheSun.effect} */
 function swordOfTheSunEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus } } = swordOfTheSun;
-	const totalResultLines = [];
+	const results = [];
 	for (const target of targets) {
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		/** @type {ModifierReceipt[]} */
-		const removedBuffReceipts = [];
 		targetBuffs.forEach(buffName => {
-			removedBuffReceipts.push(...removeModifier([target], { name: buffName, stacks: "all" }))
+			results.push(...removeModifier([target], { name: buffName, stacks: "all" }))
 		})
-		const combinedReceipts = combineModifierReceipts(removedBuffReceipts)
-		totalResultLines.push(...generateModifierResultLines(combinedReceipts));
 
 		let pendingDamage = damage.calculate(user) + 30 * combinedReceipts.reduce((total, receipt) => total + receipt.succeeded.size, 0);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
-		totalResultLines.push(...resultLines)
+		const { results: damageResults, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		results.push(...damageResults)
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 	}
 
-	return totalResultLines;
+	return results;
 }
 //#endregion Base
 
@@ -70,29 +66,25 @@ const lethalSwordOfTheSun = new GearTemplate("Lethal Sword of the Sun",
 /** @type {typeof lethalSwordOfTheSun.effect} */
 function lethalSwordOfTheSunEffect(targets, user, adventure) {
 	const { essence, scalings: { damage, critBonus } } = lethalSwordOfTheSun;
-	const totalResultLines = [];
+	const results = [];
 	for (const target of targets) {
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		/** @type {ModifierReceipt[]} */
-		const removedBuffReceipts = [];
 		targetBuffs.forEach(buffName => {
-			removedBuffReceipts.push(...removeModifier([target], { name: buffName, stacks: "all" }))
+			results.push(...removeModifier([target], { name: buffName, stacks: "all" }))
 		})
-		const combinedReceipts = combineModifierReceipts(removedBuffReceipts)
-		totalResultLines.push(...generateModifierResultLines(combinedReceipts));
 
 		let pendingDamage = damage.calculate(user) + 30 * combinedReceipts.reduce((total, receipt) => total + receipt.succeeded.size, 0);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
-		totalResultLines.push(...resultLines)
+		const { results: damageResults, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		results.push(...damageResults)
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
 	}
 
-	return totalResultLines;
+	return results;
 }
 //#endregion Lethal
 
@@ -116,24 +108,20 @@ const thiefsSwordOfTheSun = new GearTemplate("Thief's Sword of the Sun",
 
 /** @type {typeof thiefsSwordOfTheSun.effect} */
 function thiefsSwordOfTheSunEffect(targets, user, adventure) {
-	const totalResultLines = [];
+	const results = [];
 	for (const target of targets) {
 		const targetBuffs = Object.keys(target.modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
-		/** @type {ModifierReceipt[]} */
-		const removedBuffReceipts = [];
 		targetBuffs.forEach(buffName => {
-			removedBuffReceipts.push(...removeModifier([target], { name: buffName, stacks: "all" }))
+			results.push(...removeModifier([target], { name: buffName, stacks: "all" }))
 		})
-		const combinedReceipts = combineModifierReceipts(removedBuffReceipts)
-		totalResultLines.push(...generateModifierResultLines(combinedReceipts));
 
 		const { essence, scalinge: { damage, critBonus } } = thiefsSwordOfTheSun;
 		let pendingDamage = damage.calculate(user) + 30 * combinedReceipts.reduce((total, receipt) => total + receipt.succeeded.size, 0);
 		if (user.crit) {
 			pendingDamage *= critBonus;
 		}
-		const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
-		totalResultLines.push(...resultLines)
+		const { results: damageResults, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+		results.push(...damageResults)
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
@@ -142,9 +130,9 @@ function thiefsSwordOfTheSunEffect(targets, user, adventure) {
 	const { bounty } = thiefsSwordOfTheSun.scalings
 	if (targets.find(t => t.hp <= 0) !== undefined) {
 		adventure.room.addResource("Gold", "Currency", "loot", bounty);
-		totalResultLines.push(`${user.name} pillages ${bounty}g.`);
+		results.push(`${user.name} pillages ${bounty}g.`);
 	}
-	return totalResultLines
+	return results
 }
 //#endregion Thief's
 

--- a/source/gear/tempestuous-wrath.js
+++ b/source/gear/tempestuous-wrath.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily, Scaling } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
-const { dealDamage, payHP, changeStagger, addModifier, generateModifierResultLines } = require('../util/combatantUtil');
+const { dealDamage, payHP, changeStagger, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 /** @type {(variantName: string) => ({ name: "Empowerment", stacks: Scaling })} */
@@ -37,16 +37,16 @@ const tempestuousWrath = new GearTemplate("Tempestuous Wrath",
 /** @type {typeof tempestuousWrath.effect} */
 function tempestuousWrathEffect(targets, user, adventure) {
 	const { essence, modifiers: [empowerment], scalings: { damage, critBonus } } = tempestuousWrath;
-	const resultLines = generateModifierResultLines(addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) }));
+	const results = addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) });
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(damageResults, payHP(user, user.modifiers.Empowerment, adventure));
+	return results.concat(damageResults, payHP(user, user.modifiers.Empowerment, adventure));
 }
 //#endregion Base
 
@@ -70,16 +70,16 @@ const flankingTempestuousWrath = new GearTemplate("Flanking Tempestuous Wrath",
 /** @type {typeof flankingTempestuousWrath.effect} */
 function flankingTempestuousWrathEffect(targets, user, adventure) {
 	const { essence, modifiers: [empowerment, exposure], scalings: { damage, critBonus } } = flankingTempestuousWrath;
-	const resultLines = generateModifierResultLines(addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) }));
+	const results = addModifier([user], { name: empowerment.name, stacks: empowerment.stacks.calculate(user) });
 	let pendingDamage = damage.calculate(user);
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results: damageResults, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(damageResults, generateModifierResultLines(addModifier(survivors, exposure)), payHP(user, user.modifiers.Empowerment, adventure));
+	return results.concat(damageResults, addModifier(survivors, exposure), payHP(user, user.modifiers.Empowerment, adventure));
 }
 //#endregion Flanking
 

--- a/source/gear/tornado-formation.js
+++ b/source/gear/tornado-formation.js
@@ -1,7 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, addModifier, combineModifierReceipts, generateModifierResultLines } = require('../util/combatantUtil');
-const { joinAsStatement } = require('../util/textUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { scalingSwiftness } = require('./shared/modifiers');
 const { damageScalingGenerator } = require('./shared/scalings');
 
@@ -29,7 +28,7 @@ function tornadoFormationEffect(targets, user, adventure) {
 		return ["...but the party didn't have enough morale to pull it off."];
 	}
 
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -38,8 +37,7 @@ function tornadoFormationEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingSwiftness.stacks *= critBonus;
 	}
-	resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(userTeam, pendingSwiftness))));
-	return resultLines;
+	return results.concat(addModifier(userTeam, pendingSwiftness));
 }
 //#endregion Base
 
@@ -67,18 +65,16 @@ function chargingTornadoFormationEffect(targets, user, adventure) {
 		return ["...but the party didn't have enough morale to pull it off."];
 	}
 
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const receipts = [];
 	const pendingSwiftness = { name: swiftness.name, stacks: swiftness.stacks.calculate(user) };
 	const userTeam = user.team === "delver" ? adventure.delvers : adventure.room.enemies.filter(enemy => enemy.hp > 0);
 	if (user.crit) {
 		pendingSwiftness.stacks *= critBonus;
 	}
-	receipts.push(...addModifier(userTeam, pendingSwiftness).concat(addModifier(userTeam, empowerment)));
-	return resultLines.concat(generateModifierResultLines(combineModifierReceipts(receipts)));
+	return results.concat(addModifier(userTeam, pendingSwiftness), addModifier(userTeam, empowerment));
 }
 //#endregion Charging
 
@@ -107,7 +103,7 @@ function supportiveTornadoFormationEffect(targets, user, adventure) {
 		return ["...but the party didn't have enough morale to pull it off."];
 	}
 
-	const { resultLines, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, damage.calculate(user), false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
@@ -116,9 +112,7 @@ function supportiveTornadoFormationEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingStagger.stacks *= critBonus;
 	}
-	resultLines.push(...generateModifierResultLines(combineModifierReceipts(addModifier(userTeam, pendingStagger))));
-	changeStagger(userTeam, user, staggerRelief);
-	return resultLines.concat(joinAsStatement(false, userTeam.map(combatant => combatant.name), "is", "are", "relieved of Stagger."));
+	return results.concat(addModifier(userTeam, pendingStagger), changeStagger(userTeam, user, staggerRelief));
 }
 //#endregion Supportive
 

--- a/source/gear/trident.js
+++ b/source/gear/trident.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, dealDamage, generateModifierResultLines, removeModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, removeModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator, kineticDamageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -29,12 +29,12 @@ function tridentEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	return resultLines.concat(generateModifierResultLines(removeModifier([user], { name: userDebuffs[user.roundRns[`${trident.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" })));
+	return results.concat(removeModifier([user], { name: userDebuffs[user.roundRns[`${trident.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
 }
 //#endregion Base
 
@@ -63,12 +63,12 @@ function kineticTridentEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	return resultLines.concat(generateModifierResultLines(removeModifier([user], { name: userDebuffs[user.roundRns[`${kineticTrident.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" })));
+	return results.concat(removeModifier([user], { name: userDebuffs[user.roundRns[`${kineticTrident.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
 }
 //#endregion Kinetic
 
@@ -98,16 +98,17 @@ function staggeringTridentEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
+	results.push(...removeModifier([user], { name: userDebuffs[user.roundRns[`${staggeringTrident.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" }));
 	if (survivors.length > 0) {
 		let pendingStagger = stagger;
 		if (user.essence === essence) {
 			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 		}
-		changeStagger(survivors, user, pendingStagger);
+		results.push(changeStagger(survivors, user, pendingStagger));
 	}
-	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	return resultLines.concat(generateModifierResultLines(removeModifier([user], { name: userDebuffs[user.roundRns[`${staggeringTrident.name}${SAFE_DELIMITER}debuffs`][0] % userDebuffs.length], stacks: "all" })));
+	return results;
 }
 //#endregion Staggering
 

--- a/source/gear/trident.js
+++ b/source/gear/trident.js
@@ -106,7 +106,7 @@ function staggeringTridentEffect(targets, user, adventure) {
 		if (user.essence === essence) {
 			pendingStagger += ESSENCE_MATCH_STAGGER_FOE;
 		}
-		results.push(changeStagger(survivors, user, pendingStagger));
+		results.push(...changeStagger(survivors, user, pendingStagger));
 	}
 	return results;
 }

--- a/source/gear/universal-solution.js
+++ b/source/gear/universal-solution.js
@@ -1,7 +1,7 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
-const { changeStagger, generateModifierResultLines, combineModifierReceipts, addModifier, removeModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier, removeModifier } = require('../util/combatantUtil');
 
 const debuffsTransferred = 2;
 const poisonStacks = 3;
@@ -30,21 +30,20 @@ function universalSolutionEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	const receipts = [];
+	const results = [];
 	if (user.crit) {
 		for (const debuff of userDebuffs) {
-			receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-			receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+			results.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+			results.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 		}
 	} else {
 		for (let i = 0; i < debuffsTransferred; i++) {
 			const [debuff] = userDebuffs.splice(user.roundRns[`${universalSolution.name}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
-			receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-			receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+			results.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+			results.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 		}
 	}
-	receipts.push(...addModifier([user], poison))
-	return generateModifierResultLines(combineModifierReceipts(receipts));
+	return results.concat(addModifier([user], poison));
 }
 //#endregion Base
 
@@ -73,22 +72,20 @@ function centeringUniversalSolutionEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	const receipts = [];
+	const results = [];
 	if (user.crit) {
 		for (const debuff of userDebuffs) {
-			receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-			receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+			results.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+			results.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 		}
 	} else {
 		for (let i = 0; i < debuffsTransferred; i++) {
 			const [debuff] = userDebuffs.splice(user.roundRns[`${centeringUniversalSolution.name}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
-			receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-			receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+			results.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+			results.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 		}
 	}
-	changeStagger([user], user, staggerRelief);
-	receipts.push(...addModifier([user], poison));
-	return generateModifierResultLines(combineModifierReceipts(receipts)).concat(`${user.name} shrugs off some Stagger.`);
+	return results.concat(addModifier([user], poison), changeStagger([user], user, staggerRelief));
 }
 //#endregion Centering
 
@@ -117,28 +114,27 @@ function tormentingUniversalSolutionEffect(targets, user, adventure) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
 	const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
-	const receipts = [];
+	const results = [];
 	if (user.crit) {
 		for (const debuff of userDebuffs) {
-			receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-			receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+			results.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+			results.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 		}
 	} else {
 		for (let i = 0; i < debuffsTransferred; i++) {
 			const [debuff] = userDebuffs.splice(user.roundRns[`${tormentingUniversalSolution.name}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length, 1);
-			receipts.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
-			receipts.push(...removeModifier([user], { name: debuff, stacks: "all" }));
+			results.push(...addModifier(targets, { name: debuff, stacks: user.modifiers[debuff] }));
+			results.push(...removeModifier([user], { name: debuff, stacks: "all" }));
 		}
 	}
 	for (const target of targets) {
 		for (const modifier in target.modifiers) {
 			if (getModifierCategory(modifier) === "Debuff") {
-				receipts.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
+				results.push(...addModifier([target], { name: modifier, stacks: debuffIncrement }));
 			}
 		}
 	}
-	receipts.push(...addModifier([user], poison))
-	return generateModifierResultLines(combineModifierReceipts(receipts));
+	return results.concat(addModifier([user], poison));
 }
 //#endregion Tormenting
 

--- a/source/gear/vacuum-implosion.js
+++ b/source/gear/vacuum-implosion.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -33,11 +33,11 @@ function vacuumImplosionEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -72,11 +72,11 @@ function shatteringVacuumImplosionEffect([target], user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage([target], user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines.concat(generateModifierResultLines(addModifier([target], frailty)));
+	return results.concat(addModifier([target], frailty));
 }
 //#endregion Shattering
 

--- a/source/gear/vengeful-void.js
+++ b/source/gear/vengeful-void.js
@@ -1,6 +1,6 @@
 const { GearTemplate, Move, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -33,11 +33,11 @@ function vengefulVoidEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -72,14 +72,14 @@ function hexingVengefulVoidEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		resultLines.push(...generateModifierResultLines(addModifier(survivors, misfortune)));
+		results.push(...addModifier(survivors, misfortune));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Hexing
 
@@ -114,14 +114,14 @@ function numbingVengefulVoidEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		resultLines.push(...generateModifierResultLines(addModifier(survivors, clumsiness)));
+		results.push(...addModifier(survivors, clumsiness));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Numbing
 

--- a/source/gear/warhammer.js
+++ b/source/gear/warhammer.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, dealDamage, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, dealDamage, addModifier } = require('../util/combatantUtil');
 const { damageScalingGenerator } = require('./shared/scalings');
 
 //#region Base
@@ -30,11 +30,11 @@ function warhammerEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (user.essence === essence) {
 		changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -66,14 +66,14 @@ function fatiguingWarhammerEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		resultLines.push(...generateModifierResultLines(addModifier(survivors, impotence)));
+		results.push(...addModifier(survivors, impotence));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Fatiguing
 
@@ -105,14 +105,14 @@ function toxicWarhammerEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDamage *= critBonus;
 	}
-	const { resultLines, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
+	const { results, survivors } = dealDamage(targets, user, pendingDamage, false, essence, adventure);
 	if (survivors.length > 0) {
 		if (user.essence === essence) {
 			changeStagger(survivors, user, ESSENCE_MATCH_STAGGER_FOE);
 		}
-		resultLines.push(...generateModifierResultLines(addModifier(survivors, poison)));
+		results.push(...addModifier(survivors, poison));
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Toxic
 

--- a/source/gear/wave-crash.js
+++ b/source/gear/wave-crash.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE, SAFE_DELIMITER } = require('../constants');
-const { addModifier, generateModifierResultLines, dealDamage, changeStagger, removeModifier, combineModifierReceipts } = require('../util/combatantUtil');
+const { addModifier, dealDamage, changeStagger, removeModifier } = require('../util/combatantUtil');
 const { getModifierCategory } = require('../modifiers/_modifierDictionary');
 const { damageScalingGenerator } = require('./shared/scalings');
 
@@ -24,11 +24,11 @@ function waveCrashEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const resultLines = generateModifierResultLines(addModifier(targets, incompatibility));
+	const results = addModifier(targets, incompatibility);
 	if (user.crit) {
-		resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
+		results.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).results);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Base
 
@@ -56,19 +56,18 @@ function disenchantingWaveCrashEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const receipts = addModifier(targets, incompatibility);
+	const results = addModifier(targets, incompatibility);
 	const targetBuffs = Object.keys(targets[0].modifiers).filter(modifier => getModifierCategory(modifier) === "Buff");
 	if (targetBuffs.length > 0) {
 		for (let i = 0; i < pendingBuffRemovals; i++) {
 			const [selectedBuff] = targetBuffs.splice(user.roundRns(`${disenchantingWaveCrash.name}${SAFE_DELIMITER}buffs`), 1);
-			receipts.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
+			results.push(...removeModifier(targets, { name: selectedBuff, stacks: "all" }));
 		}
 	}
-	const resultLines = generateModifierResultLines(combineModifierReceipts(receipts));
 	if (user.crit) {
-		resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
+		results.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).results);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Disenchanting
 
@@ -92,11 +91,11 @@ function fatiguingWaveCrashEffect(targets, user, adventure) {
 	if (user.essence === essence) {
 		changeStagger(targets, user, ESSENCE_MATCH_STAGGER_FOE);
 	}
-	const resultLines = generateModifierResultLines(addModifier(targets, incompatibility).concat(addModifier(targets, impotence)));
+	const results = addModifier(targets, incompatibility).concat(addModifier(targets, impotence));
 	if (user.crit) {
-		resultLines.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).resultLines);
+		results.push(...dealDamage(targets, user, damage.calculate(user), false, essence, adventure).results);
 	}
-	return resultLines;
+	return results;
 }
 //#endregion Fatiguing
 

--- a/source/gear/wind-burst.js
+++ b/source/gear/wind-burst.js
@@ -1,6 +1,6 @@
 const { GearTemplate, GearFamily } = require('../classes');
 const { ESSENCE_MATCH_STAGGER_FOE } = require('../constants');
-const { changeStagger, generateModifierResultLines, addModifier } = require('../util/combatantUtil');
+const { changeStagger, addModifier } = require('../util/combatantUtil');
 const { scalingDistraction } = require('./shared/modifiers');
 
 //#region Base
@@ -27,7 +27,7 @@ function windBurstEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDistraction.stacks *= critBonus;
 	}
-	return generateModifierResultLines(addModifier(targets, pendingDistraction));
+	return addModifier(targets, pendingDistraction);
 }
 //#endregion Base
 
@@ -59,7 +59,7 @@ function inspiringWindBurstEffect(targets, user, adventure) {
 		pendingDistraction.stacks *= critBonus;
 	}
 	adventure.room.morale += morale;
-	return generateModifierResultLines(addModifier(targets, pendingDistraction)).concat("The party's morale is increased!");
+	return addModifier(targets, pendingDistraction).concat("The party's morale is increased!");
 }
 //#endregion
 
@@ -87,7 +87,7 @@ function toxicWindBurstEffect(targets, user, adventure) {
 	if (user.crit) {
 		pendingDistraction.stacks *= critBonus;
 	}
-	return generateModifierResultLines(addModifier(targets, pendingDistraction).concat(addModifier(targets, poison)));
+	return addModifier(targets, pendingDistraction).concat(addModifier(targets, poison));
 }
 //#endregion Toxic
 

--- a/source/items/alertnessbeans.js
+++ b/source/items/alertnessbeans.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Alertness Beans",
 	"Grants the user 1 @e{Vigilance}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Alertness Beans",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Vigilance", stacks: 2 }));
+		return addModifier([user], { name: "Vigilance", stacks: 2 });
 	}
 );

--- a/source/items/clearpotion.js
+++ b/source/items/clearpotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Clear Potion",
 	"Grants the user 3 @e{Unaligned Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Clear Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Unaligned Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Unaligned Absorption", stacks: 3 });
 	}
 );

--- a/source/items/creativeacorn.js
+++ b/source/items/creativeacorn.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Creative Acorn",
 	"Grants the user 15 @e{Fortune}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Creative Acorn",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Fortune", stacks: 15 }));
+		return addModifier([user], { name: "Fortune", stacks: 15 });
 	}
 );

--- a/source/items/earthenpotion.js
+++ b/source/items/earthenpotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Earthen Potion",
 	"Grants the user 3 @e{Earth Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Earthen Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Earth Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Earth Absorption", stacks: 3 });
 	}
 );

--- a/source/items/explosionpotion.js
+++ b/source/items/explosionpotion.js
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Explosion Potion",
 	30,
 	selectAllFoes,
 	(targets, user, adventure) => {
-		return dealDamage(targets, user, 75, false, "Unaligned", adventure).resultLines;
+		return dealDamage(targets, user, 75, false, "Unaligned", adventure).results;
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*Not to be confused with __Fiery Potion__. DO NOT apply to self.*" });

--- a/source/items/fierypotion.js
+++ b/source/items/fierypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Fiery Potion",
 	"Grants the user 3 @e{Fire Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Fiery Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Fire Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Fire Absorption", stacks: 3 });
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*Not to be confused with __Explosive Potion__. DO NOT apply to enemies.*" });

--- a/source/items/finessefiber.js
+++ b/source/items/finessefiber.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Finesse Fiber",
 	"Grants the user 2 @e{Finesse}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Finesse Fiber",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Finesse", stacks: 2 }));
+		return addModifier([user], { name: "Finesse", stacks: 2 });
 	}
 );

--- a/source/items/flexigrass.js
+++ b/source/items/flexigrass.js
@@ -9,6 +9,6 @@ module.exports = new ItemTemplate("Flexigrass",
 	selectSelf,
 	(targets, user, adventure) => {
 		changeStagger([user], null, 4);
-		return `${user.name} is relieved of some Stagger.`;
+		return [`${user.name} is relieved of some Stagger.`];
 	}
 );

--- a/source/items/glowingpotion.js
+++ b/source/items/glowingpotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Glowing Potion",
 	"Grants the user 3 @e{Light Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Glowing Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Light Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Light Absorption", stacks: 3 });
 	}
 );

--- a/source/items/healthpotion.js
+++ b/source/items/healthpotion.js
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Health Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return [gainHealth(user, Math.floor(user.getMaxHP() * 0.25), adventure)];
+		return gainHealth(user, Math.floor(user.getMaxHP() * 0.25), adventure);
 	}
 );

--- a/source/items/inkypotion.js
+++ b/source/items/inkypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Inky Potion",
 	"Grants the user 3 @e{Darkness Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Inky Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Darkness Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Darkness Absorption", stacks: 3 });
 	}
 );

--- a/source/items/panacea.js
+++ b/source/items/panacea.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { getModifierCategory } = require("../modifiers/_modifierDictionary");
-const { removeModifier, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { removeModifier } = require("../util/combatantUtil");
 const { SAFE_DELIMITER } = require('../constants.js');
 
 const itemName = "Panacea";
@@ -14,17 +14,16 @@ module.exports = new ItemTemplate(itemName,
 	(targets, user, adventure) => {
 		const userDebuffs = Object.keys(user.modifiers).filter(modifier => getModifierCategory(modifier) === "Debuff");
 		const debuffsToRemove = Math.min(userDebuffs.length, 2);
-		const receipts = [];
+		const results = [];
 		for (let i = 0; i < debuffsToRemove; i++) {
 			const debuffIndex = user.roundRns[`${itemName}${SAFE_DELIMITER}debuffs`][i] % userDebuffs.length;
 			const rolledDebuff = userDebuffs[debuffIndex];
 			const [removalReceipt] = removeModifier([user], { name: rolledDebuff, stacks: "all" });
-			receipts.push(removalReceipt);
+			results.push(removalReceipt);
 			if (removalReceipt.succeeded.size > 0) {
 				userDebuffs.splice(debuffIndex, 1);
 			}
 		}
-
-		return generateModifierResultLines(combineModifierReceipts(receipts));
+		return results;
 	}
 );

--- a/source/items/poppopfruit.js
+++ b/source/items/poppopfruit.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectAllFoes } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Pop-pop Fruit",
 	"Grants 1 @e{Distraction} on all foes",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Pop-pop Fruit",
 	30,
 	selectAllFoes,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier(targets, { name: "Distraction", stacks: 1 }));
+		return addModifier(targets, { name: "Distraction", stacks: 1 });
 	}
 );

--- a/source/items/quickpepper.js
+++ b/source/items/quickpepper.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Quick Pepper",
 	"Grants the user 3 @e{Swiftness}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Quick Pepper",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Swiftness", stacks: 3 }));
+		return addModifier([user], { name: "Swiftness", stacks: 3 });
 	}
 );

--- a/source/items/regenroot.js
+++ b/source/items/regenroot.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Regen Root",
 	`Grants the user 5 @e{Regeneration}`,
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Regen Root",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Regeneration", stacks: 5 }));
+		return addModifier([user], { name: "Regeneration", stacks: 5 });
 	}
 );

--- a/source/items/smokebomb.js
+++ b/source/items/smokebomb.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Smoke Bomb",
 	"Grants the user 2 @e{Evasion}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Smoke Bomb",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Evasion", stacks: 2 }));
+		return addModifier([user], { name: "Evasion", stacks: 2 });
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*\"While the foe suspects you're fleeing\" is the third best time to strike, beat only by \"when they least expect it\" and \"first\".*" });

--- a/source/items/strengthspinach.js
+++ b/source/items/strengthspinach.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Strength Spinach",
 	"Grants the user 50 @e{Empowerment}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Strength Spinach",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Empowerment", stacks: 50 }));
+		return addModifier([user], { name: "Empowerment", stacks: 50 });
 	}
 ).setFlavorText({ name: "*Additional Notes*", value: "*It does what it says on the tin.*" });

--- a/source/items/waterypotion.js
+++ b/source/items/waterypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Watery Potion",
 	"Grants the user 3 @e{Water Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Watery Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Water Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Water Absorption", stacks: 3 });
 	}
 ).setFlavorText({ name: "*Additional Note*", value: "Apply directly to the forehead." });

--- a/source/items/windypotion.js
+++ b/source/items/windypotion.js
@@ -1,6 +1,6 @@
 const { ItemTemplate } = require("../classes");
 const { selectSelf } = require("../shared/actionComponents.js");
-const { addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 module.exports = new ItemTemplate("Windy Potion",
 	"Grants the user 3 @e{Wind Absorption}",
@@ -8,6 +8,6 @@ module.exports = new ItemTemplate("Windy Potion",
 	30,
 	selectSelf,
 	(targets, user, adventure) => {
-		return generateModifierResultLines(addModifier([user], { name: "Wind Absorption", stacks: 3 }));
+		return addModifier([user], { name: "Wind Absorption", stacks: 3 });
 	}
 );

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1075,7 +1075,7 @@ function resolveMove(move, adventure) {
 		}
 	}
 
-	return `${headline}${resultLines.reduce((contextLines, currentLine) => `${contextLines}\n-# ${bold(currentLine)}`, "")}\n`;
+	return `${headline}${resultLines.reduce((contextLines, currentLine) => `${contextLines}\n-# ${currentLine}`, "")}\n`;
 }
 
 const RETAINING_MODIFIER_PAIRS = [["Exposure", "Distraction"], ["Evasion", "Vigilance"]];

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -824,7 +824,11 @@ function processResults(results) {
 			if (result.healingMap.size > 0) {
 				const healings = [];
 				for (const [source, magnitude] of result.healingMap) {
-					healings.push(`${magnitude} (${source})`)
+					if (source) {
+						healings.push(`${magnitude} (${source})`)
+					} else {
+						healings.push(magnitude);
+					}
 				}
 
 				if (result.combatantNames.size > 1) {

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -826,19 +826,7 @@ function receiptToResultLine(receipt) {
 	}
 
 	if (fragments.length > 0) {
-		let finalizedLine = `${listifyEN([...receipt.combatantNames])} ${listifyEN(fragments)}`;
-		switch (receipt.excitement) {
-			case 0:
-				finalizedLine += ".";
-				break;
-			case 1:
-				finalizedLine += "!";
-				break;
-			case 2:
-				finalizedLine += "!!!";
-				break;
-		}
-		return finalizedLine;
+		return `${listifyEN([...receipt.combatantNames])} ${listifyEN(fragments)}${receipt.excitement}`;
 	} else {
 		return "";
 	}

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -742,96 +742,6 @@ function newRound(adventure, thread, lastRoundText) {
 	});
 }
 
-/** @param {Receipt} receipt */
-function receiptToResultLine(receipt) {
-	const fragments = [];
-	// Damage
-	if (receipt.damageMap.size > 0) {
-		let damageFragment = "";
-		if (receipt.combatantNames.size > 1) {
-			damageFragment += "take ";
-		} else {
-			damageFragment += "takes ";
-		}
-		const damages = [];
-		for (const [type, magnitude] of receipt.damageMap) {
-			if (type === null) {
-				damages.unshift(magnitude);
-			} else {
-				damages.push(`${magnitude} ${type}`)
-			}
-		}
-		damageFragment += `${damages.join(" + ")} damage`;
-		const mitigationFragments = [];
-		if (receipt.blockedDamage > 0) {
-			mitigationFragments.push(`${receipt.blockedDamage} blocked`);
-		}
-		if (receipt.damageCapApplied !== null) {
-			mitigationFragments.push(`capped to ${receipt.damageCapApplied}`)
-		}
-		if (mitigationFragments.length > 0) {
-			damageFragment += ` (${mitigationFragments.join(", ")})`;
-		}
-		fragments.push(damageFragment);
-	}
-
-	// Healing
-	if (receipt.healingMap.size > 0) {
-		const healings = [];
-		for (const [source, magnitude] of receipt.healingMap) {
-			healings.push(`${magnitude} (${source})`)
-		}
-
-		if (receipt.combatantNames.size > 1) {
-			fragments.push(`gain ${healings.join(" + ")} HP`);
-		} else {
-			fragments.push(`gains ${healings.join(" + ")} HP`);
-		}
-	}
-
-	// Added Modifiers
-	if (receipt.addedModifiers.size > 0) {
-		if (receipt.combatantNames.size > 1) {
-			fragments.push(`gain ${[...receipt.addedModifiers].join("")}`);
-		} else {
-			fragments.push(`gains ${[...receipt.addedModifiers].join("")}`);
-		}
-	}
-
-	// Removed Modifiers
-	if (receipt.removedModifiers.size > 0) {
-		if (receipt.combatantNames.size > 1) {
-			fragments.push(`lose ${[...receipt.removedModifiers].join("")}`);
-		} else {
-			fragments.push(`loses ${[...receipt.removedModifiers].join("")}`);
-		}
-	}
-
-	// Stagger
-	switch (receipt.stagger) {
-		case "add":
-			if (receipt.combatantNames.size > 1) {
-				fragments.push("are staggered");
-			} else {
-				fragments.push("is staggered");
-			}
-			break;
-		case "remove":
-			if (receipt.combatantNames.size > 1) {
-				fragments.push("are relieved of stagger");
-			} else {
-				fragments.push("is relieved of stagger");
-			}
-			break;
-	}
-
-	if (fragments.length > 0) {
-		return `${listifyEN([...receipt.combatantNames])} ${listifyEN(fragments)}${receipt.excitement}`;
-	} else {
-		return "";
-	}
-}
-
 /** Consolidates receipts, then localizes receipts
  *
  * Consolidation convention set by game design as "name then change set" to minimize the number of lines required to describe all changes to a specific combatant
@@ -879,7 +789,92 @@ function processResults(results) {
 		if (typeof result === "string") {
 			resultLines.push(result);
 		} else {
-			resultLines.push(receiptToResultLine(result));
+			const fragments = [];
+			// Damage
+			if (result.damageMap.size > 0) {
+				let damageFragment = "";
+				if (result.combatantNames.size > 1) {
+					damageFragment += "take ";
+				} else {
+					damageFragment += "takes ";
+				}
+				const damages = [];
+				for (const [type, magnitude] of result.damageMap) {
+					if (type === null) {
+						damages.unshift(magnitude);
+					} else {
+						damages.push(`${magnitude} ${type}`)
+					}
+				}
+				damageFragment += `${damages.join(" + ")} damage`;
+				const mitigationFragments = [];
+				if (result.blockedDamage > 0) {
+					mitigationFragments.push(`${result.blockedDamage} blocked`);
+				}
+				if (result.damageCapApplied !== null) {
+					mitigationFragments.push(`capped to ${result.damageCapApplied}`)
+				}
+				if (mitigationFragments.length > 0) {
+					damageFragment += ` (${mitigationFragments.join(", ")})`;
+				}
+				fragments.push(damageFragment);
+			}
+
+			// Healing
+			if (result.healingMap.size > 0) {
+				const healings = [];
+				for (const [source, magnitude] of result.healingMap) {
+					healings.push(`${magnitude} (${source})`)
+				}
+
+				if (result.combatantNames.size > 1) {
+					fragments.push(`gain ${healings.join(" + ")} HP`);
+				} else {
+					fragments.push(`gains ${healings.join(" + ")} HP`);
+				}
+			}
+
+			// Added Modifiers
+			if (result.addedModifiers.size > 0) {
+				if (result.combatantNames.size > 1) {
+					fragments.push(`gain ${[...result.addedModifiers].join("")}`);
+				} else {
+					fragments.push(`gains ${[...result.addedModifiers].join("")}`);
+				}
+			}
+
+			// Removed Modifiers
+			if (result.removedModifiers.size > 0) {
+				if (result.combatantNames.size > 1) {
+					fragments.push(`lose ${[...result.removedModifiers].join("")}`);
+				} else {
+					fragments.push(`loses ${[...result.removedModifiers].join("")}`);
+				}
+			}
+
+			// Stagger
+			switch (result.stagger) {
+				case "add":
+					if (result.combatantNames.size > 1) {
+						fragments.push("are staggered");
+					} else {
+						fragments.push("is staggered");
+					}
+					break;
+				case "remove":
+					if (result.combatantNames.size > 1) {
+						fragments.push("are relieved of stagger");
+					} else {
+						fragments.push("is relieved of stagger");
+					}
+					break;
+			}
+
+			if (fragments.length > 0) {
+				resultLines.push(`${listifyEN([...result.combatantNames])} ${listifyEN(fragments)}${result.excitement}`);
+			} else {
+				resultLines.push("");
+			}
 		}
 	}
 	return resultLines;
@@ -1332,7 +1327,7 @@ module.exports = {
 	nextRoom,
 	endRoom,
 	newRound,
-	receiptToResultLine,
+	processResults,
 	endRound,
 	checkNextRound,
 	fetchRecruitMessage,

--- a/source/orcustrators/adventureOrcustrator.js
+++ b/source/orcustrators/adventureOrcustrator.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const { ThreadChannel, Message, EmbedBuilder, bold, italic } = require("discord.js");
 
-const { Adventure, CombatantReference, Move, Enemy, Delver, Room, Combatant } = require("../classes");
+const { Adventure, CombatantReference, Move, Enemy, Delver, Room, Combatant, Receipt } = require("../classes");
 
 const { SAFE_DELIMITER, RN_TABLE_BASE, ICON_PET, ICON_CRITICAL, ICON_STAGGER } = require("../constants.js");
 
@@ -11,11 +11,11 @@ const { getGearProperty, gearExists } = require("../gear/_gearDictionary");
 const { getItem } = require("../items/_itemDictionary");
 const { rollGear, rollItem, getLabyrinthProperty, prerollBoss, rollRoom } = require("../labyrinths/_labyrinthDictionary");
 const { getModifierCategory, getRoundDecrement, getMoveDecrement } = require("../modifiers/_modifierDictionary");
-const { removeModifier, dealModifierDamage, gainHealth, changeStagger, addProtection, evaluateAbsoluteTeam } = require("../util/combatantUtil");
+const { removeModifier, dealModifierDamage, gainHealth, changeStagger, addProtection, evaluateAbsoluteTeam, receiptToResultLine } = require("../util/combatantUtil");
 const { renderRoom, generateRecruitEmbed, roomHeaderString } = require("../util/embedUtil");
 const { essenceList, getCounteredEssences, getEmoji } = require("../util/essenceUtil.js");
 const { ensuredPathSave } = require("../util/fileUtil");
-const { anyDieSucceeds, parseExpression } = require("../util/mathUtil.js");
+const { anyDieSucceeds, parseExpression, areSetContentsCongruent } = require("../util/mathUtil.js");
 const { clearComponents } = require("../util/messageComponentUtil");
 const { spawnEnemy, rollGearTier } = require("../util/roomUtil");
 const { listifyEN } = require("../util/textUtil");
@@ -742,6 +742,59 @@ function newRound(adventure, thread, lastRoundText) {
 	});
 }
 
+/** Consolidates receipts, then localizes receipts
+ *
+ * Consolidation convention set by game design as "name then change set" to minimize the number of lines required to describe all changes to a specific combatant
+ * @param {(Receipt | string)[]} results
+ */
+function processResults(results) {
+	const resultLines = [];
+	// Consolidate by name
+	// eg "Combatant gains X" + "Combatant gains Y" = "Combatant gains XY"
+	for (let i = 0; i < results.length; i++) {
+		const heldResult = results[i];
+		if (heldResult instanceof Receipt) {
+			for (let j = i + 1; j < results.length; j++) {
+				const checkingResult = results[j];
+				if (checkingResult instanceof Receipt) {
+					if (areSetContentsCongruent(heldResult.combatantNames, checkingResult.combatantNames)) {
+						heldResult.combineChanges(checkingResult);
+						results.splice(j, 1);
+						j--;
+					}
+				}
+			}
+		}
+	}
+
+	// Consolidate by change sets
+	// eg "X gains ChangeSet" + "Y gains ChangeSet" = "X and Y gain ChangeSet"
+	for (let i = 0; i < results.length; i++) {
+		const heldResult = results[i];
+		if (heldResult instanceof Receipt) {
+			for (let j = i + 1; j < results.length; j++) {
+				const checkingResult = results[j];
+				if (checkingResult instanceof Receipt) {
+					if (Receipt.congruenceCheck(heldResult, checkingResult)) {
+						heldResult.combineCombatantNames(checkingResult);
+						results.splice(j, 1);
+						j--;
+					}
+				}
+			}
+		}
+	}
+
+	for (const result of results) {
+		if (typeof result === "string") {
+			resultLines.push(result);
+		} else {
+			resultLines.push(receiptToResultLine(result));
+		}
+	}
+	return resultLines;
+}
+
 /** Updates game state with the move's effect AND returns the game's description of what happened
  * @param {Move} move
  * @param {Adventure} adventure
@@ -843,7 +896,7 @@ function resolveMove(move, adventure) {
 					results.push(`${listifyEN(deadTargets.map(target => target.name), false)} ${deadTargets.length === 1 ? "was" : "were"} already dead!`);
 				}
 
-				results.push(...effect(livingTargets, user, adventure, { petRNs: adventure.petRNs }));
+				results.push(...processResults(effect(livingTargets, user, adventure, { petRNs: adventure.petRNs })));
 			} else {
 				shouldDoGearUpkeep = false;
 				if (move.targets.length === 1) {
@@ -853,7 +906,7 @@ function resolveMove(move, adventure) {
 				}
 			}
 		} else {
-			results.push(...effect([], user, adventure, { petRNs: adventure.petRNs }));
+			results.push(...processResults(effect([], user, adventure, { petRNs: adventure.petRNs })));
 		}
 
 		if (shouldDoGearUpkeep) {
@@ -901,7 +954,7 @@ function resolveMove(move, adventure) {
 		const insigniaCount = adventure.getArtifactCount("Celestial Knight Insignia");
 		if (insigniaCount > 0 && user.team === "delver" && user.crit && move.type !== "pet") {
 			const insigniaHealing = insigniaCount * 15;
-			results.push(gainHealth(user, insigniaHealing, adventure, "their Celestial Knight Insigina"));
+			results.push(receiptToResultLine(gainHealth(user, insigniaHealing, adventure, "Celestial Knight Insigina")));
 			adventure.updateArtifactStat("Health Restored", insigniaHealing);
 		}
 	} else {
@@ -912,7 +965,7 @@ function resolveMove(move, adventure) {
 		}
 
 		if ("Frailty" in user.modifiers) {
-			results.push(...dealModifierDamage(user, "Frailty", adventure));
+			results.push(...receiptToResultLine(dealModifierDamage(user, "Frailty", adventure)));
 			removeModifier([user], { name: "Frailty", stacks: "all" });
 		}
 	}
@@ -920,11 +973,11 @@ function resolveMove(move, adventure) {
 	if (move.type !== "pet") {
 		// Poison/Regeneneration effect
 		if ("Poison" in user.modifiers) {
-			results.push(...dealModifierDamage(user, "Poison", adventure));
+			results.push(...receiptToResultLine(dealModifierDamage(user, "Poison", adventure)));
 		} else {
 			const regenStacks = user.getModifierStacks("Regeneration");
 			if (regenStacks) {
-				results.push(gainHealth(user, regenStacks * 10, adventure, getApplicationEmojiMarkdown("Regeneration")));
+				results.push(receiptToResultLine(gainHealth(user, regenStacks * 10, adventure, getApplicationEmojiMarkdown("Regeneration"))));
 			}
 		}
 
@@ -1050,7 +1103,7 @@ function endRound(adventure, thread) {
 			otherHappenings.push(`${combatant.name}'s Fortune becomes protection.`);
 		}
 		if ("Misfortune" in combatant.modifiers && combatant.modifiers.Misfortune % 7 === 0) {
-			otherHappenings.push(dealModifierDamage(combatant, "Misfortune", adventure));
+			otherHappenings.push(receiptToResultLine(dealModifierDamage(combatant, "Misfortune", adventure)));
 			removeModifier([combatant], { name: "Misfortune", stacks: "all" });
 		}
 		if (otherHappenings.length > 0) {

--- a/source/pets/_pet_blueprint.js
+++ b/source/pets/_pet_blueprint.js
@@ -7,24 +7,24 @@ module.exports = new PetTemplate(petName, Colors.Blurple,
 		[
 			new PetMoveTemplate("Move 1", "description", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-
+					return [];
 				}).setRnConfig([])
 				.setModifiers({ name: "modifier", stacks: 0 }),
 			new PetMoveTemplate("Move 1", "description", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-
+					return [];
 				}).setRnConfig([])
 				.setModifiers({ name: "modifier", stacks: 0 })
 		],
 		[
 			new PetMoveTemplate("Move 2", "description", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-
+					return [];
 				}).setRnConfig([])
 				.setModifiers({ name: "modifier", stacks: 0 }),
 			new PetMoveTemplate("Move 2", "description", (owner, petRNs) => [],
 				(targets, owner, adventure, petRNs) => {
-
+					return [];
 				}).setRnConfig([])
 				.setModifiers({ name: "modifier", stacks: 0 })
 		]

--- a/source/pets/friendlyslime.js
+++ b/source/pets/friendlyslime.js
@@ -1,7 +1,7 @@
 const { Colors } = require("discord.js");
 const { PetTemplate, PetMoveTemplate } = require("../classes");
 const { rollablePotions } = require("../shared/potions");
-const { addModifier, generateModifierResultLines, combineModifierReceipts } = require("../util/combatantUtil");
+const { addModifier } = require("../util/combatantUtil");
 
 const petName = "Friendly Slime";
 module.exports = new PetTemplate(petName, Colors.Aqua,
@@ -16,16 +16,15 @@ module.exports = new PetTemplate(petName, Colors.Aqua,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const thisMove = module.exports.moves[0][0];
-					return generateModifierResultLines(addModifier(targets, thisMove.modifiers[0]));
+					return addModifier(targets, thisMove.modifiers[0]);
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Poison", stacks: 2 }),
 			new PetMoveTemplate("Sticky Toxin Spray", "Inflict @{mod0Stacks} @{mod0} and @{mod1Stacks} @{mod1} on a random foe",
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const thisMove = module.exports.moves[0][1];
-					const receipts = addModifier(targets, thisMove.modifiers[0]);
-					receipts.push(...addModifier(targets, thisMove.modifiers[1]))
-					return generateModifierResultLines(combineModifierReceipts(receipts));
+					const results = addModifier(targets, thisMove.modifiers[0]);
+					return results.concat(addModifier(targets, thisMove.modifiers[1]))
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Poison", stacks: 2 }, { name: "Torpidity", stacks: 2 })
 		],

--- a/source/pets/redtailedraptor.js
+++ b/source/pets/redtailedraptor.js
@@ -1,6 +1,6 @@
 const { Colors } = require("discord.js");
 const { PetTemplate, PetMoveTemplate } = require("../classes");
-const { dealDamage, addModifier, generateModifierResultLines } = require("../util/combatantUtil");
+const { dealDamage, addModifier } = require("../util/combatantUtil");
 const { getEmoji } = require("../util/essenceUtil");
 
 const petName = "Red-Tailed Raptor";
@@ -16,16 +16,16 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[0][0];
-					const { resultLines } = dealDamage(targets, owner, 15, false, "Wind", adventure);
-					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
+					const { results } = dealDamage(targets, owner, 15, false, "Wind", adventure);
+					return results.concat(addModifier([owner], swiftness));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 2 }),
 			new PetMoveTemplate("Secret Maneuver: Rake of the Heavens", `Deal 25 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[0][1];
-					const { resultLines } = dealDamage(targets, owner, 25, false, "Wind", adventure);
-					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
+					const { results } = dealDamage(targets, owner, 25, false, "Wind", adventure);
+					return results.concat(addModifier([owner], swiftness));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 3 }),
 		],
@@ -34,16 +34,16 @@ module.exports = new PetTemplate(petName, Colors.Red,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[1][0];
-					const { resultLines } = dealDamage(targets, owner, 15, false, "Wind", adventure);
-					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
+					const { results } = dealDamage(targets, owner, 15, false, "Wind", adventure);
+					return results.concat(addModifier([owner], swiftness));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 2 }),
 			new PetMoveTemplate("World-Cleaving Rake: The Forbidden Technique", `Deal 25 ${getEmoji("Wind")} to a random foe and grant its owner @{mod0Stacks} @{mod0}`,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const { modifiers: [swiftness] } = module.exports.moves[1][1];
-					const { resultLines } = dealDamage(targets, owner, 25, false, "Wind", adventure);
-					return resultLines.concat(generateModifierResultLines(addModifier([owner], swiftness)));
+					const { results } = dealDamage(targets, owner, 25, false, "Wind", adventure);
+					return results.concat(addModifier([owner], swiftness));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Swiftness", stacks: 3 }),
 		]

--- a/source/pets/shieldgoblin.js
+++ b/source/pets/shieldgoblin.js
@@ -27,13 +27,13 @@ module.exports = new PetTemplate(petName, Colors.Green,
 			new PetMoveTemplate("Shield Tackle", `Deal owner's protection in ${getEmoji("Earth")} damage to a random foe`,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
-					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).resultLines;
+					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).results;
 				}).setRnConfig(["enemyIndex"]),
 			new PetMoveTemplate("Shield Avalanche", `Deal owner's protection in ${getEmoji("Earth")} damage and 1 Stagger to a random foe`,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					changeStagger(targets, null, 1);
-					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).resultLines;
+					return dealDamage(targets, owner, owner.protection, false, "Earth", adventure).results;
 				}).setRnConfig(["enemyIndex"])
 		]
 	]

--- a/source/pets/shinystone.js
+++ b/source/pets/shinystone.js
@@ -1,7 +1,6 @@
 const { Colors } = require("discord.js");
 const { PetTemplate, PetMoveTemplate } = require("../classes");
-const { generateModifierResultLines, addModifier, changeStagger } = require("../util/combatantUtil");
-const { joinAsStatement } = require("../util/textUtil");
+const { addModifier, changeStagger } = require("../util/combatantUtil");
 
 const petName = "Shiny Stone";
 module.exports = new PetTemplate(petName, Colors.LightGrey,
@@ -16,14 +15,14 @@ module.exports = new PetTemplate(petName, Colors.LightGrey,
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const [distraction] = module.exports.moves[0][0].modifiers;
-					return generateModifierResultLines(addModifier(targets, distraction));
+					return addModifier(targets, distraction);
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Distraction", stacks: 2 }),
 			new PetMoveTemplate("Extra Eye-Catcher", "Inflict a random foe with @{mod0Stacks} @{mod0} and 1 Stagger",
 				(owner, petRNs) => petRNs.targetReferences,
 				(targets, owner, adventure, { petRNs }) => {
 					const [distraction] = module.exports.moves[0][1].modifiers;
-					return generateModifierResultLines(addModifier(targets, distraction)).concat(joinAsStatement(false, targets.map(target => target.name), "is", "are", "Staggered."));
+					return addModifier(targets, distraction).concat(changeStagger(targets, null, 1));
 				}).setRnConfig(["enemyIndex"])
 				.setModifiers({ name: "Distraction", stacks: 2 })
 		],
@@ -31,17 +30,17 @@ module.exports = new PetTemplate(petName, Colors.LightGrey,
 			new PetMoveTemplate("Sparkle", "Grant owner @{mod0Stacks} @{mod0}", (owner, petRNs) => [],
 				(targets, owner, adventure, { petRNs }) => {
 					const [vigilance] = module.exports.moves[1][0].modifiers;
-					return generateModifierResultLines(addModifier([owner], vigilance));
+					return addModifier([owner], vigilance);
 				}).setModifiers({ name: "Vigilance", stacks: 2 }),
 			new PetMoveTemplate("Sparkle Brilliantly", "Grant owner @{mod0Stacks} @{mod0} and relieve 1 Stagger", (owner, petRNs) => [],
 				(targets, owner, adventure, { petRNs }) => {
 					const [vigilance] = module.exports.moves[1][1].modifiers;
-					const resultLines = generateModifierResultLines(addModifier([owner], vigilance));
+					const results = addModifier([owner], vigilance);
 					if (owner.stagger > 0) {
 						changeStagger([owner], null, -1);
-						resultLines.push(`${owner.name} is relieved of Stagger.`);
+						results.push(`${owner.name} is relieved of Stagger.`);
 					}
-					return resultLines;
+					return results;
 				}).setModifiers({ name: "Vigilance", stacks: 2 })
 		]
 	]

--- a/source/pets/shinystone.js
+++ b/source/pets/shinystone.js
@@ -37,8 +37,7 @@ module.exports = new PetTemplate(petName, Colors.LightGrey,
 					const [vigilance] = module.exports.moves[1][1].modifiers;
 					const results = addModifier([owner], vigilance);
 					if (owner.stagger > 0) {
-						changeStagger([owner], null, -1);
-						results.push(`${owner.name} is relieved of Stagger.`);
+						results.push(...changeStagger([owner], null, -1));
 					}
 					return results;
 				}).setModifiers({ name: "Vigilance", stacks: 2 })

--- a/source/selects/applepiewishingwell.js
+++ b/source/selects/applepiewishingwell.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { gainHealth } = require('../util/combatantUtil');
+const { gainHealth, receiptToResultLine } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "applepiewishingwell";
@@ -19,6 +19,6 @@ module.exports = new SelectWrapper(mainId, 3000,
 		adventure.decrementItem(tossedItem, 1);
 		adventure.room.history["Items tossed"].push(tossedItem);
 		interaction.update(renderRoom(adventure, interaction.channel));
-		interaction.channel.send(gainHealth(delver, delver.maxHP, adventure, `the delicious apple pie that was previously a ${tossedItem}`));
+		interaction.channel.send(receiptToResultLine(gainHealth(delver, delver.maxHP, adventure, `the delicious apple pie that was previously a ${tossedItem}`)));
 	}
 );

--- a/source/selects/applepiewishingwell.js
+++ b/source/selects/applepiewishingwell.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { SelectWrapper } = require('../classes');
-const { getAdventure } = require('../orcustrators/adventureOrcustrator');
-const { gainHealth, receiptToResultLine } = require('../util/combatantUtil');
+const { getAdventure, receiptToResultLine } = require('../orcustrators/adventureOrcustrator');
+const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 
 const mainId = "applepiewishingwell";

--- a/source/selects/applepiewishingwell.js
+++ b/source/selects/applepiewishingwell.js
@@ -1,6 +1,6 @@
 const { MessageFlags } = require('discord.js');
 const { SelectWrapper } = require('../classes');
-const { getAdventure, receiptToResultLine } = require('../orcustrators/adventureOrcustrator');
+const { getAdventure, processResults } = require('../orcustrators/adventureOrcustrator');
 const { gainHealth } = require('../util/combatantUtil');
 const { renderRoom } = require('../util/embedUtil');
 
@@ -19,6 +19,6 @@ module.exports = new SelectWrapper(mainId, 3000,
 		adventure.decrementItem(tossedItem, 1);
 		adventure.room.history["Items tossed"].push(tossedItem);
 		interaction.update(renderRoom(adventure, interaction.channel));
-		interaction.channel.send(receiptToResultLine(gainHealth(delver, delver.maxHP, adventure, `the delicious apple pie that was previously a ${tossedItem}`)));
+		interaction.channel.send(processResults(gainHealth(delver, delver.maxHP, adventure, `the delicious apple pie that was previously a ${tossedItem}`)).join(" "));
 	}
 );

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -1,10 +1,9 @@
 const { italic, bold } = require("discord.js");
-const { Combatant, Adventure, ModifierReceipt } = require("../classes");
+const { Combatant, Adventure, Receipt } = require("../classes");
 const { getInverse, getModifierDescription } = require("../modifiers/_modifierDictionary");
 const { getEmoji, getCounteredEssences, essenceList } = require("./essenceUtil.js");
 const { getApplicationEmojiMarkdown } = require("./graphicsUtil.js");
 const { listifyEN } = require("./textUtil.js");
-const { areSetContentsCongruent } = require("./mathUtil.js");
 const { ZERO_WIDTH_WHITESPACE } = require("../constants");
 const { EmbedLimits } = require("@sapphire/discord.js-utilities");
 
@@ -13,28 +12,25 @@ const { EmbedLimits } = require("@sapphire/discord.js-utilities");
  * @param {Adventure} adventure
  */
 function downedCheck(target, adventure) {
-	const lines = {
-		addendum: "",
-		extraLines: []
-	}
+	const lines = [];
 	if (target.hp <= 0) {
 		removeModifier([target], { name: "The Target", stacks: "all" });
 		if (target.team === "delver") {
 			target.hp = target.getMaxHP();
 			adventure.lives = Math.max(adventure.lives - 1, 0);
-			lines.addendum = ` ${bold(`${target.name} was downed${adventure.lives > 0 ? " and revived" : ""}.`)}${ZERO_WIDTH_WHITESPACE}`; // need ZWW for md format nesting
+			lines.push(`${bold(`${target.name} was downed${adventure.lives > 0 ? " and revived" : ""}.`)}${ZERO_WIDTH_WHITESPACE}`); // need ZWW for md format nesting
 		} else {
 			target.hp = 0;
+			lines.push(`${bold(`${target.name} was downed`)}.${ZERO_WIDTH_WHITESPACE}`);
 			if ("Cowardice" in target.modifiers) {
 				const addBlockerCount = adventure.getArtifactCount("Add Blocker");
 				if (addBlockerCount > 0) {
 					const singleProtection = 150 * addBlockerCount;
 					addProtection(adventure.delvers, singleProtection);
 					adventure.updateArtifactStat("Add Blocker", "Protection Gained", singleProtection * adventure.delvers.length);
-					lines.extraLines.push("The Add Blocker grants all delvers protection.");
+					lines.push("The Add Blocker grants all delvers protection.");
 				}
 			}
-			lines.addendum = ` ${bold(`${target.name} was downed`)}.${ZERO_WIDTH_WHITESPACE}`;
 		}
 	}
 	return lines;
@@ -67,8 +63,8 @@ function livesCheck(previousLives, currentLives) {
  */
 function dealDamage(targets, assailant, damage, isUnblockable, essence, adventure) {
 	const previousLifeCount = adventure.lives;
-	/** @type {string[]} */
-	const resultLines = [];
+	/** @type {(string | Receipt)[]} */
+	const results = [];
 	/** @type {Combatant[]} */
 	const survivors = [];
 	for (const target of targets) {
@@ -80,62 +76,59 @@ function dealDamage(targets, assailant, damage, isUnblockable, essence, adventur
 						pendingDamage *= 1.5;
 						removeModifier([target], { name: "Exposure", stacks: 1 });
 					}
+					const changes = { damageArray: [[null, pendingDamage]] };
 					const isCounter = getCombatantCounters(target).includes(essence);
 					if (isCounter) {
-						pendingDamage += assailant.getEssenceCounterDamage();
+						const counterDamage = assailant.getEssenceCounterDamage();
+						pendingDamage += counterDamage;
+						changes.damageArray.push([getEmoji(essence), counterDamage]);
 					}
 					pendingDamage = Math.ceil(pendingDamage);
-					let blockedDamage = 0;
 					if (!isUnblockable) {
 						if (pendingDamage >= target.protection) {
 							pendingDamage -= target.protection;
-							blockedDamage = target.protection;
 							target.protection = 0;
+							changes.blockedDamage = target.protection;
 						} else {
 							target.protection -= pendingDamage;
-							blockedDamage = pendingDamage;
 							pendingDamage = 0;
+							changes.blockedDamage = pendingDamage;
 						}
 					}
-					pendingDamage = Math.min(pendingDamage, assailant.getDamageCap());
-					target.hp -= pendingDamage;
-					let damageLine = `${target.name} takes ${pendingDamage} ${getEmoji(essence)} damage`;
-					if (blockedDamage > 0) {
-						damageLine += ` (${blockedDamage} was blocked)`;
-					}
-					if (isCounter) {
-						damageLine += "!";
+					const damageCap = assailant.getDamageCap();
+					if (pendingDamage < damageCap) {
+						target.hp -= pendingDamage;
 					} else {
-						damageLine += ".";
+						target.hp -= damageCap;
+						changes.damageCapApplied = damageCap;
 					}
+					const receipt = new Receipt([target.name], isCounter ? "!" : ".", changes);
 					const downedLines = downedCheck(target, adventure);
-					if (downedLines.addendum !== "") {
-						damageLine += downedLines.addendum;
-					}
-					if (downedLines.addendum === "" || (target.team === "delver" && adventure.lives > 0)) {
+					if (downedLines.length < 1 || (target.team === "delver" && adventure.lives > 0)) {
 						survivors.push(target);
 					}
-					resultLines.push(damageLine, ...downedLines.extraLines);
+					results.push(receipt, ...downedLines);
 					if (pendingDamage > 0 && "Curse of Midas" in target.modifiers) {
 						const midasGold = Math.floor(pendingDamage / 10 * target.modifiers["Curse of Midas"]);
 						adventure.room.addResource("Gold", "Currency", "loot", midasGold);
-						resultLines.push(`${getApplicationEmojiMarkdown("Curse of Midas")}: Loot +${midasGold}g`)
+						results.push(`${getApplicationEmojiMarkdown("Curse of Midas")}: Loot +${midasGold}g`)
 					}
 				} else {
 					removeModifier([target], { name: "Evasion", stacks: 1 });
-					resultLines.push(`${target.name} evades the attack!`);
+					results.push(`${target.name} evades the attack!`);
 					survivors.push(target);
 				}
 			} else {
-				resultLines.push(gainHealth(target, damage, adventure, "Essence Absorption"));
+				results.push(gainHealth(target, damage, adventure, "Essence Absorption"));
+				survivors.push(target);
 			}
 		}
 	}
 	const lifeLine = livesCheck(previousLifeCount, adventure.lives);
 	if (lifeLine) {
-		resultLines.push(lifeLine);
+		results.push(lifeLine);
 	}
-	return { resultLines, survivors };
+	return { results, survivors };
 }
 
 const MODIFIER_DAMAGE_PER_STACK = {
@@ -159,32 +152,26 @@ function dealModifierDamage(target, modifier, adventure) {
 		pendingDamage += funnelDamage;
 		adventure.updateArtifactStat("Spiral Funnel", `Extra ${modifier} Damage`, funnelDamage);
 	}
-	let blockedDamage = 0;
+	const changes = { damageArray: [[getApplicationEmojiMarkdown(modifier), pendingDamage]] };
 	if (pendingDamage >= target.protection) {
 		pendingDamage -= target.protection;
-		blockedDamage = target.protection;
 		target.protection = 0;
+		changes.blockedDamage = target.protection;
 	} else {
 		target.protection -= pendingDamage;
-		blockedDamage = pendingDamage;
 		pendingDamage = 0;
+		changes.blockedDamage = pendingDamage;
 	}
 	target.hp -= pendingDamage;
-	let damageLine = `${target.name} takes ${pendingDamage} ${getApplicationEmojiMarkdown(modifier)} damage!`;
-	if (blockedDamage > 0) {
-		damageLine += ` (${blockedDamage} blocked)`;
-	}
-	const downedLines = downedCheck(target, adventure);
-	if (downedLines.addendum !== "") {
-		damageLine += downedLines.addendum;
-	}
-	const resultLines = [damageLine].concat(downedLines.extraLines);
+	const receipt = new Receipt([target.name], funnelCount > 0 ? "!" : ".", changes);
+	/** @type {(Receipt | string)[]} */
+	const results = [receipt, ...downedCheck(target, adventure)];
 
 	const lifeLine = livesCheck(previousLifeCount, adventure.lives);
 	if (lifeLine) {
-		resultLines.push(lifeLine);
+		results.push(lifeLine);
 	}
-	return resultLines;
+	return results;
 }
 
 /**
@@ -195,13 +182,7 @@ function dealModifierDamage(target, modifier, adventure) {
 function payHP(user, damage, adventure) {
 	const previousLifeCount = adventure.lives;
 	user.hp -= damage;
-	let paymentLine = `${user.name} pays ${damage} HP.`;
-	const downedLines = downedCheck(user, adventure);
-	if (downedLines.addendum !== "") {
-		paymentLine += downedLines.addendum;
-	}
-	const resultLines = [paymentLine];
-	resultLines.push(...downedLines.extraLines);
+	const resultLines = [`${user.name} pays ${damage} HP.`, ...downedCheck(user, adventure)];
 	const lifeLine = livesCheck(previousLifeCount, adventure.lives);
 	if (lifeLine) {
 		resultLines.push(lifeLine);
@@ -229,11 +210,12 @@ function gainHealth(combatant, healing, adventure, source) {
 		}
 	}
 
-	if (combatant.hp === maxHP) {
-		return `${combatant.name} was fully healed${loopholeGold > 0 ? ` (${loopholeGold} gold gained)` : ""}${source ? ` from ${source}` : ""}!`;
-	} else {
-		return `${combatant.name} ${italic(`gained ${healing} HP`)}${source ? ` from ${source}` : ""}.`;
+	/** @type {(string | Receipt)[]} */
+	const results = [new Receipt([combatant.name], combatant.hp === maxHP ? "!" : ".", { healingsArray: [source || null, healing] })];
+	if (loopholeGold > 0) {
+		results.push(`Health Insurance Loophole${loopholeCount === 1 ? "" : "s"} granted ${loopholeGold} gold.`);
 	}
+	return results;
 }
 
 /** Checks if adding the modifier inverts exisiting modifiers, increments the (remaining) stacks, then checks if stacks exceed a trigger threshold
@@ -260,7 +242,7 @@ function addModifier(combatants, { name: modifier, stacks: pendingStacks }) {
 			}
 		}
 
-		receipts.push(new ModifierReceipt(combatant.name, "add", [getApplicationEmojiMarkdown(modifier)], []));
+		receipts.push(new Receipt([combatant.name], "!", { addedModifierEmojiArray: [getApplicationEmojiMarkdown(modifier)] }));
 	}
 	return receipts;
 }
@@ -281,79 +263,112 @@ function removeModifier(combatants, { name: modifier, stacks }) {
 			combatant.modifiers[modifier] -= stacks;
 		}
 		if (didHaveModifier) {
-			receipts.push(new ModifierReceipt(combatant.name, "remove", [getApplicationEmojiMarkdown(modifier)], []));
+			receipts.push(new Receipt([combatant.name], "!", { removedModifierEmojiArray: [getApplicationEmojiMarkdown(modifier)] }));
 		}
 	}
 	return receipts;
 }
 
-/**  Consolidation convention set by game design as "name then modifier set" to minimize the number of lines required to describe all changes to a specific combatant
- * @param {ModifierReceipt[]} receipts
- */
-function combineModifierReceipts(receipts) {
-	// Consolidate by name
-	// eg "Combatant gains X" + "Combatant gains Y" = "Combatant gains XY"
-	for (let i = 0; i < receipts.length; i++) {
-		const heldReceipt = receipts[i];
-		for (let j = i + 1; j < receipts.length; j++) {
-			const checkingReceipt = receipts[j];
-			if (heldReceipt.type === checkingReceipt.type && areSetContentsCongruent(heldReceipt.combatantNames, checkingReceipt.combatantNames)) {
-				heldReceipt.combineModifierSets(checkingReceipt);
-				receipts.splice(j, 1);
-				j--;
-			}
-		}
-	}
-
-	// Consolidate by modifier sets
-	// eg "X gains ModifierSet" + "Y gains ModifierSet" = "X and Y gain ModifierSet"
-	for (let i = 0; i < receipts.length; i++) {
-		const heldReceipt = receipts[i];
-		for (let j = i + 1; j < receipts.length; j++) {
-			const checkingReceipt = receipts[j];
-			if (heldReceipt.type === checkingReceipt.type && areSetContentsCongruent(heldReceipt.succeeded, checkingReceipt.succeeded)) {
-				heldReceipt.combineCombatantNames(checkingReceipt);
-				receipts.splice(j, 1);
-				j--;
-			}
-		}
-	}
-	return receipts;
-}
-
-/** @param {ModifierReceipt[]} receipts */
-function generateModifierResultLines(receipts) {
-	const resultLines = [];
-	for (const receipt of receipts) {
-		if (receipt.type === "add") {
-			const addedFragments = [];
-			if (receipt.succeeded.size > 0) {
-				if (receipt.combatantNames.size > 1) {
-					addedFragments.push(`gain ${[...receipt.succeeded].join("")}`);
-				} else {
-					addedFragments.push(`gains ${[...receipt.succeeded].join("")}`);
-				}
-			}
-
-			if (addedFragments.length > 0) {
-				resultLines.push(`${listifyEN([...receipt.combatantNames])} ${listifyEN(addedFragments)}.`);
-			}
+/** @param {Receipt} receipt */
+function receiptToResultLine(receipt) {
+	const fragments = [];
+	// Damage
+	if (receipt.damageMap.size > 0) {
+		let damageFragment = "";
+		if (receipt.combatantNames.size > 1) {
+			damageFragment += "take ";
 		} else {
-			const removedFragments = [];
-			if (receipt.succeeded.size > 0) {
-				if (receipt.combatantNames.size > 1) {
-					removedFragments.push(`lose ${[...receipt.succeeded].join("")}`);
-				} else {
-					removedFragments.push(`loses ${[...receipt.succeeded].join("")}`);
-				}
-			}
-
-			if (removedFragments.length > 0) {
-				resultLines.push(`${listifyEN([...receipt.combatantNames])} ${listifyEN(removedFragments)}.`);
+			damageFragment += "takes ";
+		}
+		const damages = [];
+		for (const [type, magnitude] of receipt.damageMap) {
+			if (type === null) {
+				damages.unshift(magnitude);
+			} else {
+				damages.push(`${magnitude} ${type}`)
 			}
 		}
+		damageFragment += `${damages.join(" + ")} damage`;
+		const mitigationFragments = [];
+		if (receipt.blockedDamage > 0) {
+			mitigationFragments.push(`${receipt.blockedDamage} blocked`);
+		}
+		if (receipt.damageCapApplied !== null) {
+			mitigationFragments.push(`capped to ${receipt.damageCapApplied}`)
+		}
+		if (mitigationFragments.length > 0) {
+			damageFragment += ` (${mitigationFragments.join(", ")})`;
+		}
+		fragments.push(damageFragment);
 	}
-	return resultLines;
+
+	// Healing
+	if (receipt.healingMap.size > 0) {
+		const healings = [];
+		for (const [source, magnitude] of receipt.healingMap) {
+			healings.push(`${magnitude} (${source})`)
+		}
+
+		if (receipt.combatantNames.size > 1) {
+			fragments.push(`gain ${healings.join(" + ")} HP`);
+		} else {
+			fragments.push(`gains ${healings.join(" + ")} HP`);
+		}
+	}
+
+	// Added Modifiers
+	if (receipt.addedModifiers.size > 0) {
+		if (receipt.combatantNames.size > 1) {
+			fragments.push(`gain ${[...receipt.addedModifiers].join("")}`);
+		} else {
+			fragments.push(`gains ${[...receipt.addedModifiers].join("")}`);
+		}
+	}
+
+	// Removed Modifiers
+	if (receipt.removedModifiers.size > 0) {
+		if (receipt.combatantNames.size > 1) {
+			fragments.push(`lose ${[...receipt.removedModifiers].join("")}`);
+		} else {
+			fragments.push(`loses ${[...receipt.removedModifiers].join("")}`);
+		}
+	}
+
+	// Stagger
+	switch (receipt.stagger) {
+		case "add":
+			if (receipt.combatantNames.size > 1) {
+				fragments.push("are staggered");
+			} else {
+				fragments.push("is staggered");
+			}
+			break;
+		case "remove":
+			if (receipt.combatantNames.size > 1) {
+				fragments.push("are relieved of stagger");
+			} else {
+				fragments.push("is relieved of stagger");
+			}
+			break;
+	}
+
+	if (fragments.length > 0) {
+		let finalizedLine = `${listifyEN([...receipt.combatantNames])} ${listifyEN(fragments)}`;
+		switch (receipt.excitement) {
+			case 0:
+				finalizedLine += ".";
+				break;
+			case 1:
+				finalizedLine += "!";
+				break;
+			case 2:
+				finalizedLine += "!!!";
+				break;
+		}
+		return finalizedLine;
+	} else {
+		return "";
+	}
 }
 
 /** add Stagger, negative values allowed
@@ -365,20 +380,24 @@ function changeStagger(combatants, applier, value) {
 	if (!Number.isFinite(value)) {
 		console.error(new Error(`Non-finite value (${value}) provided to changeStagger()`));
 	}
+	const receipts = [];
 	for (const combatant of combatants) {
 		if (!combatant.isStunned) {
 			let pendingStagger = value;
 			if (applier && pendingStagger > 0) {
 				if (applier.getModifierStacks("Impact") > 0) {
 					pendingStagger++;
+					receipts.push(new Receipt([combatant.name], ".", { bonusStagger: "add" }));
 				}
 				if (applier.getModifierStacks("Impotence") > 0) {
 					pendingStagger--;
+					receipts.push(new Receipt([combatant.name], ".", { bonusStagger: "remove" }));
 				}
 			}
 			combatant.stagger = Math.max(combatant.stagger + pendingStagger, 0);
 		}
 	}
+	return receipts;
 }
 
 /**
@@ -441,8 +460,7 @@ module.exports = {
 	gainHealth,
 	addModifier,
 	removeModifier,
-	combineModifierReceipts,
-	generateModifierResultLines,
+	receiptToResultLine,
 	changeStagger,
 	addProtection,
 	modifiersToString,

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -269,108 +269,6 @@ function removeModifier(combatants, { name: modifier, stacks }) {
 	return receipts;
 }
 
-/** @param {Receipt} receipt */
-function receiptToResultLine(receipt) {
-	const fragments = [];
-	// Damage
-	if (receipt.damageMap.size > 0) {
-		let damageFragment = "";
-		if (receipt.combatantNames.size > 1) {
-			damageFragment += "take ";
-		} else {
-			damageFragment += "takes ";
-		}
-		const damages = [];
-		for (const [type, magnitude] of receipt.damageMap) {
-			if (type === null) {
-				damages.unshift(magnitude);
-			} else {
-				damages.push(`${magnitude} ${type}`)
-			}
-		}
-		damageFragment += `${damages.join(" + ")} damage`;
-		const mitigationFragments = [];
-		if (receipt.blockedDamage > 0) {
-			mitigationFragments.push(`${receipt.blockedDamage} blocked`);
-		}
-		if (receipt.damageCapApplied !== null) {
-			mitigationFragments.push(`capped to ${receipt.damageCapApplied}`)
-		}
-		if (mitigationFragments.length > 0) {
-			damageFragment += ` (${mitigationFragments.join(", ")})`;
-		}
-		fragments.push(damageFragment);
-	}
-
-	// Healing
-	if (receipt.healingMap.size > 0) {
-		const healings = [];
-		for (const [source, magnitude] of receipt.healingMap) {
-			healings.push(`${magnitude} (${source})`)
-		}
-
-		if (receipt.combatantNames.size > 1) {
-			fragments.push(`gain ${healings.join(" + ")} HP`);
-		} else {
-			fragments.push(`gains ${healings.join(" + ")} HP`);
-		}
-	}
-
-	// Added Modifiers
-	if (receipt.addedModifiers.size > 0) {
-		if (receipt.combatantNames.size > 1) {
-			fragments.push(`gain ${[...receipt.addedModifiers].join("")}`);
-		} else {
-			fragments.push(`gains ${[...receipt.addedModifiers].join("")}`);
-		}
-	}
-
-	// Removed Modifiers
-	if (receipt.removedModifiers.size > 0) {
-		if (receipt.combatantNames.size > 1) {
-			fragments.push(`lose ${[...receipt.removedModifiers].join("")}`);
-		} else {
-			fragments.push(`loses ${[...receipt.removedModifiers].join("")}`);
-		}
-	}
-
-	// Stagger
-	switch (receipt.stagger) {
-		case "add":
-			if (receipt.combatantNames.size > 1) {
-				fragments.push("are staggered");
-			} else {
-				fragments.push("is staggered");
-			}
-			break;
-		case "remove":
-			if (receipt.combatantNames.size > 1) {
-				fragments.push("are relieved of stagger");
-			} else {
-				fragments.push("is relieved of stagger");
-			}
-			break;
-	}
-
-	if (fragments.length > 0) {
-		let finalizedLine = `${listifyEN([...receipt.combatantNames])} ${listifyEN(fragments)}`;
-		switch (receipt.excitement) {
-			case 0:
-				finalizedLine += ".";
-				break;
-			case 1:
-				finalizedLine += "!";
-				break;
-			case 2:
-				finalizedLine += "!!!";
-				break;
-		}
-		return finalizedLine;
-	} else {
-		return "";
-	}
-}
-
 /** add Stagger, negative values allowed
  * @param {Combatant[]} combatants
  * @param {Combatant | null} applier
@@ -460,7 +358,6 @@ module.exports = {
 	gainHealth,
 	addModifier,
 	removeModifier,
-	receiptToResultLine,
 	changeStagger,
 	addProtection,
 	modifiersToString,

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -211,7 +211,7 @@ function gainHealth(combatant, healing, adventure, source) {
 	}
 
 	/** @type {(string | Receipt)[]} */
-	const results = [new Receipt([combatant.name], combatant.hp === maxHP ? "!" : ".", { healingsArray: [source || null, healing] })];
+	const results = [new Receipt([combatant.name], combatant.hp === maxHP ? "!" : ".", { healingsArray: [[source || null, healing]] })];
 	if (loopholeGold > 0) {
 		results.push(`Health Insurance Loophole${loopholeCount === 1 ? "" : "s"} granted ${loopholeGold} gold.`);
 	}

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -76,12 +76,12 @@ function dealDamage(targets, assailant, damage, isUnblockable, essence, adventur
 						pendingDamage *= 1.5;
 						removeModifier([target], { name: "Exposure", stacks: 1 });
 					}
-					const changes = { damageArray: [[null, pendingDamage]] };
+					const changes = { damagesArray: [[null, pendingDamage]] };
 					const isCounter = getCombatantCounters(target).includes(essence);
 					if (isCounter) {
 						const counterDamage = assailant.getEssenceCounterDamage();
 						pendingDamage += counterDamage;
-						changes.damageArray.push([getEmoji(essence), counterDamage]);
+						changes.damagesArray.push([getEmoji(essence), counterDamage]);
 					}
 					pendingDamage = Math.ceil(pendingDamage);
 					if (!isUnblockable) {
@@ -152,7 +152,7 @@ function dealModifierDamage(target, modifier, adventure) {
 		pendingDamage += funnelDamage;
 		adventure.updateArtifactStat("Spiral Funnel", `Extra ${modifier} Damage`, funnelDamage);
 	}
-	const changes = { damageArray: [[getApplicationEmojiMarkdown(modifier), pendingDamage]] };
+	const changes = { damagesArray: [[getApplicationEmojiMarkdown(modifier), pendingDamage]] };
 	if (pendingDamage >= target.protection) {
 		pendingDamage -= target.protection;
 		target.protection = 0;

--- a/source/util/combatantUtil.js
+++ b/source/util/combatantUtil.js
@@ -285,14 +285,18 @@ function changeStagger(combatants, applier, value) {
 			if (applier && pendingStagger > 0) {
 				if (applier.getModifierStacks("Impact") > 0) {
 					pendingStagger++;
-					receipts.push(new Receipt([combatant.name], ".", { bonusStagger: "add" }));
 				}
 				if (applier.getModifierStacks("Impotence") > 0) {
 					pendingStagger--;
-					receipts.push(new Receipt([combatant.name], ".", { bonusStagger: "remove" }));
 				}
 			}
-			combatant.stagger = Math.max(combatant.stagger + pendingStagger, 0);
+			if (pendingStagger > 0) {
+				receipts.push(new Receipt([combatant.name], ".", { bonusStagger: "add" }));
+				combatant.stagger = combatant.stagger + pendingStagger;
+			} else if (pendingStagger < 0) {
+				receipts.push(new Receipt([combatant.name], ".", { bonusStagger: "remove" }));
+				combatant.stagger = Math.max(combatant.stagger + pendingStagger, 0);
+			}
 		}
 	}
 	return receipts;


### PR DESCRIPTION
Summary
-------
- expand receipts to include more change types
   - damage
   - damage cap applied
   - blocked damage
   - healing
   - stagger
- Barrel Roll staggers user on crit instead of relieving stagger
- Targets not listed among surivors if using elemental absorption
- Fix Flexigrass return

Local Tests Performed
---------------------
- [x] bot still turns on (no BuildErrors or circular dependencies)

Issue
-----
Closes #557, Closes #558